### PR TITLE
Release 1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This is a node.js SDK for Campaign API. It exposes the Campaign API exactly like
 ## Version 1.0.3
 _2021_09_25_
 * Added the `sdk.ip()` function to retreive the ouptbound IP to be whitelisted to access Campaign
+* New `ofSecurityToken` authentication method for the client-side SDK, which can be used to log on with a security token only. The session token will be passed automatically by the browser.
 
 ## Version 1.0.2
 _2021/09/17_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This is a node.js SDK for Campaign API. It exposes the Campaign API exactly like
 
 # Changelog
 
+## Version 1.0.3
+_2021_09_25_
+* Added the `sdk.ip()` function to retreive the ouptbound IP to be whitelisted to access Campaign
+
 ## Version 1.0.2
 _2021/09/17_
 * Dummy version to fix NPM build. Need to have the version in both package.json and a commit message to be "Release x.y.z" in master

--- a/README.md
+++ b/README.md
@@ -158,6 +158,35 @@ const connectionParameters = sdk.ConnectionParameters.ofAnonymousUser(url);
 const client = await sdk.init(connectionParameters);
 ```
 
+## Logon with Security token
+
+If you want to use the SDK client-side in a web page returned by Campaign, you cannot use the previous authentication functions because you do not know the user and password, and because you cannot read the session token cookie.
+
+For this scenario, the `ofSecurityToken` function can be used. Pass it a security token (usually available as document.__securitytoken), and the SDK will let the browser handle the session token (cookie) for you.
+
+```html
+    <script src="acc-sdk.js"></script>
+    <script>
+        (async () => {
+            try {
+                const sdk = document.accSDK;
+                var securityToken = "@UyAN...";
+	            const connectionParameters = sdk.ConnectionParameters.ofSecurityToken(url, securityToken);
+                const client = await sdk.init(connectionParameters);
+                await client.logon();
+                const option = await client.getOption("XtkDatabaseId");
+                console.log(option);
+            } catch(ex) {
+                console.error(ex);
+            }
+        })();
+    </script>
+    </body>
+</html>
+```
+
+Note: if the HTML page is served by the Campaign server (which is normally the case in this situation), you can pass an empty url to the `ofSecurityToken` API call.
+
 
 ## LogOn / LogOff
 

--- a/README.md
+++ b/README.md
@@ -171,6 +171,24 @@ await client.logon();
 await client.logoff();
 ```
 
+## IP Whitelisting
+
+Campaign includes an IP whitelisting component which prevents connections from unauthorized IP addresses. This is a common source of authentication errors. 
+
+A node application using the SDK must be whitelisted to be able to access Campaign. The SDK `ip` function is a helper function that can help you find the IP or IPs which need to be whitelisted.
+
+This API is only meant for troubleshooting purposes and uses the `https://api.db-ip.com/v2/free/self` service.
+
+```js
+const ip = await sdk.ip();
+```
+
+Will return something like
+
+```json
+{ "ipAddress":"AAA.BBB.CCC.DDD","continentCode":"EU","continentName":"Europe","countryCode":"FR","countryName":"France","stateProv":"Centre-Val de Loire","city":"Bourges" }
+```
+
 ## Calling static SOAP methods
 
 The NLWS object allows to dynamically perform SOAP calls on the targetted Campaign instance.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adobe/acc-js-sdk",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@adobe/acc-js-sdk",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "ISC",
       "dependencies": {
         "axios": "^0.21.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/acc-js-sdk",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "ACC Javascript SDK",
   "main": "src/index.js",
   "homepage": "https://github.com/adobe/acc-js-sdk#readme",

--- a/samples/000 - basics - logon.js
+++ b/samples/000 - basics - logon.js
@@ -29,6 +29,15 @@ const utils = require("./utils.js");
   });
 
   await utils.sample({
+    title: "Display the outbound IP address (can be useful to troubleshoot IP whitelisting issues)",
+    labels: [ "Basics", "IP", "Whitelisting", "403" ],
+    code: async () => {
+      const ip = await sdk.ip();
+      console.log(`>> ${JSON.stringify(ip)}`);
+    }
+  });
+
+  await utils.sample({
     title: "Log on and log off",
     labels: [ "Basics", "connectionParameters", "ofUserAndPassword", "xtk:session", "logon", "logoff" ],
     description: `How to create a "ConnectionParameters" object and logon and logoff to Campaign using a user and password`,

--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,31 @@ const { Client, Credentials, ConnectionParameters } = require('./client.js');
 const request = require('./transport.js').request;
 
 /**
+ * Get/Set the transport function (defaults to Axios). This function is used for testing / mocking the transport layer.
+ * Called without arguments, it returns the current transport function
+ * Called with an argument, it sets the current transport function and returns the previous one
+ * 
+ * const t = jest.fn();
+ * const old = sdk._transport(t);
+ * try {
+ *   t.mockReturnValueOnce(Promise.resolve(...);
+ *   ... call sdk function which uses the transport layer, for instance ip()
+ * } finally {
+ *   sdk._transport(old);
+ * }
+ */
+
+var transport = request;
+function _transport(t) {
+    if (t) {
+        const old = transport;
+        transport = t;
+        return old;
+    }
+    return transport;
+}
+
+/**
  * @namespace Campaign
  */
 
@@ -68,7 +93,8 @@ function getSDKVersion() {
  * Can be useful to troubleshoot IP whitelisting issues
  */
  async function ip() {
-    const ip = await request({ url: "https://api.db-ip.com/v2/free/self" });
+    const transport = _transport();
+    const ip = await transport({ url: "https://api.db-ip.com/v2/free/self" });
     return ip;
 }
 
@@ -128,6 +154,7 @@ module.exports = {
     XtkCaster: XtkCaster,
     DomUtil: DomUtil,
     Credentials: Credentials,
-    ConnectionParameters: ConnectionParameters
+    ConnectionParameters: ConnectionParameters,
+    _transport: _transport
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,7 @@ const pjson = require('../package.json');
 const DomUtil = require('./domUtil.js').DomUtil;
 const XtkCaster = require('./xtkCaster.js').XtkCaster;
 const { Client, Credentials, ConnectionParameters } = require('./client.js');
+const request = require('./transport.js').request;
 
 /**
  * @namespace Campaign
@@ -60,6 +61,15 @@ function getSDKVersion() {
         name: pjson.name,
         description: pjson.description
     }
+}
+
+/**
+ * Get the outbound IP address (https://api.db-ip.com/v2/free/self)
+ * Can be useful to troubleshoot IP whitelisting issues
+ */
+ async function ip() {
+    const ip = await request({ url: "https://api.db-ip.com/v2/free/self" });
+    return ip;
 }
 
 /** 
@@ -113,6 +123,7 @@ function escapeXtk(p1, ...p2)
 module.exports = {
     init: init,
     getSDKVersion: getSDKVersion,
+    ip: ip,
     escapeXtk: escapeXtk,
     XtkCaster: XtkCaster,
     DomUtil: DomUtil,

--- a/src/transport.js
+++ b/src/transport.js
@@ -52,7 +52,7 @@ if (!Util.isBrowser()) {
 
   const request = (options) => {
     const request = {
-      method: options.method,
+      method: options.method || "GET",
       url: options.url,
       headers: options.headers,
       data: options.data,

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -1877,4 +1877,23 @@ describe('ACC Client', function () {
             expect(calls[0][0].data).toMatch("Logon");
         });
     })
+
+    describe("Security token authentication", () => {
+        // Security token authentication is used when embedding the SDK in Campaign: the session token
+        // is provided by the browser as a cookie. The cookie is not readable by JavaScript code and
+        // should be passed automatically by the browser, not by the SDK
+        it("Should create logged client", async() => {
+            const connectionParameters = sdk.ConnectionParameters.ofSecurityToken("http://acc-sdk:8080", "$security_token$");
+            const client = await sdk.init(connectionParameters);
+            client._transport = jest.fn();
+            expect(client.isLogged()).toBeFalsy();
+            await client.logon();
+            expect(client.isLogged()).toBeTruthy();
+            const logoff = client._transport.mockReturnValueOnce(Mock.LOGOFF_RESPONSE);
+            await client.logoff();
+            expect(client.isLogged()).toBeFalsy();
+            // Ensure logoff has been called
+            expect(logoff.mock.calls.length).toBe(1);
+        })   
+     })
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -60,4 +60,19 @@ describe('ACC SDK', function() {
         });
     });
 
+
+    describe("IP", () => {
+        it("Should get IP address", async () => {
+            const t = jest.fn();
+            const old = sdk._transport(t);
+            try {
+                t.mockReturnValueOnce(Promise.resolve({ "ipAddress":"AAA.BBB.CCC.DDD","continentCode":"EU","continentName":"Europe","countryCode":"FR","countryName":"France","stateProv":"Centre-Val de Loire","city":"Bourges" }));
+                const ip = await sdk.ip();
+                expect(ip).toMatchObject({ "ipAddress":"AAA.BBB.CCC.DDD" });
+            } finally {
+                sdk._transport(old);
+            }
+        });
+    })
+
 });

--- a/test/soap.test.js
+++ b/test/soap.test.js
@@ -150,14 +150,15 @@ describe('SOAP', function() {
             assert.equal(request.headers["Content-type"], "application/soap+xml");
             assert.equal(request.headers["SoapAction"], "xtk:session#Empty");
             assert.equal(request.headers["X-Security-Token"], "");
-            assert.equal(request.headers["Cookie"], "__sessiontoken=");
+            expect(request.headers["Cookie"]).toBeUndefined();
             const env = DomUtil.parse(request.data).documentElement;
             const header = hasChildElement(env, "SOAP-ENV:Header");
-            hasChildElement(header, "Cookie", "__sessiontoken=");
+            expect(DomUtil.findElement(header, "Cookie")).toBeFalsy();
             hasChildElement(header, "X-Security-Token");
             const body = hasChildElement(env, "SOAP-ENV:Body");
             const method = hasChildElement(body, "m:Empty", undefined, "xmlns:m", "urn:xtk:session", "SOAP-ENV:encodingStyle", "http://schemas.xmlsoap.org/soap/encoding/");
-            hasChildElement(method, "sessiontoken", "", "xsi:type", "xsd:string");
+            // sessiontoken is always required as first parameter, even if not set
+            expect(DomUtil.findElement(method, "sessiontoken")).toBeTruthy();
         });
 
         it('Should have set authentication tokens', function() {


### PR DESCRIPTION
* Added the `sdk.ip()` function to retreive the ouptbound IP to be whitelisted to access Campaign
* New `ofSecurityToken` authentication method for the client-side SDK, which can be used to log on with a security token only. The session token will be passed automatically by the browser.
