### PR TITLE
Issue #1 - Query in select mode should always return an array, even if result is empty or one one row

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ This is a node.js SDK for Campaign API. It exposes the Campaign API exactly like
 
 # Changelog
 
+### Version 0.1.1
+Bug fixes
+* Query in select mode should always return an array, even if result is empty or one one row (https://github.com/adobe/acc-js-sdk/issues/1)
+
+
 ### Version 0.1.0
 Initial version
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/acc-js-sdk",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/acc-js-sdk",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "ACC Javascript SDK",
   "main": "src/index.js",
   "homepage": "https://git.corp.adobe.com/Campaign/acc-js-sdk",

--- a/src/dom.js
+++ b/src/dom.js
@@ -211,11 +211,16 @@ DomUtil.prototype._toJSON = function(xml, json) {
         }
     }
 
+    // Heuristic to determine if element is an object or an array
+    const isCollection = xml.tagName.length > 11 && xml.tagName.substr(xml.tagName.length-11) == '-collection';
+
     var child = xml.firstChild;
     while (child) {
         var childName = child.nodeName;
+        if (isCollection && (json[childName] === null || json[childName] === undefined))
+            json[childName] = [ ];
         var isArray = !!json[childName];
-        if (isArray && !json[childName].length)
+         if (isArray && (json[childName].length === undefined || json[childName].length === null))
             json[childName] = [ json[childName] ];
         if (child.nodeType == 1) {  // element
             const jsonChild = {};

--- a/test/dom.test.js
+++ b/test/dom.test.js
@@ -374,4 +374,37 @@ describe('DomUtil', function() {
         });
     });
 
+
+    describe("https://github.com/adobe/acc-js-sdk/issues/1", () => {
+        it("Should parse empty collections", () => {
+            const xml = DomUtil.parse("<root-collection></root-collection>");
+            const json = DomUtil.toJSON(xml);
+            expect(JSON.stringify(json)).toBe("{}");
+        });
+
+        // Root node ends with "-collection" forces the result as an array
+        it("Should parse collections with exactly one element", () => {
+            const xml = DomUtil.parse("<root-collection><root id='1'/></root-collection>");
+            const json = DomUtil.toJSON(xml);
+            expect(JSON.stringify(json)).toBe('{"root":[{"@id":"1"}]}');
+        });
+
+        it("Should parse collections with more than one element", () => {
+            const xml = DomUtil.parse("<root-collection><root id='1'/><root id='2'/></root-collection>");
+            const json = DomUtil.toJSON(xml);
+            expect(JSON.stringify(json)).toBe('{"root":[{"@id":"1"},{"@id":"2"}]}');
+        });
+
+        it("Should parse non-collections with exactly one element", () => {
+            const xml = DomUtil.parse("<root-not-coll><root id='1'/></root-not-coll>");
+            const json = DomUtil.toJSON(xml);
+            expect(JSON.stringify(json)).toBe('{"root":{"@id":"1"}}');
+        });
+        it("Should parse non-collections with more than one element", () => {
+            const xml = DomUtil.parse("<root-not-coll><root id='1'/><root id='2'/></root-not-coll>");
+            const json = DomUtil.toJSON(xml);
+            expect(JSON.stringify(json)).toBe('{"root":[{"@id":"1"},{"@id":"2"}]}');
+        });
+    });
+
 });


### PR DESCRIPTION
## Description

XML to JSON transformation uses the following heuristic. When an XML element has several children with the same name, it consider it to be an array. If there's only one child with a given name, the situation is ambiguous: is it a child element or a child array of 1 element.

Collections can be identified with a better heuristic because the parent name ends with "-collection". In this case, we'll always assume that children are an array.

For instance, with the previous heuristic
```
<root><elem id="1"></root> => { elem: { "@id": "1" } }
<root><elem id="1"><elem id="2"></root> => { elem: [ { "@id": "1" } , { "@id": "2" } ] }
```

With the new heuristic, this is only changed for elements whose name ends with "-collection"
```
<root><elem id="1"></root> => { elem: { "@id": "1" } }
<root><elem id="1"><elem id="2"></root> => { elem: [ { "@id": "1" } , { "@id": "2" } ] }
<root-collection><elem id="1"></root-collection> => { elem: [ { "@id": "1" } ] }
<root-collection><elem id="1"><elem id="2"></root-collection> => { elem: [ { "@id": "1" } , { "@id": "2" } ] }
```


## How Has This Been Tested?

New test in dom.test.js showing the failure and the new behavior.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
