### PR TITLE
Release 1.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,11 @@ This is a node.js SDK for Campaign API. It exposes the Campaign API exactly like
 # Changelog 
 
 ## Version 1.0.5
-_2021/10/08_
+_2021/10/09_
 * Fix an issue in the logon() function which was not always returning a promise. Some authentication methods such as SessionToken we returning synchronously. Made it so that logon always returns a promise. This should not be a breaking change as logon does not actually return a value
 * Refactor caches (Options cache, Schemas cache, and Methods cache) to use a generic cache class
 * Make sure options parameter of ConnectionParameters constructor is not modified
+* Added a persistent cache for schemas, methods, and options using the browser localStorage by default
 
 ## Version 1.0.4
 _2021/10/07_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This is a node.js SDK for Campaign API. It exposes the Campaign API exactly like
 
 # Changelog 
 
+## Version 1.0.5
+_2021/10/08_
+* Fix an issue in the logon() function which was not always returning a promise. Some authentication methods such as SessionToken we returning synchronously. Made it so that logon always returns a promise. This should not be a breaking change as logon does not actually return a value
+
 ## Version 1.0.4
 _2021/10/07_
 * Fix a bug which caused XML text and cdata elements to be skipped during SimpleJson transformation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This is a node.js SDK for Campaign API. It exposes the Campaign API exactly like
 ## Version 1.0.5
 _2021/10/08_
 * Fix an issue in the logon() function which was not always returning a promise. Some authentication methods such as SessionToken we returning synchronously. Made it so that logon always returns a promise. This should not be a breaking change as logon does not actually return a value
+* Refactor caches (Options cache, Schemas cache, and Methods cache) to use a generic cache class
+* Make sure options parameter of ConnectionParameters constructor is not modified
 
 ## Version 1.0.4
 _2021/10/07_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ _2021/10/09_
 * Make sure options parameter of ConnectionParameters constructor is not modified
 * Added a persistent cache for schemas, methods, and options using the browser localStorage by default
 * Make sure X-Security-Token header is hidden as well as session token cookies
+* Added jshint configuration and fixed warnings reported by jshint
 
 ## Version 1.0.4
 _2021/10/07_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ _2021/10/09_
 * Refactor caches (Options cache, Schemas cache, and Methods cache) to use a generic cache class
 * Make sure options parameter of ConnectionParameters constructor is not modified
 * Added a persistent cache for schemas, methods, and options using the browser localStorage by default
+* Make sure X-Security-Token header is hidden as well as session token cookies
 
 ## Version 1.0.4
 _2021/10/07_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ _2021/10/09_
 * Added a persistent cache for schemas, methods, and options using the browser localStorage by default
 * Make sure X-Security-Token header is hidden as well as session token cookies
 * Added jshint configuration and fixed warnings reported by jshint
+* Fixed vulnerability in ansi-regex; upgrade jest-junit to version 13 to fix
 
 ## Version 1.0.4
 _2021/10/07_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ _2021/10/09_
 * Make sure X-Security-Token header is hidden as well as session token cookies
 * Added jshint configuration and fixed warnings reported by jshint
 * Fixed vulnerability in ansi-regex; upgrade jest-junit to version 13 to fix
+* Small jsdoc improvements
 
 ## Version 1.0.4
 _2021/10/07_

--- a/README.md
+++ b/README.md
@@ -1439,9 +1439,14 @@ If you need to access entity attributes (or child elements) in a generic way, yo
 
 To build this project, you need node and npm
 
-````
+```sh
 npm install
-````
+```
+
+## Check if there are any code warnings
+```sh
+node_modules/jshint/bin/jshint src/
+```
 
 ## Run tests
 ```sh

--- a/README.md
+++ b/README.md
@@ -120,6 +120,13 @@ Attribute|Default|Description
 ---|---|---
 representation|"SimpleJson"| See below. Will determine if the SDK works with xml of json object. Default is JSON
 rememberMe|false| The Campaign `rememberMe` attribute which can be used to extend the lifetime of session tokens
+entityCacheTTL|300000| The TTL (in milliseconds) for the xtk entity cache
+methodCacheTTL|300000| The TTL (in milliseconds) for the xtk method cache
+optionCacheTTL|300000| The TTL (in milliseconds) for the xtk option cache
+traceAPICalls|false| Activates tracing of API calls or not
+transport|axios|Overrides the transport layer
+noStorage|false|De-activate using of local storage
+storage|localStorage|Overrides the local storage for caches
 
 ```js
 const connectionParameters = sdk.ConnectionParameters.ofUserAndPassword(
@@ -565,7 +572,7 @@ It's also noteworthy that all the data returned in a CampaignException is trimme
 
 ## Caches
 
-The following caches are manage by the SDK
+The following caches are managed by the SDK and active by default. They are in-memory caches.
 
 * Options cache. Stores typed option values, by option name.
 * Entity cache. Caches schemas and other entities
@@ -582,6 +589,21 @@ or
 ```js
 client.clearAllCaches();
 ```
+
+Caches have a TTL of 5 minutes by default. The TTL can be changed at connection time using connection options `entityCacheTTL`, `methodCacheTTL`, and `optionCacheTTL`.
+
+Caches can be de-activated by setting a TTL of -1 which will have the effect of making all cached data always invalid.
+
+
+
+## Persistent caches
+In addition to memory caches, it is possible to use persistent caches as well. This was introduced in version 1.0.5 and is active by default as well when using the SDK in a browser. The browser local storage is used (if allowed).
+
+Cached data is stored in local storage with keys prefixed with  `acc.js.sdk.{{version}}.{{server}}.cache.` where `version` is the SDK version and `server` is the Campaign server name. This means that the cached data is lost when upgrading the SDK.
+
+It's possible to disable persistent caches using the `noStorage` connection option.
+
+It is also possible to setup one's own persistent cache, by passing a `storage` object as a connection option. This object should implement 3 methods: `getItem`, `setItem`, and `removeItem` (synchronous)
 
 
 ## Passwords

--- a/README.md
+++ b/README.md
@@ -1462,6 +1462,7 @@ npm run unit-tests
 ## Build JavaScript documentation
 ```sh
 npm run jsdoc
+open ./docs/jsdoc/index.html
 ```
 
 The HTML doc will be generated in the docs/ folder

--- a/README.md
+++ b/README.md
@@ -1443,6 +1443,12 @@ To build this project, you need node and npm
 npm install
 ```
 
+## Check and resolve any security issues
+```sh
+npm audit
+npm audit fix --force
+```
+
 ## Check if there are any code warnings
 ```sh
 node_modules/jshint/bin/jshint src/

--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ See the [Change log](./CHANGELOG.md) for more information about the different ve
 
 The API is fully asynchronous using promises and works as well on the server side than on the client side in the browser.
 
+Install
+```js
+npm install --save @adobe/acc-js-sdk
+```
+
 The SDK entrypoint is the `sdk` object from which everything else can be created.
 
 ```js

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "@adobe/acc-js-sdk",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@adobe/acc-js-sdk",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "ISC",
       "dependencies": {
         "axios": "^0.21.4",
-        "jsdom": "^16.7.0"
+        "jsdom": "^16.7.0",
+        "pegjs": "^0.10.0"
       },
       "devDependencies": {
         "docdash": "^1.2.0",
@@ -4388,6 +4389,17 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
+    },
+    "node_modules/pegjs": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/pegjs/-/pegjs-0.10.0.tgz",
+      "integrity": "sha1-z4uvrm7d/0tafvsYUmnqr0YQ3b0=",
+      "bin": {
+        "pegjs": "bin/pegjs"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
     },
     "node_modules/picomatch": {
       "version": "2.3.0",
@@ -8956,6 +8968,11 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
+    },
+    "pegjs": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/pegjs/-/pegjs-0.10.0.tgz",
+      "integrity": "sha1-z4uvrm7d/0tafvsYUmnqr0YQ3b0="
     },
     "picomatch": {
       "version": "2.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,8 @@
         "jest": "^27.2.0",
         "jest-junit": "^12.2.0",
         "jsdoc": "^3.6.7",
-        "jsdoc-to-markdown": "^7.0.1"
+        "jsdoc-to-markdown": "^7.0.1",
+        "jshint": "^2.13.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1586,6 +1587,19 @@
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
       "dev": true
     },
+    "node_modules/cli": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cli/-/cli-1.0.1.tgz",
+      "integrity": "sha1-IoF1NPJL+klQw01TLUjsvGIbjBQ=",
+      "dev": true,
+      "dependencies": {
+        "exit": "0.1.2",
+        "glob": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=0.2.5"
+      }
+    },
     "node_modules/cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -1782,6 +1796,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/console-browserify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+      "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
+      "dev": true,
+      "dependencies": {
+        "date-now": "^0.1.4"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
@@ -1790,6 +1813,12 @@
       "dependencies": {
         "safe-buffer": "~5.1.1"
       }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -1838,6 +1867,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/date-now": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+      "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
+      "dev": true
     },
     "node_modules/debug": {
       "version": "4.3.2",
@@ -1956,6 +1991,34 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
+      "integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
+      "dev": true,
+      "dependencies": {
+        "domelementtype": "^2.0.1",
+        "entities": "^2.0.0"
+      }
+    },
+    "node_modules/dom-serializer/node_modules/domelementtype": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
+      "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ]
+    },
+    "node_modules/domelementtype": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
+      "dev": true
+    },
     "node_modules/domexception": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
@@ -1973,6 +2036,25 @@
       "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/domhandler": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
+      "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
+      "dev": true,
+      "dependencies": {
+        "domelementtype": "1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+      "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+      "dev": true,
+      "dependencies": {
+        "dom-serializer": "0",
+        "domelementtype": "1"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -2712,6 +2794,25 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
     },
+    "node_modules/htmlparser2": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+      "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
+      "dev": true,
+      "dependencies": {
+        "domelementtype": "1",
+        "domhandler": "2.3",
+        "domutils": "1.5",
+        "entities": "1.0",
+        "readable-stream": "1.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+      "integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY=",
+      "dev": true
+    },
     "node_modules/http-proxy-agent": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
@@ -2916,6 +3017,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
+    },
+    "node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
       "dev": true
     },
     "node_modules/isexe": {
@@ -3865,6 +3972,37 @@
         "node": ">=4"
       }
     },
+    "node_modules/jshint": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.13.1.tgz",
+      "integrity": "sha512-vymzfR3OysF5P774x6zYv0bD4EpH6NWRxpq54wO9mA9RuY49yb1teKSICkLx2Ryx+mfzlVVNNbTBtsRtg78t7g==",
+      "dev": true,
+      "dependencies": {
+        "cli": "~1.0.0",
+        "console-browserify": "1.1.x",
+        "exit": "0.1.x",
+        "htmlparser2": "3.8.x",
+        "lodash": "~4.17.21",
+        "minimatch": "~3.0.2",
+        "shelljs": "0.3.x",
+        "strip-json-comments": "1.0.x"
+      },
+      "bin": {
+        "jshint": "bin/jshint"
+      }
+    },
+    "node_modules/jshint/node_modules/strip-json-comments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+      "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+      "dev": true,
+      "bin": {
+        "strip-json-comments": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -4502,6 +4640,18 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
     },
+    "node_modules/readable-stream": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+      "dev": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
     "node_modules/reduce-extract": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/reduce-extract/-/reduce-extract-1.0.0.tgz",
@@ -4749,6 +4899,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/shelljs": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
+      "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E=",
+      "dev": true,
+      "bin": {
+        "shjs": "bin/shjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/signal-exit": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.4.tgz",
@@ -4888,6 +5050,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "dev": true
     },
     "node_modules/string-length": {
       "version": "4.0.2",
@@ -6792,6 +6960,16 @@
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
       "dev": true
     },
+    "cli": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cli/-/cli-1.0.1.tgz",
+      "integrity": "sha1-IoF1NPJL+klQw01TLUjsvGIbjBQ=",
+      "dev": true,
+      "requires": {
+        "exit": "0.1.2",
+        "glob": "^7.1.1"
+      }
+    },
     "cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -6956,6 +7134,15 @@
         }
       }
     },
+    "console-browserify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+      "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
+      "dev": true,
+      "requires": {
+        "date-now": "^0.1.4"
+      }
+    },
     "convert-source-map": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
@@ -6964,6 +7151,12 @@
       "requires": {
         "safe-buffer": "~5.1.1"
       }
+    },
+    "core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -7005,6 +7198,12 @@
         "whatwg-mimetype": "^2.3.0",
         "whatwg-url": "^8.0.0"
       }
+    },
+    "date-now": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+      "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
+      "dev": true
     },
     "debug": {
       "version": "4.3.2",
@@ -7094,6 +7293,30 @@
         "esutils": "^2.0.2"
       }
     },
+    "dom-serializer": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
+      "integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
+      "dev": true,
+      "requires": {
+        "domelementtype": "^2.0.1",
+        "entities": "^2.0.0"
+      },
+      "dependencies": {
+        "domelementtype": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
+          "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==",
+          "dev": true
+        }
+      }
+    },
+    "domelementtype": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
+      "dev": true
+    },
     "domexception": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
@@ -7107,6 +7330,25 @@
           "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
           "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA=="
         }
+      }
+    },
+    "domhandler": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
+      "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1"
+      }
+    },
+    "domutils": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+      "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+      "dev": true,
+      "requires": {
+        "dom-serializer": "0",
+        "domelementtype": "1"
       }
     },
     "electron-to-chromium": {
@@ -7650,6 +7892,27 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
     },
+    "htmlparser2": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+      "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1",
+        "domhandler": "2.3",
+        "domutils": "1.5",
+        "entities": "1.0",
+        "readable-stream": "1.1"
+      },
+      "dependencies": {
+        "entities": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+          "integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY=",
+          "dev": true
+        }
+      }
+    },
     "http-proxy-agent": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
@@ -7797,6 +8060,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
+    },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
       "dev": true
     },
     "isexe": {
@@ -8544,6 +8813,30 @@
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
       "dev": true
     },
+    "jshint": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.13.1.tgz",
+      "integrity": "sha512-vymzfR3OysF5P774x6zYv0bD4EpH6NWRxpq54wO9mA9RuY49yb1teKSICkLx2Ryx+mfzlVVNNbTBtsRtg78t7g==",
+      "dev": true,
+      "requires": {
+        "cli": "~1.0.0",
+        "console-browserify": "1.1.x",
+        "exit": "0.1.x",
+        "htmlparser2": "3.8.x",
+        "lodash": "~4.17.21",
+        "minimatch": "~3.0.2",
+        "shelljs": "0.3.x",
+        "strip-json-comments": "1.0.x"
+      },
+      "dependencies": {
+        "strip-json-comments": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+          "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+          "dev": true
+        }
+      }
+    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -9039,6 +9332,18 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
     },
+    "readable-stream": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+      "dev": true,
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
     "reduce-extract": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/reduce-extract/-/reduce-extract-1.0.0.tgz",
@@ -9223,6 +9528,12 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
     },
+    "shelljs": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
+      "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E=",
+      "dev": true
+    },
     "signal-exit": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.4.tgz",
@@ -9334,6 +9645,12 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/stream-via/-/stream-via-1.0.4.tgz",
       "integrity": "sha512-DBp0lSvX5G9KGRDTkR/R+a29H+Wk2xItOF+MpZLLNDWbEV9tGPnqLPxHEYjmiz8xGtJHRIqmI+hCjmNzqoA4nQ==",
+      "dev": true
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
       "dev": true
     },
     "string-length": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "docdash": "^1.2.0",
         "eslint": "^7.32.0",
         "jest": "^27.2.0",
-        "jest-junit": "^12.2.0",
+        "jest-junit": "^13.0.0",
         "jsdoc": "^3.6.7",
         "jsdoc-to-markdown": "^7.0.1",
         "jshint": "^2.13.1"
@@ -3391,39 +3391,18 @@
       }
     },
     "node_modules/jest-junit": {
-      "version": "12.2.0",
-      "resolved": "https://registry.npmjs.org/jest-junit/-/jest-junit-12.2.0.tgz",
-      "integrity": "sha512-ecGzF3KEQwLbMP5xMO7wqmgmyZlY/5yWDvgE/vFa+/uIT0KsU5nluf0D2fjIlOKB+tb6DiuSSpZuGpsmwbf7Fw==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/jest-junit/-/jest-junit-13.0.0.tgz",
+      "integrity": "sha512-JSHR+Dhb32FGJaiKkqsB7AR3OqWKtldLd6ZH2+FJ8D4tsweb8Id8zEVReU4+OlrRO1ZluqJLQEETm+Q6/KilBg==",
       "dev": true,
       "dependencies": {
         "mkdirp": "^1.0.4",
-        "strip-ansi": "^5.2.0",
+        "strip-ansi": "^6.0.1",
         "uuid": "^8.3.2",
         "xml": "^1.0.1"
       },
       "engines": {
         "node": ">=10.12.0"
-      }
-    },
-    "node_modules/jest-junit/node_modules/ansi-regex": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/jest-junit/node_modules/strip-ansi": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/jest-leak-detector": {
@@ -5085,12 +5064,12 @@
       }
     },
     "node_modules/strip-ansi": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "dependencies": {
-        "ansi-regex": "^5.0.0"
+        "ansi-regex": "^5.0.1"
       },
       "engines": {
         "node": ">=8"
@@ -8347,32 +8326,15 @@
       }
     },
     "jest-junit": {
-      "version": "12.2.0",
-      "resolved": "https://registry.npmjs.org/jest-junit/-/jest-junit-12.2.0.tgz",
-      "integrity": "sha512-ecGzF3KEQwLbMP5xMO7wqmgmyZlY/5yWDvgE/vFa+/uIT0KsU5nluf0D2fjIlOKB+tb6DiuSSpZuGpsmwbf7Fw==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/jest-junit/-/jest-junit-13.0.0.tgz",
+      "integrity": "sha512-JSHR+Dhb32FGJaiKkqsB7AR3OqWKtldLd6ZH2+FJ8D4tsweb8Id8zEVReU4+OlrRO1ZluqJLQEETm+Q6/KilBg==",
       "dev": true,
       "requires": {
         "mkdirp": "^1.0.4",
-        "strip-ansi": "^5.2.0",
+        "strip-ansi": "^6.0.1",
         "uuid": "^8.3.2",
         "xml": "^1.0.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
-        }
       }
     },
     "jest-leak-detector": {
@@ -9675,12 +9637,12 @@
       }
     },
     "strip-ansi": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "requires": {
-        "ansi-regex": "^5.0.0"
+        "ansi-regex": "^5.0.1"
       }
     },
     "strip-bom": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "axios": "^0.21.4",
-        "jsdom": "^16.7.0",
-        "pegjs": "^0.10.0"
+        "jsdom": "^16.7.0"
       },
       "devDependencies": {
         "docdash": "^1.2.0",
@@ -4389,17 +4388,6 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
-    },
-    "node_modules/pegjs": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/pegjs/-/pegjs-0.10.0.tgz",
-      "integrity": "sha1-z4uvrm7d/0tafvsYUmnqr0YQ3b0=",
-      "bin": {
-        "pegjs": "bin/pegjs"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
     },
     "node_modules/picomatch": {
       "version": "2.3.0",
@@ -8968,11 +8956,6 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
-    },
-    "pegjs": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/pegjs/-/pegjs-0.10.0.tgz",
-      "integrity": "sha1-z4uvrm7d/0tafvsYUmnqr0YQ3b0="
     },
     "picomatch": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -19,12 +19,16 @@
     "jest": "^27.2.0",
     "jest-junit": "^12.2.0",
     "jsdoc": "^3.6.7",
-    "jsdoc-to-markdown": "^7.0.1"
+    "jsdoc-to-markdown": "^7.0.1",
+    "jshint": "^2.13.1"
   },
   "author": "",
   "scripts": {
     "publish:npm": "npm publish --access public",
     "unit-tests": "jest --config test/jest.config.js --maxWorkers=2",
     "jsdoc": "jsdoc -a all -c jsdoc.json -r -R README.md src/*.js -d docs/jsdoc"
+  },
+  "jshintConfig": {
+    "esversion": 8
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "docdash": "^1.2.0",
     "eslint": "^7.32.0",
     "jest": "^27.2.0",
-    "jest-junit": "^12.2.0",
+    "jest-junit": "^13.0.0",
     "jsdoc": "^3.6.7",
     "jsdoc-to-markdown": "^7.0.1",
     "jshint": "^2.13.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/acc-js-sdk",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "ACC Javascript SDK",
   "main": "src/index.js",
   "homepage": "https://github.com/adobe/acc-js-sdk#readme",
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "axios": "^0.21.4",
-    "jsdom": "^16.7.0"
+    "jsdom": "^16.7.0",
+    "pegjs": "^0.10.0"
   },
   "devDependencies": {
     "docdash": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
   },
   "dependencies": {
     "axios": "^0.21.4",
-    "jsdom": "^16.7.0",
-    "pegjs": "^0.10.0"
+    "jsdom": "^16.7.0"
   },
   "devDependencies": {
     "docdash": "^1.2.0",

--- a/src/application.js
+++ b/src/application.js
@@ -659,8 +659,6 @@ function newCurrentLogin(userInfo) {
 // ========================================================================================
 
 /**
- * The Application object provides access to certain properties of the Campaign server.
- * 
  * @class
  * @constructor
  * @param {Campaign.Client} client The Campaign Client from which this Application object is created
@@ -668,6 +666,12 @@ function newCurrentLogin(userInfo) {
  */
 class Application {
 
+    /**
+     * The Application object provides access to certain properties of the Campaign server.
+     * Do not create this object directly, it's automatically created by the Campaign.Client at Logon time
+     * @private
+     * @param {Campaign.Client} client the Campaign client representing the Campaign instance
+     */
     constructor(client) {
         this.client = client;
         const info = this.client.getSessionInfo();

--- a/src/application.js
+++ b/src/application.js
@@ -1,4 +1,3 @@
-"use strict";
 /*
 Copyright 2020 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
@@ -10,6 +9,8 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
+(function() {
+"use strict";
 
 
 /**********************************************************************************
@@ -31,7 +32,7 @@ const EntityAccessor = require('./entityAccessor.js').EntityAccessor;
 // ========================================================================================
  
 // Determine if a name is an attribute name, i.e. if it starts with the "@" character
-const isAttributeName = function(name) { return name.length > 0 && name[0] == '@'; }
+const isAttributeName = function(name) { return name.length > 0 && name[0] == '@'; };
 
 
 /**
@@ -325,7 +326,7 @@ class XtkSchemaNode {
             else if (element.isParent())
                 childNode = node.parent;
             else
-                childNode = node._getChildDefAutoExpand(name, mustExist)
+                childNode = node._getChildDefAutoExpand(name, mustExist);
             node = childNode;
         }
         return node;
@@ -737,3 +738,4 @@ exports.Application = Application;
 // For tests
 exports.newSchema = newSchema;
 exports.newCurrentLogin = newCurrentLogin;
+})();

--- a/src/campaign.js
+++ b/src/campaign.js
@@ -19,18 +19,8 @@ const { Util } = require("./util.js");
  */
 
 /**
- * Represents a Campaign exception, i.e. any kind of error that can happen when calling Campaign APIs, 
- * ranging from HTTP errors, XML serialization errors, SOAP errors, authentication errors, etc.
- * 
- * @todo does not really belong to soap.js. Move it to a better place
  * @class
  * @constructor
- * @param {SoapMethodCall|request} call the call that triggered the error. It can be a SoapMethodCall object, a HTTP request object, or even be undefined if the exception is generated outside of the context of a call
- * @param {number} statusCode the HTTP status code (200, 500, etc.)
- * @param {string} faultCode the fault code, i.e. an error code
- * @param {string} faultString a short description of the error
- * @param {string} detail a more detailed description of the error
- * @param {*} cause an optional error object representing the cause of the exception
  * @memberof Campaign
  */
  class CampaignException {
@@ -48,10 +38,28 @@ const { Util } = require("./util.js");
   static NOT_LOGGED_IN(call, details)                     { return new CampaignException(     call, 400, 16384, `SDK-000010 Cannot call API because client is not logged in`, details); }
   static DECRYPT_ERROR(details)                           { return new CampaignException(undefined, 400, 16384, `SDK-000011 "Cannot decrypt password: password marker is missing`, details); }
   
+
+  /**
+   * Returns a short description of the exception
+   * @returns {string} a short description of the exception
+   */
   toString() {
       return this.message;
   }
 
+  /**
+   * Represents a Campaign exception, i.e. any kind of error that can happen when calling Campaign APIs, 
+   * ranging from HTTP errors, XML serialization errors, SOAP errors, authentication errors, etc.
+   * 
+   * Members of this object are trimmed, and all session tokens, security tokens, passwords, etc. are replaced by "***"
+   * 
+   * @param {SoapMethodCall|request} call the call that triggered the error. It can be a SoapMethodCall object, a HTTP request object, or even be undefined if the exception is generated outside of the context of a call
+   * @param {number} statusCode the HTTP status code (200, 500, etc.)
+   * @param {string} faultCode the fault code, i.e. an error code
+   * @param {string} faultString a short description of the error
+   * @param {string} detail a more detailed description of the error
+   * @param {Error|string} cause an optional error object representing the cause of the exception
+   */  
   constructor(call, statusCode, faultCode, faultString, detail, cause) {
 
       // Provides a shorter and more friendly description of the call and method name
@@ -190,6 +198,7 @@ const { Util } = require("./util.js");
 
 /**
  * Creates a CampaignException for a SOAP call and from a root exception
+ * 
  * @private
  * @param {SoapMethodCall} call the SOAP call
  * @param {*} err the exception causing the SOAP call.

--- a/src/campaign.js
+++ b/src/campaign.js
@@ -1,8 +1,3 @@
-"use strict";
-
-const { Util } = require("./util.js");
-
-
 /*
 Copyright 2020 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
@@ -14,8 +9,11 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
+(function() {
+"use strict";    
 
-
+const { Util } = require("./util.js");
+   
 /**
  * @namespace Campaign
  */
@@ -58,10 +56,10 @@ governing permissions and limitations under the License.
 
       // Provides a shorter and more friendly description of the call and method name
       // depending on whether the exception is thrown by a SOAP or HTTP call
-      var methodCall = undefined;
-      var methodName = undefined;
+      var methodCall;
+      var methodName;
       if (call) {
-          const ctor = call.__proto__.constructor;
+          const ctor = Object.getPrototypeOf(call).constructor;
           if (ctor && ctor.name == "SoapMethodCall") {
               methodCall = {
                   type: "SOAP",
@@ -204,7 +202,7 @@ function makeCampaignException(call, err) {
       return err;
   
   // Wraps DOM exceptions which can occur when dealing with malformed XML
-  const ctor = err.__proto__.constructor;
+  const ctor = Object.getPrototypeOf(err).constructor;
   if (ctor && ctor.name == "DOMException") {
       return new CampaignException(call, 500, err.code, `DOMException (${err.name})`, err.message, err);
   }
@@ -516,7 +514,7 @@ exports.OPERATOR_TYPE_GROUP = 1;
 exports.OPERATOR_TYPE_RIGHT = 2;
 
 exports.WORKFLOWTASK_STATUS_PENDING = 0;
-exports.WORKFLOWTASK_STATUS_COMPLETED = 1
+exports.WORKFLOWTASK_STATUS_COMPLETED = 1;
 
 exports.MOBILE_MSGTYPE_SMS     = 0;
 exports.MOBILE_MSGTYPE_WAPPUSH = 1;
@@ -662,3 +660,5 @@ exports.ACTION_TYPE_EXPIRED = 11;
 exports.CONTENT_EDITING_MODE_DEFAULT = 0;
 exports.CONTENT_EDITING_MODE_DCE = 1;
 exports.CONTENT_EDITING_MODE_AEM = 2;
+
+})();

--- a/src/client.js
+++ b/src/client.js
@@ -1,4 +1,3 @@
-"use strict";
 /*
 Copyright 2020 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
@@ -10,7 +9,9 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
-
+(function() {
+"use strict";    
+    
 
 /**********************************************************************************
  * 
@@ -86,7 +87,7 @@ const xtkObjectHandler = {
         });
 
     }
-}
+};
 
 /**
  * Java Script Proxy handler for NLWS. 
@@ -143,7 +144,7 @@ const clientHandler = {
                     return function(body) {
                         callContext.object = body;
                         return new Proxy(callContext, xtkObjectHandler);
-                    }
+                    };
                 }
 
                 return new Proxy(caller, {
@@ -263,7 +264,7 @@ class ConnectionParameters {
         this._endpoint = endpoint;
         this._credentials = credentials;
 
-        var storage = undefined;
+        var storage;
         if (!options.noStorage) {
             storage = options.storage;
             try {
@@ -378,7 +379,7 @@ class ConnectionParameters {
                     { "expr": "@type=3" }
                 ]
             }
-        }
+        };
         // Convert to current representation
         queryDef = client.convertToRepresentation(queryDef, "SimpleJson");
         const query = client.NLWS.xtkQueryDef.create(queryDef);
@@ -646,20 +647,20 @@ class Client {
         const safeCallData = Util.trim(soapCall.request.data);
         if (that._traceAPICalls)
             console.log(`SOAP//request ${safeCallData}`);
-        that._notifyObservers((observer) => { observer.onSOAPCall && observer.onSOAPCall(soapCall, safeCallData); });
+        that._notifyObservers((observer) => observer.onSOAPCall && observer.onSOAPCall(soapCall, safeCallData) );
         
         return soapCall.execute()
             .then(() => {
                 const safeCallResponse = Util.trim(soapCall.response);
                 if (that._traceAPICalls)
                     console.log(`SOAP//response ${safeCallResponse}`);
-                that._notifyObservers((observer) => { observer.onSOAPCallSuccess && observer.onSOAPCallSuccess(soapCall, safeCallResponse); });
+                that._notifyObservers((observer) => observer.onSOAPCallSuccess && observer.onSOAPCallSuccess(soapCall, safeCallResponse) );
                 return Promise.resolve();
             })
             .catch((ex) => {
                 if (that._traceAPICalls)
                     console.log(`SOAP//failure ${ex.toString()}`);
-                that._notifyObservers((observer) => { observer.onSOAPCallFailure && observer.onSOAPCallFailure(soapCall, ex); });
+                that._notifyObservers((observer) => observer.onSOAPCallFailure && observer.onSOAPCallFailure(soapCall, ex) );
                 return Promise.reject(ex);
             });
     }
@@ -678,7 +679,7 @@ class Client {
 
         // Clear session token cookie to ensure we're not inheriting an expired cookie. See NEO-26589
         if (credentials._type != "SecurityToken" && typeof document != "undefined") {
-            document.cookie = '__sessiontoken=;path=/;'
+            document.cookie = '__sessiontoken=;path=/;';
         }
         if (credentials._type == "SessionToken" || credentials._type == "AnonymousUser") {
             that._sessionInfo = undefined;
@@ -788,7 +789,7 @@ class Client {
      * @return the option value, casted in the expected data type. If the option does not exist, it will return null.
      */
     async getOption(name, useCache = true) {
-        var value = undefined;
+        var value;
         if (useCache)
             value = this._optionCache.get(name);
         if (value === undefined) {
@@ -1139,9 +1140,10 @@ class Client {
                             // type can reference a schema element. The naming convension is that the type name
                             // is {schemaName}{elementNameCamelCase}. For instance, the type "sessionUserInfo"
                             // matches the "userInfo" element of the "xtkSession" schema
+                            let element;
                             if (type.substr(0, schemaName.length) == schemaName) {
                                 const shortTypeName = type.substr(schemaName.length, 1).toLowerCase() + type.substr(schemaName.length + 1);
-                                var element = DomUtil.getFirstChildElement(schema, "element");
+                                element = DomUtil.getFirstChildElement(schema, "element");
                                 while (element) {
                                     if (element.getAttribute("name") == shortTypeName) {
                                         // Type found in schema: Process as a DOM element
@@ -1149,16 +1151,10 @@ class Client {
                                         returnValue = that.toRepresentation(returnValue);
                                         break;
                                     }
-                                    element = DomUtil.getNextSiblingElement(element, "element")
+                                    element = DomUtil.getNextSiblingElement(element, "element");
                                 }
 
                             }
-    /*                    else if (type == "sessionUserInfo") {
-                            returnValue = soapCall.getNextElement();
-                            if (that._representation == "BadgerFish")
-                                returnValue = DomUtil.toJSON(returnValue);
-                        }
-                        */
                             if (!element)
                                 throw CampaignException.UNEXPECTED_SOAP_RESPONSE(soapCall, `Unsupported return type '${type}' for parameter '${paramName}' of method '${methodName}' of schema '${schemaId}'`);
                         }
@@ -1183,18 +1179,18 @@ class Client {
             const safeCallData = Util.trim(request.data);
             if (this._traceAPICalls)
                 console.log(`HTTP//request ${request.method} ${request.url}${safeCallData ? " " + safeCallData : ""}`);
-            this._notifyObservers((observer) => { observer.onHTTPCall && observer.onHTTPCall(request, safeCallData); });
+            this._notifyObservers((observer) => observer.onHTTPCall && observer.onHTTPCall(request, safeCallData) );
             const body = await this._transport(request);
 
             const safeCallResponse = Util.trim(body);
             if (this._traceAPICalls)
                 console.log(`HTTP//response${safeCallResponse ? " " + safeCallResponse : ""}`);
-            this._notifyObservers((observer) => { observer.onHTTPCallSuccess && observer.onHTTPCallSuccess(request, safeCallResponse); });
+            this._notifyObservers((observer) => observer.onHTTPCallSuccess && observer.onHTTPCallSuccess(request, safeCallResponse) );
             return body;
         } catch(err) {
             if (this._traceAPICalls)
                 console.log("HTTP//failure", err);
-            this._notifyObservers((observer) => { observer.onHTTPCallFailure && observer.onHTTPCallFailure(request, err); });
+            this._notifyObservers((observer) => observer.onHTTPCallFailure && observer.onHTTPCallFailure(request, err) );
             throw makeCampaignException({ request:request, reqponse:err.response }, err);
         }
     }
@@ -1264,8 +1260,8 @@ class Client {
         var status = lines[0].trim();
         if (status != "") root.setAttribute("status", status);
         
-        var rtCount = undefined;
-        var threshold = undefined;
+        var rtCount;
+        var threshold;
         if (status == "Error") {
             const error = lines.length > 1 ? lines[1] : "";
             root.setAttribute("error", error);
@@ -1305,3 +1301,5 @@ Client.CampaignException = CampaignException;
 exports.Client = Client;
 exports.Credentials = Credentials;
 exports.ConnectionParameters = ConnectionParameters;
+
+})();

--- a/src/client.js
+++ b/src/client.js
@@ -161,20 +161,21 @@ const clientHandler = {
 // Campaign credentials
 // ========================================================================================
 
-/**
- * Credentials to a Campaign instance. Encapsulates the various types of credentials.
- * Do not create directly, use one of the methods in ConnectionParameters
- * 
+/** 
  * @class
  * @constructor
  * @private
- * @param {string} type the credentials type. Supported types are "UserPassword" and "ImsServiceToken" and "SessionToken" and "AnonymousUser"
- * @param {string} sessionToken the session token. It's exact form depends on the credentials type. For instance it can be "user/passord" for the "UserPassword" credentials type
- * @param {string} securityToken the security token. Will use an empty token if not specified
  * @memberof Campaign
  */
 class Credentials {
 
+    /**
+     * Credentials to a Campaign instance. Encapsulates the various types of credentials.
+     * Do not create directly, use one of the methods in ConnectionParameters
+     * @param {string} type the credentials type. Supported types are "UserPassword" and "ImsServiceToken" and "SessionToken" and "AnonymousUser"
+     * @param {string} sessionToken the session token. It's exact form depends on the credentials type. For instance it can be "user/passord" for the "UserPassword" credentials type
+     * @param {string} securityToken the security token. Will use an empty token if not specified
+     */
     constructor(type, sessionToken, securityToken) {
         if (type != "UserPassword" && type != "ImsServiceToken" && type != "SessionToken" && 
             type != "AnonymousUser" && type != "SecurityToken")
@@ -219,18 +220,34 @@ class Credentials {
 // ========================================================================================
 
 /**
- * Creates a connection parameters object which can be used to create a Client object
- * to connect to a Campaign instance
- * 
+ * @typedef {Object} ConnectionOptions
+ * @property {string} representation - the representation to use, i.e. "SimpleJson" (the default), "BadgerFish", or "xml"
+ * @property {boolean} rememberMe - The Campaign `rememberMe` attribute which can be used to extend the lifetime of session tokens
+ * @property {number} entityCacheTTL - The TTL (in milliseconds) after which cached XTK entities expire. Defaults to 5 minutes
+ * @property {number} methodCacheTTL - The TTL (in milliseconds) after which cached XTK methods expire. Defaults to 5 minutes
+ * @property {number} optionCacheTTL - The TTL (in milliseconds) after which cached XTK options expire. Defaults to 5 minutes
+ * @property {boolean} traceAPICalls - Activates the tracing of all API calls
+ * @property {Utils.Transport} transport - Overrides the transport (i.e. HTTP layer)
+ * @property {boolean} noStorage - De-activate using of local storage. By default, and in addition to in-memory cache, entities, methods, and options are also persisted in local storage if there is one.
+ * @property {Storage} storage - Overrides the storage interface (i.e. LocalStorage)
+ * @memberOf Campaign
+ */
+ 
+
+/**
  * @class
  * @constructor
- * @param {string} endpoint The campaign endpoint (URL)
- * @param {Credentials} credentials The credentials for the connection
- * @param {*} options connection options. Currently only contains a "representation" attribute which controls what type of entities (xml or json) the SDK handles
  * @memberof Campaign
  */
 class ConnectionParameters {
-    
+
+    /**
+     * Creates a connection parameters object which can be used to create a Client object
+     * to connect to a Campaign instance
+     * @param {string} endpoint The campaign endpoint (URL)
+     * @param {Campaign.Credentials} credentials The credentials for the connection
+     * @param {Campaign.ConnectionOptions} options connection options
+     */
     constructor(endpoint, credentials, options) {
         // this._options will be populated with the data from "options" and with
         // default values. But the "options" parameter will not be modified
@@ -283,7 +300,7 @@ class ConnectionParameters {
      * @param {string} endpoint The campaign endpoint (URL)
      * @param {string} user The user name
      * @param {string} password The user password
-     * @param {*} options connection options
+     * @param {Campaign.ConnectionOptions} options connection options
      * @returns {ConnectionParameters} a ConnectionParameters object which can be used to create a Client
      */
     static ofUserAndPassword(endpoint, user, password, options) {
@@ -297,7 +314,7 @@ class ConnectionParameters {
      * @param {string} endpoint The campaign endpoint (URL)
      * @param {string} user The user name
      * @param {string} serviceToken The IMS service token
-     * @param {*} options connection options
+     * @param {Campaign.ConnectionOptions} options connection options
      * @returns {ConnectionParameters} a ConnectionParameters object which can be used to create a Client
      */
     static ofUserAndServiceToken(endpoint, user, serviceToken, options) {
@@ -311,7 +328,7 @@ class ConnectionParameters {
      * @static
      * @param {string} endpoint The campaign endpoint (URL)
      * @param {string} sessionToken The session token
-     * @param {*} options connection options
+     * @param {Campaign.ConnectionOptions} options connection options
      * @returns {ConnectionParameters} a ConnectionParameters object which can be used to create a Client
      */
     static ofSessionToken(endpoint, sessionToken, options) {
@@ -328,7 +345,7 @@ class ConnectionParameters {
      * @static
      * @param {string} endpoint The campaign endpoint (URL)
      * @param {string} securityToken The session token
-     * @param {*} options connection options
+     * @param {Campaign.ConnectionOptions} options connection options
      * @returns {ConnectionParameters} a ConnectionParameters object which can be used to create a Client
      */
     static ofSecurityToken(endpoint, securityToken, options) {
@@ -340,7 +357,7 @@ class ConnectionParameters {
      * Creates connection parameters for a Campaign instance for an anonymous user
      * 
      * @param {string} endpoint The campaign endpoint (URL)
-     * @param {*} options connection options
+     * @param {Campaign.ConnectionOptions} options connection options
      * @returns {ConnectionParameters} a ConnectionParameters object which can be used to create a Client
      */
     static ofAnonymousUser(endpoint, options) {
@@ -381,7 +398,7 @@ class ConnectionParameters {
             }
         };
         // Convert to current representation
-        queryDef = client.convertToRepresentation(queryDef, "SimpleJson");
+        queryDef = client._convertToRepresentation(queryDef, "SimpleJson");
         const query = client.NLWS.xtkQueryDef.create(queryDef);
         const extAccount = await query.executeQuery();
 
@@ -404,18 +421,20 @@ class ConnectionParameters {
 // ========================================================================================
 
 /**
- * ACC API Client.
- * Do not create directly, use SDK.init instead
- * 
  * @private
  * @class
  * @constructor
- * @param {Campaign.SDK} sdk is the global sdk object used to create the client
- * @param {Campaign.ConnectionParameters} user user name, for instance admin
  * @memberof Campaign
  */
 class Client {
-    
+
+    /**
+     * ACC API Client.
+     * Do not create directly, use SDK.init instead
+     * 
+     * @param {Campaign.SDK} sdk is the global sdk object used to create the client
+     * @param {Campaign.ConnectionParameters} user user name, for instance admin
+     */
     constructor(sdk, connectionParameters) {
         this.sdk = sdk;
         this._connectionParameters = connectionParameters; // ## TODO security concern (password kept in memory)
@@ -477,7 +496,7 @@ class Client {
      * 
      * @returns {string} the user agent string
      */
-    getUserAgentString() {
+    _getUserAgentString() {
         const version = this.sdk.getSDKVersion();
         return `${version.name}/${version.version} ${version.description}`;
     }
@@ -490,7 +509,7 @@ class Client {
      * @param {string} representation the expected representation ('xml', 'BadgerFish', or 'SimpleJson'). If not set, will use the current representation
      * @returns {XML.XtkObject} the object converted in the requested representation
      */
-    toRepresentation(xml, representation) {
+    _toRepresentation(xml, representation) {
         representation = representation || this._representation;
         if (representation == "xml")
             return xml;
@@ -508,7 +527,7 @@ class Client {
      * @param {string} representation the expected representation ('xml', 'BadgerFish', or 'SimpleJson'). If not set, will use the current representation
      * @returns {DOMElement} the object converted to XML
      */
-    fromRepresentation(rootName, entity, representation) {
+    _fromRepresentation(rootName, entity, representation) {
         representation = representation || this._representation;
         if (representation == "xml")
             return entity;
@@ -528,12 +547,12 @@ class Client {
      * @param {string} toRepresentation the target representation ('xml', 'BadgerFish', or 'SimpleJson'). If not set, will use the current representation
      * @returns {DOMElement} the converted object
      */
-    convertToRepresentation(entity, fromRepresentation, toRepresentation) {
+    _convertToRepresentation(entity, fromRepresentation, toRepresentation) {
         toRepresentation = toRepresentation || this._representation;
-        if (this.isSameRepresentation(fromRepresentation, toRepresentation))
+        if (this._isSameRepresentation(fromRepresentation, toRepresentation))
             return entity;
-        var xml = this.fromRepresentation("root", entity, fromRepresentation);
-        entity = this.toRepresentation(xml, toRepresentation);
+        var xml = this._fromRepresentation("root", entity, fromRepresentation);
+        entity = this._toRepresentation(xml, toRepresentation);
         return entity;
     }
 
@@ -545,7 +564,7 @@ class Client {
      * @param {string} rep2 the second representation ('xml', 'BadgerFish', or 'SimpleJson')
      * @returns a boolean indicating if the 2 representations are the same or not
      */
-    isSameRepresentation(rep1, rep2) {
+    _isSameRepresentation(rep1, rep2) {
         if (!rep1 || !rep2) throw CampaignException.INVALID_REPRESENTATION(undefined, "Cannot compare to undefined representation");
         if (rep1 != "xml" && rep1 != "SimpleJson" && rep1 != "BadgerFish") throw CampaignException.INVALID_REPRESENTATION(rep1, "Cannot compare to invalid representation");
         if (rep2 != "xml" && rep2 != "SimpleJson" && rep2 != "BadgerFish") throw CampaignException.INVALID_REPRESENTATION(rep2, "Cannot compare to invalid representation");
@@ -624,20 +643,20 @@ class Client {
      * @return {SOAP.SoapMethodCall} a SoapMethodCall which have been initialized with security tokens... and to which the method
      * parameters should be set
      */
-    prepareSoapCall(urn, method, internal) {
-        const soapCall = new SoapMethodCall(this._transport, urn, method, this._sessionToken, this._securityToken, this.getUserAgentString());
+    _prepareSoapCall(urn, method, internal) {
+        const soapCall = new SoapMethodCall(this._transport, urn, method, this._sessionToken, this._securityToken, this._getUserAgentString());
         soapCall.internal = !!internal;
         return soapCall;
     }
 
     /**
-     * After a SOAP method call has been prepared with 'prepareSoapCall', and parameters have been added,
+     * After a SOAP method call has been prepared with '_prepareSoapCall', and parameters have been added,
      * this function actually executes the SOAP call
      * 
      * @private
      * @param {SOAP.SoapMethodCall} soapCall the SOAP method to call
      */
-    makeSoapCall(soapCall) {
+    _makeSoapCall(soapCall) {
         const that = this;
         if (soapCall.requiresLogon() && !that.isLogged())
             throw CampaignException.NOT_LOGGED_IN(soapCall, `Cannot execute SOAP call ${soapCall.urn}#${soapCall.methodName}: you are not logged in. Use the Logon function first`);
@@ -701,7 +720,7 @@ class Client {
             const user = credentials._getUser();
             const password = credentials._getPassword();
 
-            const soapCall = this.prepareSoapCall("xtk:session", "Logon");
+            const soapCall = this._prepareSoapCall("xtk:session", "Logon");
             soapCall.writeString("login", user);
             soapCall.writeString("password", password);
             var parameters = null;
@@ -711,7 +730,7 @@ class Client {
             }
             soapCall.writeElement("parameters", parameters);
             
-            return this.makeSoapCall(soapCall).then(function() {
+            return this._makeSoapCall(soapCall).then(function() {
                 const sessionToken = soapCall.getNextString();
                 
                 that._sessionInfo = soapCall.getNextDocument();
@@ -754,7 +773,7 @@ class Client {
      */
     getSessionInfo(representation) {
         representation = representation || this._representation;
-        return this.toRepresentation(this._sessionInfo, representation);
+        return this._toRepresentation(this._sessionInfo, representation);
     }
 
     /**
@@ -766,8 +785,8 @@ class Client {
         
         const credentials = this._connectionParameters._credentials;
         if (credentials._type != "SessionToken" && credentials._type != "AnonymousUser") {
-            var soapCall = that.prepareSoapCall("xtk:session", "Logoff");
-                return this.makeSoapCall(soapCall).then(function() {
+            var soapCall = that._prepareSoapCall("xtk:session", "Logoff");
+                return this._makeSoapCall(soapCall).then(function() {
                 that._sessionToken = "";
                 that._securityToken = "";
                 that.application = null;
@@ -895,34 +914,38 @@ class Client {
     }
 
     /**
-     * Fetches an entity (GetEntityIfMoreRecent)
+     * Gets an entity, such as a schema, a source schema, a form, a navtree, etc. Each Campaign entity has a MD5 which is used to determine
+     * if an entity has changed or not. The GetEntityIfMoreRecent SOAP call can use this MD5 to avoid returning entities that did not 
+     * actually changed. Currently, the SDK, however is not able to use the MD5 and will perform a SOAP call every time the function is
+     * called and return the whole entity
      * 
-     * @private
      * @param {string} entityType is the type of entity requested, such as "xtk:schema", "xtk:srcSchema", "xtk:navtree", "xtk:form", etc.
      * @param {string} fullName is the fully qualified name of the entity (i.e. <namespace>:<name>)
      * @param {string} representation the expected representation, or undefined to set the default
-     * @return A DOM representation of the entity, or null if the entity is not found
+     * @param {boolean} internal indicates an "internal" call, i.e. a call performed by the SDK itself rather than the user of the SDK. For instance, the SDK will dynamically load schemas to find method definitions
+     * @return {XML.XtkObject} A DOM or JSON representation of the entity, or null if the entity is not found
      */
      async getEntityIfMoreRecent(entityType, fullName, representation, internal) {
         const that = this;
-        const soapCall = this.prepareSoapCall("xtk:persist", "GetEntityIfMoreRecent", internal);
+        const soapCall = this._prepareSoapCall("xtk:persist", "GetEntityIfMoreRecent", internal);
         soapCall.writeString("pk", entityType + "|" + fullName);
         soapCall.writeString("md5", "");
         soapCall.writeBoolean("mustExist", false);
-        return this.makeSoapCall(soapCall).then(function() {
+        return this._makeSoapCall(soapCall).then(function() {
             var doc = soapCall.getNextDocument();
             soapCall.checkNoMoreArgs();
-            doc = that.toRepresentation(doc, representation);
+            doc = that._toRepresentation(doc, representation);
             return doc;
         });
     }
 
     /**
-     * Get a schema definition.
+     * Get a compiled schema (not a source schema) definition as a DOM or JSON object depending on hte current representation
      * 
      * @param {string} schemaId the schema id, such as "xtk:session", or "nms:recipient"
      * @param {string} representation an optional representation of the schema: "BadgerFish", "SimpleJson" or "xml". If not set, we'll use the client default representation
-     * @returns {*} the schema definition, as either a DOM document or a JSON object
+     * @param {boolean} internal indicates an "internal" call, i.e. a call performed by the SDK itself rather than the user of the SDK. For instance, the SDK will dynamically load schemas to find method definitions
+     * @returns {XML.XtkObject}  the schema definition, as either a DOM document or a JSON object
      */
     async getSchema(schemaId, representation, internal) {
         var that = this;
@@ -933,7 +956,7 @@ class Client {
         if (entity)
             that._entityCache.put("xtk:schema", schemaId, entity);
 
-        entity = that.toRepresentation(entity, representation);
+        entity = that._toRepresentation(entity, representation);
         return entity;
     }
 
@@ -942,7 +965,7 @@ class Client {
      * 
      * @param {string} enumName
      * @param {string} optionalStartSchemaOrSchemaName
-     * @returns the enumeration definition in the current representation
+     * @returns {XML.XtkObject} the enumeration definition in the current representation
      */
     async getSysEnum(enumName, optionalStartSchemaOrSchemaName) {
 
@@ -1007,7 +1030,7 @@ class Client {
         // console.log(method.toXMLString());
 
         var urn = that._methodCache.getSoapUrn(schemaId, methodName);
-        var soapCall = that.prepareSoapCall(urn, methodName);
+        var soapCall = that._prepareSoapCall(urn, methodName);
 
         const isStatic = DomUtil.getAttributeAsBoolean(method, "static");
         var object = callContext.object;
@@ -1016,7 +1039,7 @@ class Client {
                 throw CampaignException.SOAP_UNKNOWN_METHOD(schemaId, methodName, `Cannot call non-static method '${methodName}' of schema '${schemaId}' : no object was specified`);
 
             const rootName = schemaId.substr(schemaId.indexOf(':') + 1);
-            object = that.fromRepresentation(rootName, object);
+            object = that._fromRepresentation(rootName, object);
             soapCall.writeDocument("document", object);
         }
 
@@ -1064,7 +1087,7 @@ class Client {
                             const index = xtkschema.indexOf(":");
                             docName = xtkschema.substr(index+1);
                         }
-                        var xmlValue = that.fromRepresentation(docName, paramValue);
+                        var xmlValue = that._fromRepresentation(docName, paramValue);
                         if (type == "DOMDocument")
                             soapCall.writeDocument(paramName, xmlValue);
                         else
@@ -1077,13 +1100,13 @@ class Client {
             }
         }
         
-        return that.makeSoapCall(soapCall).then(function() {
+        return that._makeSoapCall(soapCall).then(function() {
             if (!isStatic) {
                 // Non static methods, such as xtk:query#SelectAll return a element named "entity" which is the object itself on which
                 // the method is called. This is the new version of the object (in XML form)
                 const entity = soapCall.getEntity();
                 if (entity) {
-                    callContext.object = that.toRepresentation(entity);
+                    callContext.object = that._toRepresentation(entity);
                 }
             }
 
@@ -1114,7 +1137,7 @@ class Client {
                             returnValue = soapCall.getNextDate();
                         else if (type == "DOMDocument") {
                             returnValue = soapCall.getNextDocument();
-                            returnValue = that.toRepresentation(returnValue);
+                            returnValue = that._toRepresentation(returnValue);
                             if (schemaId === "xtk:queryDef" && methodName === "ExecuteQuery" && paramName === "output") {
                                 // https://github.com/adobe/acc-js-sdk/issues/3
                                 // Check if query operation is "getIfExists". The "object" variable at this point
@@ -1134,7 +1157,7 @@ class Client {
                         }
                         else if (type == "DOMElement") {
                             returnValue = soapCall.getNextElement();
-                            returnValue = that.toRepresentation(returnValue);
+                            returnValue = that._toRepresentation(returnValue);
                         }
                         else {
                             // type can reference a schema element. The naming convension is that the type name
@@ -1148,7 +1171,7 @@ class Client {
                                     if (element.getAttribute("name") == shortTypeName) {
                                         // Type found in schema: Process as a DOM element
                                         returnValue = soapCall.getNextElement();
-                                        returnValue = that.toRepresentation(returnValue);
+                                        returnValue = that._toRepresentation(returnValue);
                                         break;
                                     }
                                     element = DomUtil.getNextSiblingElement(element, "element");
@@ -1174,7 +1197,7 @@ class Client {
         request.method = request.method || "GET";
         request.headers = request.headers || [];
         if (!request.headers['User-Agent'])
-            request.headers['User-Agent'] = this.getUserAgentString();
+            request.headers['User-Agent'] = this._getUserAgentString();
         try {
             const safeCallData = Util.trim(request.data);
             if (this._traceAPICalls)
@@ -1207,7 +1230,7 @@ class Client {
         };
         const body = await this._makeHttpCall(request);
         const xml = DomUtil.parse(body);
-        const result = this.toRepresentation(xml);
+        const result = this._toRepresentation(xml);
         return result;
     }
 
@@ -1235,7 +1258,7 @@ class Client {
             const timestamp = lines[1].trim();
             if (timestamp != "") root.setAttribute("timestamp", timestamp);
         }
-        const result = this.toRepresentation(doc);
+        const result = this._toRepresentation(doc);
         return result;
     }
 
@@ -1290,7 +1313,7 @@ class Client {
         }
         if (rtCount !== undefined && rtCount.trim() != "") root.setAttribute("eventQueueSize", rtCount);
         if (threshold !== undefined && rtCount.trim() != "") root.setAttribute("eventQueueMaxSize", threshold);
-        const result = this.toRepresentation(doc);
+        const result = this._toRepresentation(doc);
         return result;
     }
 }

--- a/src/client.js
+++ b/src/client.js
@@ -657,6 +657,7 @@ class Client {
             that._sessionToken = credentials._sessionToken;
             that._securityToken = "";
             that.application = new Application(that);
+            return Promise.resolve();
         }
         else if (credentials._type == "SecurityToken") {
             that._sessionInfo = undefined;
@@ -664,6 +665,7 @@ class Client {
             that._sessionToken = "";
             that._securityToken = credentials._securityToken;
             that.application = new Application(that);
+            return Promise.resolve();
         }
         else if (credentials._type == "UserPassword") {
             const user = credentials._getUser();
@@ -994,7 +996,7 @@ class Client {
             var param = DomUtil.getFirstChildElement(params, "param");
             var paramIndex = 0;
             while (param) {
-                const inout = DomUtil.getAttributeAsString(param, "inout");
+                   const inout = DomUtil.getAttributeAsString(param, "inout");
                 if (!inout || inout=="in") {
                     const type = DomUtil.getAttributeAsString(param, "type");
                     const paramName = DomUtil.getAttributeAsString(param, "name");
@@ -1266,7 +1268,6 @@ class Client {
         const result = this.toRepresentation(doc);
         return result;
     }
-
 }
 
 

--- a/src/client.js
+++ b/src/client.js
@@ -130,7 +130,7 @@ const clientHandler = {
                         var promise = callContext.client._callMethod(methodName, callContext, argumentsList);
                         return promise.then(function(optionAndValue) {
                             const optionName = argumentsList[0];
-                            client._optionCache.cache(optionName, optionAndValue);
+                            client._optionCache.put(optionName, optionAndValue);
                             return optionAndValue;
                         });
                     }
@@ -231,6 +231,10 @@ class Credentials {
 class ConnectionParameters {
     
     constructor(endpoint, credentials, options) {
+        // this._options will be populated with the data from "options" and with
+        // default values. But the "options" parameter will not be modified
+        this._options = {};
+
         // Default value
         if (options === undefined || options === null)
             options = { };
@@ -240,18 +244,24 @@ class ConnectionParameters {
         if (typeof options  != "object")
             throw CampaignException.INVALID_CONNECTION_OPTIONS(options);
 
-        if (options.representation === undefined || options.representation === null)
-            options.representation = "SimpleJson";
+        this._options.representation = options.representation;
+        if (this._options.representation === undefined || this._options.representation === null)
+            this._options.representation = "SimpleJson";
 
-        if (options.representation != "xml" && options.representation != "BadgerFish" && options.representation != "SimpleJson")
-            throw CampaignException.INVALID_REPRESENTATION(options.representation, "Cannot create Campaign client");
+        if (this._options.representation != "xml" && this._options.representation != "BadgerFish" && this._options.representation != "SimpleJson")
+            throw CampaignException.INVALID_REPRESENTATION(this._options.representation, "Cannot create Campaign client");
 
         // Defaults for rememberMe
-        options.rememberMe = !!options.rememberMe;
+        this._options.rememberMe = !!options.rememberMe;
+
+        this._options.entityCacheTTL = options.entityCacheTTL || 1000*300; // 5 mins
+        this._options.methodCacheTTL = options.methodCacheTTL || 1000*300; // 5 mins
+        this._options.optionCacheTTL = options.optionCacheTTL || 1000*300; // 5 mins 
+        this._options.traceAPICalls = options.traceAPICalls === null || options.traceAPICalls ? !!options.traceAPICalls : false;
+        this._options.transport = options.transport || request;
 
         this._endpoint = endpoint;
         this._credentials = credentials;
-        this._options = options;
     }
 
     /**
@@ -405,13 +415,13 @@ class Client {
         
         this._secretKeyCipher = undefined;
         
-        this._entityCache = new XtkEntityCache();
-        this._methodCache = new MethodCache();
-        this._optionCache = new OptionCache();
+        this._entityCache = new XtkEntityCache(connectionParameters._options.entityCacheTTL);
+        this._methodCache = new MethodCache(connectionParameters._options.methodCacheTTL);
+        this._optionCache = new OptionCache(connectionParameters._options.optionCacheTTL);
         this.NLWS = new Proxy(this, clientHandler);
 
-        this._transport = request;
-        this._traceAPICalls = false;
+        this._transport = connectionParameters._options.transport;
+        this._traceAPICalls = connectionParameters._options.traceAPICalls;
         this._observers = [];
 
         // expose utilities
@@ -764,8 +774,8 @@ class Client {
             value = this._optionCache.get(name);
         if (value === undefined) {
             const option = await this.NLWS.xtkSession.getOption(name);
-            value = this._optionCache.cache(name, option);
-            this._optionCache.cache(name, option);
+            value = this._optionCache.put(name, option);
+            this._optionCache.put(name, option);
         }
         return value;
     }
@@ -799,7 +809,7 @@ class Client {
         doc[attName] = value;
         return this.NLWS.xtkSession.write(doc).then(() => {
             // Once set, cache the value
-            this._optionCache.cache(name, [value, type]);
+            this._optionCache.put(name, [value, type]);
         });
     }
 
@@ -969,7 +979,7 @@ class Client {
         var schemaName = schema.getAttribute("name");
         var method = that._methodCache.get(schemaId, methodName);
         if (!method) {
-            this._methodCache.cache(schema);
+            this._methodCache.put(schema);
             method = that._methodCache.get(schemaId, methodName);
         }
         if (!method)

--- a/src/crypto.js
+++ b/src/crypto.js
@@ -1,4 +1,3 @@
-"use strict";
 /*
 Copyright 2020 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
@@ -10,7 +9,9 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
-
+(function() {
+"use strict";    
+    
 const { Util } = require('./util.js');
 
 
@@ -128,3 +129,5 @@ if (!Util.isBrowser()) {
   exports.Cipher = Cipher;
 }
 
+
+})();

--- a/src/domUtil.js
+++ b/src/domUtil.js
@@ -91,12 +91,17 @@ class DomException {
 
 
 /**
- * Helpers for common manipulation of DOM documents
  * @memberof XML
  * @class
  * @constructor
  */
 class DomUtil {
+
+    /**
+     * Helpers for common manipulation of DOM documents. Al functions are static, it is not necessary to create new instances of this object
+     */
+    constructor() {
+    }
     
     /**
      * Parse an XML string as a DOM Document

--- a/src/domUtil.js
+++ b/src/domUtil.js
@@ -1,4 +1,3 @@
-"use strict";
 /*
 Copyright 2020 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
@@ -10,11 +9,13 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
-
+(function() {
+"use strict";    
+    
 const XtkCaster = require('./xtkCaster.js').XtkCaster;
 const { Util } = require("./util.js");
 
-var JSDOM = undefined;
+var JSDOM;
 
 /* istanbul ignore else */
 if (!Util.isBrowser()) {
@@ -34,11 +35,11 @@ else {
     var dom = parser.parseFromString(text, "application/xml");
     this.window = {
         document: dom
-    }
+    };
     this.serialize = function() {
         return new XMLSerializer().serializeToString(dom);
-    }
-  }
+    };
+  };
 
   JSDOM = jsdom;
 }
@@ -443,10 +444,10 @@ class DomUtil {
             else if (child.nodeType === 3 || child.nodeType === 4) { // text and CDATA
                 if (flavor == "BadgerFish") {
                     const text = child.nodeValue;
-                    if (json["$"] === undefined)
-                        json["$"] = text;
+                    if (json.$ === undefined)
+                        json.$ = text;
                     else 
-                        json["$"] = json["$"] + text;
+                        json.$ = json.$ + text;
                 }
             }
             child = child.nextSibling;
@@ -638,3 +639,5 @@ exports.DomException = DomException;
 exports.BadgerFishObject = BadgerFishObject;
 exports.XPath = XPath;
 exports.XPathElement = XPathElement;
+
+})();

--- a/src/entityAccessor.js
+++ b/src/entityAccessor.js
@@ -1,4 +1,3 @@
-"use strict";
 /*
 Copyright 2020 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
@@ -10,7 +9,8 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
-
+(function() {
+"use strict";
 
 /**********************************************************************************
  * 
@@ -204,3 +204,5 @@ class EntityAccessor {
 
 // Public exports
 exports.EntityAccessor = EntityAccessor;
+
+})();

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,3 @@
-"use strict";
 /*
 Copyright 2020 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
@@ -10,15 +9,14 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
-
-
+(function() {
+"use strict";    
+    
 /**********************************************************************************
  * 
  * Adobe Campaign Classic Core SDK
  * 
  *********************************************************************************/
-
-'use strict'
 
 const pjson = require('../package.json');
 const DomUtil = require('./domUtil.js').DomUtil;
@@ -42,119 +40,123 @@ const request = require('./transport.js').request;
  */
 
 var transport = request;
-function _transport(t) {
-    if (t) {
-        const old = transport;
-        transport = t;
-        return old;
-    }
-    return transport;
-}
 
 /**
  * @namespace Campaign
  */
+class SDK {
 
-/**
- * Returns a Client interface which allows you to logon on to an ACC instance and call SOAP methods
- *
- * @memberof Campaign
- * @param {ConnectionParameters} connectionParameters. Use ConnectionParameters.ofUserAndPassword for example
- * @return {Promise<Client>} an ACC client object
- */
-async function init (connectionParameters) {
-    const client = new Client(this, connectionParameters);
-    return client;
-}
+    constructor() {
+    }
 
-/**
- * @typedef {Object} SDKVersion
- * @property {string} version - the version of the SDK (example: "1.0.0")
- * @property {string} name - the name of the npm package ("@adobe/acc-js-sdk")
- * @property {string} description - the version of the SDK (example: "ACC JavaScript SDK")
- * @memberOf Campaign
- */
+    _transport(t) {
+        if (t) {
+            const old = transport;
+            transport = t;
+            return old;
+        }
+        return transport;
+    }
+    
+    /**
+     * Returns a Client interface which allows you to logon on to an ACC instance and call SOAP methods
+     *
+     * @memberof Campaign
+     * @param {ConnectionParameters} connectionParameters. Use ConnectionParameters.ofUserAndPassword for example
+     * @return {Promise<Client>} an ACC client object
+     */
+    async init (connectionParameters) {
+        const client = new Client(this, connectionParameters);
+        return client;
+    }
 
-/**
- * Get client SDK version
- * @memberof Campaign
- * @returns {Campaign.SDKVersion} an object containing information about the SDK, such as it's name, version, etc.
- */
-function getSDKVersion() {
-    return {
-        version: pjson.version,
-        name: pjson.name,
-        description: pjson.description
+    /**
+     * @typedef {Object} SDKVersion
+     * @property {string} version - the version of the SDK (example: "1.0.0")
+     * @property {string} name - the name of the npm package ("@adobe/acc-js-sdk")
+     * @property {string} description - the version of the SDK (example: "ACC JavaScript SDK")
+     * @memberOf Campaign
+     */
+
+    /**
+     * Get client SDK version
+     * @memberof Campaign
+     * @returns {Campaign.SDKVersion} an object containing information about the SDK, such as it's name, version, etc.
+     */
+    getSDKVersion() {
+        return {
+            version: pjson.version,
+            name: pjson.name,
+            description: pjson.description
+        };
+    }
+
+    /**
+     * Get the outbound IP address (https://api.db-ip.com/v2/free/self)
+     * Can be useful to troubleshoot IP whitelisting issues
+     */
+    async ip() {
+        const transport = this._transport();
+        const ip = await transport({ url: "https://api.db-ip.com/v2/free/self" });
+        return ip;
+    }
+
+    /** 
+     * Escapes and quotes string contained in Xtk expressions. It's common to build xtk expressions such as "@name='Hello'". If 'Hello' is a variable, it's
+     * tempting to write "@name='" + hello + "'", or `@name='${hello}'`. The issue is that if the hello variable contains characters such as a
+     * simple quote, there can be security concerns (xtk injections). The escapeXtk function ensure proper escaping in this case. In addition, it will also
+     * surround the string with quotes, so you can write `@name=${escapeXtk(hello)}`.
+     * <p>
+     * There are 2 alternate signatures for this function
+     * <ul>
+     * <li> the first one takes one single parameter which is a string and returns the escaped, quoted string
+     * <li> the second one takes 2 array of strings and is called when using the function in tagged string litterals. The first array is the constant parts
+     *   of the string litteral, and the second array contains the variable parts. See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals
+     * </ul>
+     * <p>
+     * The function can be used in a tagged string litterals like this: "var expr = escapeXtk`@name=${hello}`"
+     * <p>
+     * @memberof Campaign
+     * @param {string|string[]} p1 is the text to escape. If the text is null or undefined, it will be handled as an empty string. when using the escapeXtk for a tagged string litteral, this parameter is the array of constant values in the template.
+     * @param {undefined|string[]} p2 when using the escapeXtk for a tagged string litteral, this parameter is the array of expression values in the template.
+     * @returns {string} the escaped and quoted (simple quotes) text.
+     * 
+     * @example
+     * expect(sdk.escapeXtk("Rock 'n' Roll")).toBe("'Rock \\'n\\' Roll'");
+     * 
+     * @example
+     * expect(sdk.escapeXtk`@name=${"Rock 'n' Roll"}`).toBe("@name='Rock \\'n\\' Roll'");
+     */
+    escapeXtk(p1, ...p2)
+    {
+        // first syntax: only one parameter which is a string => returns the escaped string.
+        // that's how the Campaign function in common.js behaves
+        if (p1 === undefined || p1 === null)
+            return "''";
+        if (typeof p1 === 'string') {
+            return "'" + String(p1).replace(/\\/g, "\\\\").replace(/'/g,  "\\'") + "'";
+        }
+
+        // Second syntax: for use in tagged template litterals
+        // instead of writing:  { expr: "@name = " + escapeXtk(userName) }
+        // you write { expr: escapeXtk`@name = {userName}` }
+        if (p1.length == 0) return "''";
+        var str = p1[0];
+        for (var i=1; i<p1.length; i++) {
+            str = str + this.escapeXtk(p2[i-1]) + p1[i];
+        }
+        return str;
     }
 }
 
-/**
- * Get the outbound IP address (https://api.db-ip.com/v2/free/self)
- * Can be useful to troubleshoot IP whitelisting issues
- */
- async function ip() {
-    const transport = _transport();
-    const ip = await transport({ url: "https://api.db-ip.com/v2/free/self" });
-    return ip;
-}
-
-/** 
- * Escapes and quotes string contained in Xtk expressions. It's common to build xtk expressions such as "@name='Hello'". If 'Hello' is a variable, it's
- * tempting to write "@name='" + hello + "'", or `@name='${hello}'`. The issue is that if the hello variable contains characters such as a
- * simple quote, there can be security concerns (xtk injections). The escapeXtk function ensure proper escaping in this case. In addition, it will also
- * surround the string with quotes, so you can write `@name=${escapeXtk(hello)}`.
- * <p>
- * There are 2 alternate signatures for this function
- * <ul>
- * <li> the first one takes one single parameter which is a string and returns the escaped, quoted string
- * <li> the second one takes 2 array of strings and is called when using the function in tagged string litterals. The first array is the constant parts
- *   of the string litteral, and the second array contains the variable parts. See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals
- * </ul>
- * <p>
- * The function can be used in a tagged string litterals like this: "var expr = escapeXtk`@name=${hello}`"
- * <p>
- * @memberof Campaign
- * @param {string|string[]} p1 is the text to escape. If the text is null or undefined, it will be handled as an empty string. when using the escapeXtk for a tagged string litteral, this parameter is the array of constant values in the template.
- * @param {undefined|string[]} p2 when using the escapeXtk for a tagged string litteral, this parameter is the array of expression values in the template.
- * @returns {string} the escaped and quoted (simple quotes) text.
- * 
- * @example
- * expect(sdk.escapeXtk("Rock 'n' Roll")).toBe("'Rock \\'n\\' Roll'");
- * 
- * @example
- * expect(sdk.escapeXtk`@name=${"Rock 'n' Roll"}`).toBe("@name='Rock \\'n\\' Roll'");
- */
-function escapeXtk(p1, ...p2)
-{
-    // first syntax: only one parameter which is a string => returns the escaped string.
-    // that's how the Campaign function in common.js behaves
-    if (p1 === undefined || p1 === null)
-        return "''";
-    if (typeof p1 === 'string') {
-        return "'" + String(p1).replace(/\\/g, "\\\\").replace(/'/g,  "\\'") + "'";
-    }
-
-    // Second syntax: for use in tagged template litterals
-    // instead of writing:  { expr: "@name = " + escapeXtk(userName) }
-    // you write { expr: escapeXtk`@name = {userName}` }
-    if (p1.length == 0) return "''";
-    var str = p1[0];
-    for (var i=1; i<p1.length; i++) {
-        str = str + escapeXtk(p2[i-1]) + p1[i];
-    }
-    return str;
-}
+const sdk = new SDK();
+sdk.XtkCaster = XtkCaster;
+sdk.Credentials = Credentials;
+sdk.DomUtil = DomUtil;
+sdk.ConnectionParameters = ConnectionParameters;
 
 // Public exports
-module.exports = {
-    init: init,
-    getSDKVersion: getSDKVersion,
-    ip: ip,
-    escapeXtk: escapeXtk,
-    XtkCaster: XtkCaster,
-    DomUtil: DomUtil,
-    Credentials: Credentials,
-    ConnectionParameters: ConnectionParameters,
-    _transport: _transport
-};
+module.exports = sdk;
 
+
+})();

--- a/src/methodCache.js
+++ b/src/methodCache.js
@@ -30,16 +30,21 @@ const { Cache } = require('./util.js');
  */
 
 /**
- * A in-memory cache for SOAP call method definitions. Not intended to be used directly,
- * but an internal cache for the Campaign.Client object
- * 
  * @private
  * @class
  * @constructor
  * @memberof Campaign
  */
 class MethodCache extends Cache {
-    
+
+    /**
+     * A in-memory cache for SOAP call method definitions. Not intended to be used directly,
+     * but an internal cache for the Campaign.Client object
+     * 
+     * @param {Storage} storage is an optional Storage object, such as localStorage or sessionStorage
+     * @param {string} rootKey is an optional root key to use for the storage object
+     * @param {number} ttl is the TTL for objects in ms. Defaults to 5 mins
+     */
     constructor(storage, rootKey, ttl) {
         super(storage, rootKey, ttl, ((schemaId, methodName) => schemaId + "#" + methodName ));
     }

--- a/src/methodCache.js
+++ b/src/methodCache.js
@@ -1,4 +1,3 @@
-"use strict";
 /*
 Copyright 2020 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
@@ -10,7 +9,9 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
-
+(function() {
+"use strict";    
+    
 
 /**********************************************************************************
  * 
@@ -122,3 +123,5 @@ class MethodCache extends Cache {
 
 // Public exports
 exports.MethodCache = MethodCache;
+
+})();

--- a/src/methodCache.js
+++ b/src/methodCache.js
@@ -39,8 +39,8 @@ const { Cache } = require('./util.js');
  */
 class MethodCache extends Cache {
     
-    constructor(ttl) {
-        super(ttl, ((schemaId, methodName) => schemaId + "#" + methodName ));
+    constructor(storage, rootKey, ttl) {
+        super(storage, rootKey, ttl, ((schemaId, methodName) => schemaId + "#" + methodName ));
     }
 
     /**

--- a/src/optionCache.js
+++ b/src/optionCache.js
@@ -33,9 +33,6 @@ const { Cache } = require('./util.js');
 
 
 /**
- * A in-memory cache for xtk option values. Not intended to be used directly,
- * but an internal cache for the Campaign.Client object
- * 
  * @private
  * @class
  * @constructor
@@ -43,7 +40,15 @@ const { Cache } = require('./util.js');
  */
 class OptionCache extends Cache {
     
-    constructor(storage, rootKey, ttl) {
+    /**
+     * A in-memory cache for xtk option values. Not intended to be used directly,
+     * but an internal cache for the Campaign.Client object
+     * 
+     * @param {Storage} storage is an optional Storage object, such as localStorage or sessionStorage
+     * @param {string} rootKey is an optional root key to use for the storage object
+     * @param {number} ttl is the TTL for objects in ms. Defaults to 5 mins
+     */
+     constructor(storage, rootKey, ttl) {
         super(storage, rootKey, ttl);
     }
 

--- a/src/optionCache.js
+++ b/src/optionCache.js
@@ -43,8 +43,8 @@ const { Cache } = require('./util.js');
  */
 class OptionCache extends Cache {
     
-    constructor(ttl) {
-        super(ttl);
+    constructor(storage, rootKey, ttl) {
+        super(storage, rootKey, ttl);
     }
 
     /**

--- a/src/optionCache.js
+++ b/src/optionCache.js
@@ -1,4 +1,3 @@
-"use strict";
 /*
 Copyright 2020 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
@@ -10,7 +9,8 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
-
+(function() {
+"use strict";    
 
 /**********************************************************************************
  * 
@@ -70,7 +70,7 @@ class OptionCache extends Cache {
     put(name, rawValueAndtype) {
         var value = null;
         var type = 0;
-        var rawValue = undefined;
+        var rawValue;
         if (rawValueAndtype && rawValueAndtype[1] != 0) {
             rawValue = rawValueAndtype[0];
             type = rawValueAndtype[1];
@@ -105,3 +105,5 @@ class OptionCache extends Cache {
 
 // Public exports
 exports.OptionCache = OptionCache;
+
+})();

--- a/src/optionCache.js
+++ b/src/optionCache.js
@@ -18,6 +18,8 @@ governing permissions and limitations under the License.
  * 
  *********************************************************************************/
 const XtkCaster = require('./xtkCaster.js').XtkCaster;
+const { Cache } = require('./util.js');
+
 
 /**
  * @namespace Campaign
@@ -39,15 +41,23 @@ const XtkCaster = require('./xtkCaster.js').XtkCaster;
  * @constructor
  * @memberof Campaign
  */
-class OptionCache {
+class OptionCache extends Cache {
     
-    constructor() {
-        /**
-         * The option values, by option name
-         * @private
-         * @type {Object<string,Campaign.XtkOption>}
-         */
-        this._optionsByName = {};
+    constructor(ttl) {
+        super(ttl);
+    }
+
+    /**
+     * Cache an option and its value
+     * For backward compatibility purpose. Use "put" instead
+     * 
+     * @deprecated
+     * @param {string} name is the option name
+     * @param {Array} rawValueAndtype a 2 elements array, whose first element is the raw option value (text serialized) and the second element 
+     * is the data type of the option. Such an array is returned by the xtk:session#GetOption method
+     */
+     cache(schemaId, methodName) {
+        return this.put(schemaId, methodName);
     }
 
     /**
@@ -57,7 +67,7 @@ class OptionCache {
      * @param {Array} rawValueAndtype a 2 elements array, whose first element is the raw option value (text serialized) and the second element 
      * is the data type of the option. Such an array is returned by the xtk:session#GetOption method
      */
-    cache(name, rawValueAndtype) {
+    put(name, rawValueAndtype) {
         var value = null;
         var type = 0;
         var rawValue = undefined;
@@ -66,7 +76,7 @@ class OptionCache {
             type = rawValueAndtype[1];
             value = XtkCaster.as(rawValue, type);
         }
-        this._optionsByName[name] = { value:value, type:type, rawValue:rawValue };
+        super.put(name, { value:value, type:type, rawValue:rawValue });
         return value;
     }
 
@@ -77,7 +87,7 @@ class OptionCache {
      * @returns {*} the option value
      */
     get(name) {
-        const option = this._optionsByName[name];
+        const option = super.get(name);
         return option ? option.value : undefined;
     }
 
@@ -88,17 +98,8 @@ class OptionCache {
      * @returns {Campaign.XtkOption} the option
      */
     getOption(name) {
-        const option = this._optionsByName[name];
-        return option;
+        return super.get(name);
     }
-
-    /**
-     * Clears the cache
-     */
-    clear() {
-        this._optionsByName = {};
-    }
-
 }
 
 

--- a/src/soap.js
+++ b/src/soap.js
@@ -1,4 +1,3 @@
-"use strict";
 /*
 Copyright 2020 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
@@ -10,7 +9,9 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
-
+(function() {
+"use strict";    
+    
 
 /**********************************************************************************
  * 
@@ -514,7 +515,7 @@ class SoapMethodCall {
      * @returns a boolean set to true if ther are no more response args to read
      */ 
     checkNoMoreArgs() {
-        return !this.elemCurrent
+        return !this.elemCurrent;
     }
 
     /**
@@ -535,7 +536,7 @@ class SoapMethodCall {
             data: DomUtil.toXMLString(this._doc)
         };
         if (this._sessionToken)
-            options.headers['Cookie'] = '__sessiontoken=' + this._sessionToken;
+            options.headers.Cookie = '__sessiontoken=' + this._sessionToken;
         if (this._userAgentString)
             options.headers['User-Agent'] = this._userAgentString;
         return options;
@@ -636,3 +637,5 @@ class SoapMethodCall {
 
 // Public exports
 exports.SoapMethodCall = SoapMethodCall;
+
+})();

--- a/src/transport.js
+++ b/src/transport.js
@@ -9,6 +9,8 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
+(function() {
+"use strict";    
 
 const { Util } = require('./util.js');
 
@@ -70,9 +72,8 @@ if (!Util.isBrowser()) {
         return Promise.reject(new HttpError(500, error ? error.toString() : undefined));
       // HTTP errors (400, 404, 500, etc.) are returned here
       return Promise.reject(new HttpError(response.status, response.statusText, response.data));
-    })
-  }
-
+    });
+  };
 
   exports.request = request;
   exports.HttpError = HttpError;
@@ -107,13 +108,16 @@ if (!Util.isBrowser()) {
             return blob.text();
         });
     }).catch((ex) => {
-      if (ex.__proto__.constructor.name == "HttpError")
+      const proto = Object.getPrototypeOf(ex);
+      if (proto.constructor.name == "HttpError")
         throw ex;
       throw new HttpError(ex.status, ex.statusText);
-    })
+    });
     return p;
-  }
+  };
 
   module.exports.request = request;
 
 }
+
+})();

--- a/src/util.js
+++ b/src/util.js
@@ -78,7 +78,24 @@ class Util {
         }
         if (typeof text == "object") {
           for (const p in text) {
-            text[p] = Util.trim(text[p]);
+            if (p.toLowerCase() === "x-security-token")
+              text[p] = "***";
+            else if (p === "Cookie") {
+              var index = text[p].toLowerCase().indexOf("__sessiontoken");
+              if (index !== -1) {
+                index = text[p].indexOf("=", index);
+                if (index !== -1) {
+                  index = index + 1;
+                  const endIndex = text[p].indexOf(";", index);
+                  if (endIndex == -1)
+                    text[p] = text[p].substring(0, index) + "***";
+                  else 
+                    text[p] = text[p].substring(0, index) + "***" + text[p].substring(endIndex);
+                }
+              }
+            }
+            else
+              text[p] = Util.trim(text[p]);
           }
         }
         if (typeof text == "string") {

--- a/src/util.js
+++ b/src/util.js
@@ -96,8 +96,69 @@ class Util {
         }
         return text;
       }
+}
 
+
+/**********************************************************************************
+ * 
+ * A simple cache for XtkEntities, options, etc.
+ * 
+ *********************************************************************************/
+
+/**
+ * An object in the cache.
+ */
+class CachedObject {
+  constructor(value, cachedAt, expiresAt) {
+      this.value = value;
+      this.cachedAt = cachedAt;
+      this.expiresAt = expiresAt
+  }
+}
+
+/**
+ * A general purpose cache with TTL
+ * @param {number} ttl is the TTL for objects in ms. Defaults to 5 mins
+ * @param {makeKeyFn} is an optional function which will generate a key for objects in the cache. It's passed the arguments of the cache 'get' function
+ */
+class Cache {
+  constructor(ttl, makeKeyFn) {
+      this._ttl = ttl || 1000*300;
+      this._makeKeyFn = makeKeyFn || ((x) => x);
+      this._cache = {};
+  }
+
+  _getIfActive(key) {
+      const cached = this._cache[key];
+      if (!cached) return undefined;
+      if (cached.expiresAt <= Date.now()) {
+          delete this._cache[key];
+          return undefined;
+      }
+      return cached.value;
+  }
+
+  get() {
+      const key = this._makeKeyFn.apply(this, arguments);
+      const cached = this._getIfActive(key);
+      return cached;
+  }
+
+  put() {
+      const value = arguments[arguments.length -1];
+      const key = this._makeKeyFn.apply(this, arguments);
+      const now = Date.now();
+      const expiresAt = now + this._ttl;
+      const cached = new CachedObject(value, now, expiresAt);
+      this._cache[key] = cached;
+      return cached;
+  }
+  
+  clear() {
+      this._cache = {};
+  }
 }
 
 // Public expots
 exports.Util = Util;
+exports.Cache = Cache;

--- a/src/util.js
+++ b/src/util.js
@@ -20,99 +20,119 @@ governing permissions and limitations under the License.
  *********************************************************************************/
 
 /**
- * @namespace Campaign
+ * @namespace Utils
  */
 
 /**
- * Helpers for common manipulation of DOM documents
- * @memberof Campaign
+ * @memberof Utils
  * @class
  * @constructor
  */
 class Util {
 
-    static isBrowser() {
-        const browser = typeof window !== 'undefined';
-        return browser;
-    }
-    
-    static isArray(o) {
-        if (o === null || o === undefined) return false;
-        // JavaScript arrays are objects
-        if (typeof o != "object") return false;
-        // They also have a length property. But checking the length is not enough
-        // since, it can also be an object litteral with a "length" property. Campaign
-        // schema attributes typically have a "length" attribute and are not arrays
-        if (o.length === undefined || o.length === null) return false;
-        // So check for a "push" function
-        if (o.push === undefined || o.push === null) return false;
-        if (typeof o.push != "function") 
-            return false;
-        return true;
-    }
+  /**
+   * Generic helper functions available everywhere in the SDK. Al functions are static, it is not necessary to create new instances of this object
+   */
+  constructor() {
+  }
 
+  /**
+   * Indicates whether the SDK is running in a browser or not
+   * @returns {boolean} a boolean indicating if the SDK is running in a browser or not
+   */
+  static isBrowser() {
+    const browser = typeof window !== 'undefined';
+    return browser;
+  }
+  
+  /**
+   * Tests if an object is a JavaScript array
+   * @param {*} obj the object to test, may be undefined
+   * @returns {boolean} true if the object is an array
+   */
+  static isArray(obj) {
+    if (obj === null || obj === undefined) return false;
+    // JavaScript arrays are objects
+    if (typeof obj != "object") return false;
+    // They also have a length property. But checking the length is not enough
+    // since, it can also be an object litteral with a "length" property. Campaign
+    // schema attributes typically have a "length" attribute and are not arrays
+    if (obj.length === undefined || obj.length === null) return false;
+    // So check for a "push" function
+    if (obj.push === undefined || obj.push === null) return false;
+    if (typeof obj.push != "function") 
+        return false;
+    return true;
+  }
 
-    static _removeBetween(text, from, to) {
-        var index = 0;
-        while (index < text.length) {
-          index = text.indexOf(from, index);
-          if (index == -1) break;
-          const index2 = text.indexOf(to, index);
-          if (index2 == -1) {
-            break;
-          }
-          text = text.substring(0, index + from.length) + '***' + text.substring(index2);
-          index = index2;
-        }
-        return text;
+  // Helper function for trim() to replace text between 2 indices
+  static _removeBetween(text, from, to) {
+    var index = 0;
+    while (index < text.length) {
+      index = text.indexOf(from, index);
+      if (index == -1) break;
+      const index2 = text.indexOf(to, index);
+      if (index2 == -1) {
+        break;
       }
-    
-      static trim(text) {
-        if (text == null || text == undefined) return undefined;
-        if (Util.isArray(text)) {
-          const a = [];
-          for (const p of text) {
-            a.push(Util.trim(p));
-          }
-          return a;
-        }
-        if (typeof text == "object") {
-          for (const p in text) {
-            if (p.toLowerCase() === "x-security-token")
-              text[p] = "***";
-            else if (p === "Cookie") {
-              var index = text[p].toLowerCase().indexOf("__sessiontoken");
-              if (index !== -1) {
-                index = text[p].indexOf("=", index);
-                if (index !== -1) {
-                  index = index + 1;
-                  const endIndex = text[p].indexOf(";", index);
-                  if (endIndex == -1)
-                    text[p] = text[p].substring(0, index) + "***";
-                  else 
-                    text[p] = text[p].substring(0, index) + "***" + text[p].substring(endIndex);
-                }
-              }
+      text = text.substring(0, index + from.length) + '***' + text.substring(index2);
+      index = index2;
+    }
+    return text;
+  }
+  
+  /**
+   * Trims a text, an object or an array and remove sensitive information, such as session tokens, passwords, etc.
+   * 
+   * @param {string|Object|Array} obj is the object to trim
+   * @returns {string|Object|Array} the trimmed object
+   */
+  static trim(obj) {
+    if (obj == null || obj == undefined) return undefined;
+    if (Util.isArray(obj)) {
+      const a = [];
+      for (const p of obj) {
+        a.push(Util.trim(p));
+      }
+      return a;
+    }
+    if (typeof obj == "object") {
+      for (const p in obj) {
+        if (p.toLowerCase() === "x-security-token")
+          obj[p] = "***";
+        else if (p === "Cookie") {
+          var index = obj[p].toLowerCase().indexOf("__sessiontoken");
+          if (index !== -1) {
+            index = obj[p].indexOf("=", index);
+            if (index !== -1) {
+              index = index + 1;
+              const endIndex = obj[p].indexOf(";", index);
+              if (endIndex == -1)
+                obj[p] = obj[p].substring(0, index) + "***";
+              else 
+                obj[p] = obj[p].substring(0, index) + "***" + obj[p].substring(endIndex);
             }
-            else
-              text[p] = Util.trim(text[p]);
           }
         }
-        if (typeof text == "string") {
-          // Remove trailing blanks
-          while (text && (text.endsWith(' ') || text.endsWith('\n') || text.endsWith('\r') || text.endsWith('\t')))
-            text = text.substring(0, text.length - 1);
-    
-          // Hide session tokens
-          text = this._removeBetween(text, "<Cookie>__sessiontoken=", "</Cookie>");
-          text = this._removeBetween(text, "<X-Security-Token>", "</X-Security-Token>");
-          text = this._removeBetween(text, '<sessiontoken xsi:type="xsd:string">', '</sessiontoken>');
-          text = this._removeBetween(text, "<pstrSessionToken xsi:type='xsd:string'>", "</pstrSessionToken>");
-          text = this._removeBetween(text, "<pstrSecurityToken xsi:type='xsd:string'>", "</pstrSecurityToken>");
-          text = this._removeBetween(text, '<password xsi:type="xsd:string">', '</password>');
-        }
-        return text;
+        else
+          obj[p] = Util.trim(obj[p]);
       }
+    }
+    if (typeof obj == "string") {
+      // Remove trailing blanks
+      while (obj && (obj.endsWith(' ') || obj.endsWith('\n') || obj.endsWith('\r') || obj.endsWith('\t')))
+        obj = obj.substring(0, obj.length - 1);
+
+      // Hide session tokens
+      obj = this._removeBetween(obj, "<Cookie>__sessiontoken=", "</Cookie>");
+      obj = this._removeBetween(obj, "<X-Security-Token>", "</X-Security-Token>");
+      obj = this._removeBetween(obj, '<sessiontoken xsi:type="xsd:string">', '</sessiontoken>');
+      obj = this._removeBetween(obj, "<pstrSessionToken xsi:type='xsd:string'>", "</pstrSessionToken>");
+      obj = this._removeBetween(obj, "<pstrSecurityToken xsi:type='xsd:string'>", "</pstrSecurityToken>");
+      obj = this._removeBetween(obj, '<password xsi:type="xsd:string">', '</password>');
+    }
+    return obj;
+  }
 }
 
 
@@ -122,18 +142,38 @@ class Util {
  * 
  *********************************************************************************/
 
-
-// Wrapper to LocalStorage which is "safe"
-// - Will never throw / support local stroage to be undefined or not accessible
-// - Handle the notion of "root key", i.e. prefix 
-// - Set/get values as JSON only
+/**
+ * @private
+ * @class
+ * @constructor
+ * @memberof Utils
+ */
 class SafeStorage {
 
+  /**
+   * A wrapper to the Storage interface (LocalStorage, etc.) which is "safe", i.e.
+   * 
+   * - it will never throw / support local stroage to be undefined or not accessible
+   * - Handle the notion of "root key", i.e. prefix 
+   * - Set/get values as JSON only and not as strings
+   * - Silently caches all exceptions
+   * - Automatically remove from storage cached values which are not valid, expired, or cannot be parsed
+   * 
+   * SafeStorage objects are created automatically by Caches
+   * 
+   * @param {Storage} delegate an optional delegate options, confomring to the Storage interface (getItem, setItem, removeItem)
+   * @param {string} rootKey an optional prefix which will be prepend to all keys
+   */
   constructor(delegate, rootKey) {
     this._delegate = delegate;
     this._rootKey = rootKey ? `${rootKey}$` : "";
   }
 
+  /**
+   * Get an item from storage
+   * @param {string} key the item key (relative to the root key)
+   * @returns {Object} the cached JSON object, or undefined if not found 
+   */
   getItem(key) {
     if (!this._delegate || this._rootKey === undefined || this._rootKey === null)
       return;
@@ -148,7 +188,12 @@ class SafeStorage {
     }
   }
 
-  setItem(key, json) {
+  /**
+   * Put an item into storage
+   * @param {string} key the item key (relative to the root key)
+   * @param {Object} json the value to cache
+   */
+   setItem(key, json) {
     if (!this._delegate || this._rootKey === undefined || this._rootKey === null)
       return;
     try {
@@ -162,6 +207,10 @@ class SafeStorage {
     this.removeItem(key);
   }
 
+  /**
+   * Removes an item from the storage
+   * @param {string} key the item key (relative to the root key)
+   */
   removeItem(key) {
     if (!this._delegate || this._rootKey === undefined || this._rootKey === null)
       return;
@@ -173,9 +222,21 @@ class SafeStorage {
 }
 
 /**
- * An object in the cache.
+ * @private
+ * @class
+ * @constructor
+ * @memberof Utils
  */
 class CachedObject {
+
+  /**
+   * An object in the cache, i.e. a wrapped to a cached value and additional metadata to manage the cache.
+   * Do not create such objects directly, they are 100% managed by the Cache object
+   * 
+   * @param {*} value the cached value
+   * @param {number} cachedAt the timestamp at which the value was cached
+   * @param {number} expiresAt the timestamp at which the cached value expires
+   */
   constructor(value, cachedAt, expiresAt) {
       this.value = value;
       this.cachedAt = cachedAt;
@@ -183,14 +244,27 @@ class CachedObject {
   }
 }
 
-/**
- * A general purpose cache with TTL
- * @param {Storage} storage is an optional Storage object, such as localStorage or sessionStorage
- * @param {string} rootKey is an optional root key to use for the storage object
- * @param {number} ttl is the TTL for objects in ms. Defaults to 5 mins
- * @param {makeKeyFn} is an optional function which will generate a key for objects in the cache. It's passed the arguments of the cache 'get' function
+/** 
+ * @private
+ * @class
+ * @constructor
+ * @memberof Utils
  */
 class Cache {
+
+  /**
+   * A general purpose in-memory cache with TTL. In addition to caching in memory, the cache has the ability to delegate the caching
+   * to a persistent cache, such as the browser localStorage. The interface is 100% synchronous.
+   * 
+   * By default, caches take a single parameter for the key. It is possible however to use a more complex scenario by setting a makeKeyFn.
+   * When set, such a function will take 1 or more arguments and will be responsible to create a primitive key (a string) from the arguments.
+   * The cache public APIs : get and put therefore can take a variable number of key arguments, which will be combined into the actual primitive key.
+   * 
+   * @param {Storage} storage is an optional Storage object, such as localStorage or sessionStorage. This object will be wrapped into a SafeStorage object to ensure access is safe and will not throw any exceptions
+   * @param {string} rootKey is an optional root key to use for the storage object
+   * @param {number} ttl is the TTL for objects in ms. Defaults to 5 mins
+   * @param {function} makeKeyFn is an optional function which will generate a key for objects in the cache. It's passed the arguments of the cache 'get' function
+   */
   constructor(storage, rootKey, ttl, makeKeyFn) {
       this._storage = new SafeStorage(storage, rootKey);
       this._ttl = ttl || 1000*300;
@@ -250,13 +324,24 @@ class Cache {
     return cached.value;
   }
 
+  /**
+   * Get a value from the cache
+   * @param {*} key the key or keys of the value to retreive
+   * @returns {*} the cached value, or undefined if not found
+   */
   get() {
       const key = this._makeKeyFn.apply(this, arguments);
       const cached = this._getIfActive(key);
       return cached;
   }
 
-  put() {
+  /**
+   * Put a value from the cache
+   * @param {*} key the key or keys of the value to retreive
+   * @param {*} value the value to cache
+   * @returns {CachedObject} a cached object containing the cached value
+   */
+   put() {
       const value = arguments[arguments.length -1];
       const key = this._makeKeyFn.apply(this, arguments);
       const now = Date.now();
@@ -267,6 +352,10 @@ class Cache {
       return cached;
   }
   
+  /**
+   * Removes everything from the cache. It does not directly removes data from persistent storage if there is, but it marks the cache
+   * as cleared so that subsequent get operation will not actually return any data cached in persistent storage
+   */
   clear() {
       this._cache = {};
       this._saveLastCleared();

--- a/src/util.js
+++ b/src/util.js
@@ -1,5 +1,3 @@
-"use strict";
-
 /*
 Copyright 2020 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
@@ -11,7 +9,9 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
-
+(function() {
+"use strict";    
+  
 
 /**********************************************************************************
  * 
@@ -179,7 +179,7 @@ class CachedObject {
   constructor(value, cachedAt, expiresAt) {
       this.value = value;
       this.cachedAt = cachedAt;
-      this.expiresAt = expiresAt
+      this.expiresAt = expiresAt;
   }
 }
 
@@ -277,3 +277,5 @@ class Cache {
 exports.Util = Util;
 exports.SafeStorage = SafeStorage;
 exports.Cache = Cache;
+
+})();

--- a/src/xtkCaster.js
+++ b/src/xtkCaster.js
@@ -1,4 +1,3 @@
-"use strict";
 /*
 Copyright 2020 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
@@ -10,7 +9,8 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
-
+(function() {
+"use strict";    
 
 /**********************************************************************************
  * 
@@ -111,7 +111,7 @@ class XtkCaster {
             case "datetimenotz": 
             case 10:            // FIELD_DATE
             case "date": 
-                return "timeStampValue"
+                return "timeStampValue";
             default: {
                 throw CampaignException.BAD_PARAMETER("type", type, `Cannot get variant storage attribute name for type '${type}'`);
             }
@@ -371,3 +371,5 @@ class XtkCaster {
 }
 
 exports.XtkCaster = XtkCaster;
+
+})();

--- a/src/xtkCaster.js
+++ b/src/xtkCaster.js
@@ -56,15 +56,16 @@ governing permissions and limitations under the License.
  * @memberof Campaign
  */
 
-/**
- * Helpers to convert between JavaScript data types and Campaign XTK data types
- * 
+/** 
  * @memberof Campaign
  * @class
  * @constructor
  */
 class XtkCaster {
     
+    /**
+     * Helpers to convert between JavaScript data types and Campaign XTK data types
+     */
     constructor() {
     }
 

--- a/src/xtkEntityCache.js
+++ b/src/xtkEntityCache.js
@@ -22,9 +22,23 @@ const { Cache } = require('./util.js');
  * 
  *********************************************************************************/
 
+/**
+ * @private
+ * @class
+ * @constructor
+ * @memberof Campaign
+ */
 class XtkEntityCache extends Cache {
     
-    constructor(storage, rootKey, ttl) {
+    /**
+     * A in-memory cache for xtk entities. Not intended to be used directly,
+     * but an internal cache for the Campaign.Client object
+     * 
+     * @param {Storage} storage is an optional Storage object, such as localStorage or sessionStorage
+     * @param {string} rootKey is an optional root key to use for the storage object
+     * @param {number} ttl is the TTL for objects in ms. Defaults to 5 mins
+     */
+     constructor(storage, rootKey, ttl) {
         super(storage, rootKey, ttl, (entityType, entityFullName) => entityType + "|" + entityFullName);
     }
 

--- a/src/xtkEntityCache.js
+++ b/src/xtkEntityCache.js
@@ -22,8 +22,8 @@ const { Cache } = require('./util.js');
 
 class XtkEntityCache extends Cache {
     
-    constructor(ttl) {
-        super(ttl, (entityType, entityFullName) => entityType + "|" + entityFullName);
+    constructor(storage, rootKey, ttl) {
+        super(storage, rootKey, ttl, (entityType, entityFullName) => entityType + "|" + entityFullName);
     }
 
     /**

--- a/src/xtkEntityCache.js
+++ b/src/xtkEntityCache.js
@@ -11,6 +11,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 const DomUtil = require('./domUtil.js').DomUtil;
+const { Cache } = require('./util.js');
 
 
 /**********************************************************************************
@@ -19,14 +20,10 @@ const DomUtil = require('./domUtil.js').DomUtil;
  * 
  *********************************************************************************/
 
-function entityKey(entityType, entityFullName) {
-    return entityType + "|" + entityFullName;
-}
- 
-class XtkEntityCache {
+class XtkEntityCache extends Cache {
     
-    constructor() {
-        this.cache = {}
+    constructor(ttl) {
+        super(ttl, (entityType, entityFullName) => entityType + "|" + entityFullName);
     }
 
     /**
@@ -36,9 +33,7 @@ class XtkEntityCache {
      * @returns {*} the cached entity, or undefined if not found
      */
     get(entityType, entityFullName) {
-        const key = entityKey(entityType, entityFullName);
-        var entity = this.cache[key]
-        return entity;
+        return super.get(entityType, entityFullName);
     }
 
     /**
@@ -48,29 +43,18 @@ class XtkEntityCache {
      * @param {*} entity is the entity
      */
     put(entityType, entityFullName, entity) {
-        var key = entityKey(entityType, entityFullName);
-        this.cache[key] = entity;
-
+        super.put(entityType, entityFullName, entity);
         // For schemas, cache interfaces
         if (entityType == "xtk:schema") {
             const namespace = entity.getAttribute("namespace");
             var interfaceElement = DomUtil.getFirstChildElement(entity, "interface");
             while (interfaceElement) {
                 const name = `${namespace}:${interfaceElement.getAttribute("name")}`;
-                const key = entityKey(entityType, name);
-                this.cache[key] = interfaceElement;
+                super.put(entityType, name, interfaceElement);
                 interfaceElement = DomUtil.getNextSiblingElement(interfaceElement, "interface");
             }
         }
     }
-
-    /**
-     * Clears the cache
-     */
-    clear() {
-        this.cache = {};
-    }
-
 }
 
 

--- a/src/xtkEntityCache.js
+++ b/src/xtkEntityCache.js
@@ -1,4 +1,3 @@
-"use strict";
 /*
 Copyright 2020 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
@@ -10,6 +9,9 @@ the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTA
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 */
+(function() {
+"use strict";
+
 const DomUtil = require('./domUtil.js').DomUtil;
 const { Cache } = require('./util.js');
 
@@ -60,3 +62,5 @@ class XtkEntityCache extends Cache {
 
 // Public exports
 exports.XtkEntityCache = XtkEntityCache;
+
+})();

--- a/test/caches.test.js
+++ b/test/caches.test.js
@@ -34,13 +34,13 @@ describe('Caches', function() {
         })
 
         it("Should expires after TTL", () => {
-            const cache = new Cache(-1);    // negative TTL => will immediately expire
+            const cache = new Cache(undefined, undefined, -1);    // negative TTL => will immediately expire
             cache.put("Hello", "World");
             expect(cache.get("Hello")).toBeUndefined();
         })
 
         it("Should support custom key function", () => {
-            const cache = new Cache(300000, ((a, b) => a + "||" + b));
+            const cache = new Cache(undefined, undefined, 300000, ((a, b) => a + "||" + b));
             cache.put("key-part-1", "key-part-2", "value");
             expect(cache.get("key-part-1")).toBeUndefined();
             expect(cache.get("key-part-2")).toBeUndefined();

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -1896,4 +1896,57 @@ describe('ACC Client', function () {
             expect(logoff.mock.calls.length).toBe(1);
         })   
      })
+
+    describe("Logon should always return a promise", () => {
+
+        it("Should return a promise with UserPassword", async () => {
+            const connectionParameters = sdk.ConnectionParameters.ofUserAndPassword("http://acc-sdk:8080", "$user$", "$password$");
+            const client = await sdk.init(connectionParameters);
+            client._transport = jest.fn();
+            client._transport.mockReturnValueOnce(Mock.LOGON_RESPONSE);
+            const result = client.logon();
+            expect(result instanceof Promise).toBe(true);
+            await result;
+        })
+
+        it("Should return a promise with UserAndServiceToken", async () => {
+            const connectionParameters = sdk.ConnectionParameters.ofUserAndServiceToken("http://acc-sdk:8080", "$user$", "$service_token$");
+            const client = await sdk.init(connectionParameters);
+            client._transport = jest.fn();
+            const result = client.logon();
+            expect(result instanceof Promise).toBe(true);
+            try {
+                await result;
+            } catch(ex) { /* result or exception is not handled */ }
+        })
+
+        it("Should return a promise with SessionToken", async () => {
+            const connectionParameters = sdk.ConnectionParameters.ofSessionToken("http://acc-sdk:8080", "$session_token$");
+            const client = await sdk.init(connectionParameters);
+            client._transport = jest.fn();
+            const result = client.logon();
+            expect(result instanceof Promise).toBe(true);
+            await result;
+        })
+
+        it("Should return a promise with SecurityToken", async () => {
+            const connectionParameters = sdk.ConnectionParameters.ofSecurityToken("http://acc-sdk:8080", "$security_token$");
+            const client = await sdk.init(connectionParameters);
+            client._transport = jest.fn();
+            const result = client.logon();
+            expect(result instanceof Promise).toBe(true);
+            await result;
+        })
+
+        it("Should return a promise with AnonymousUser", async () => {
+            const connectionParameters = sdk.ConnectionParameters.ofAnonymousUser("http://acc-sdk:8080");
+            const client = await sdk.init(connectionParameters);
+            client._transport = jest.fn();
+            const result = client.logon();
+            expect(result instanceof Promise).toBe(true);
+            await result;
+        })
+    })
+
+
 });

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -1193,13 +1193,13 @@ describe('ACC Client', function () {
 
         it("from default representation", async () => {
             const client = await Mock.makeClient();
-            var xml = DomUtil.toXMLString(client.fromRepresentation("root", {}));
+            var xml = DomUtil.toXMLString(client._fromRepresentation("root", {}));
             expect(xml).toBe("<root/>");
         })
 
         it("from SimpleJson representation", async () => {
             const client = await Mock.makeClient();
-            var xml = DomUtil.toXMLString(client.fromRepresentation("root", {}, "SimpleJson"));
+            var xml = DomUtil.toXMLString(client._fromRepresentation("root", {}, "SimpleJson"));
             expect(xml).toBe("<root/>");
         })
 
@@ -1208,14 +1208,14 @@ describe('ACC Client', function () {
             it("Should convert from BadgerFish to BadgerFish", async () => {
                 const client = await Mock.makeClient();
                 var from = { "@id": "1", "child": {} };
-                var to = client.convertToRepresentation(from, "BadgerFish", "BadgerFish");
+                var to = client._convertToRepresentation(from, "BadgerFish", "BadgerFish");
                 expect(to).toStrictEqual(from);
             })
 
             it("Should convert from BadgerFish to SimpleJson", async () => {
                 const client = await Mock.makeClient();
                 var from = { "@id": "1", "child": {} };
-                var to = client.convertToRepresentation(from, "BadgerFish", "SimpleJson");
+                var to = client._convertToRepresentation(from, "BadgerFish", "SimpleJson");
                 expect(to).toStrictEqual({ id: "1", child: {} });
             })
 
@@ -1224,20 +1224,20 @@ describe('ACC Client', function () {
 
         it("Compare representations", async () => {
             const client = await Mock.makeClient();
-            expect(() => { client.isSameRepresentation("json", "json") }).toThrow("SDK-000004");
-            expect(() => { client.isSameRepresentation("json", "BadgerFish") }).toThrow("SDK-000004");
-            expect(() => { client.isSameRepresentation("BadgerFish", "json") }).toThrow("SDK-000004");
-            expect(client.isSameRepresentation("SimpleJson", "SimpleJson")).toBeTruthy();
-            expect(client.isSameRepresentation("BadgerFish", "SimpleJson")).toBeFalsy();
-            expect(client.isSameRepresentation("SimpleJson", "BadgerFish")).toBeFalsy();
-            expect(client.isSameRepresentation("xml", "BadgerFish")).toBeFalsy();
-            expect(client.isSameRepresentation("SimpleJson", "xml")).toBeFalsy();
-            expect(() => { client.isSameRepresentation("Xml", "Xml") }).toThrow("SDK-000004");
-            expect(() => { client.isSameRepresentation("xml", "Xml") }).toThrow("SDK-000004");
-            expect(() => { client.isSameRepresentation("Xml", "xml") }).toThrow("SDK-000004");
-            expect(() => { client.isSameRepresentation("", "xml") }).toThrow("SDK-000004");
-            expect(() => { client.isSameRepresentation("xml", "") }).toThrow("SDK-000004");
-            expect(() => { client.isSameRepresentation("xml", null) }).toThrow("SDK-000004");
+            expect(() => { client._isSameRepresentation("json", "json") }).toThrow("SDK-000004");
+            expect(() => { client._isSameRepresentation("json", "BadgerFish") }).toThrow("SDK-000004");
+            expect(() => { client._isSameRepresentation("BadgerFish", "json") }).toThrow("SDK-000004");
+            expect(client._isSameRepresentation("SimpleJson", "SimpleJson")).toBeTruthy();
+            expect(client._isSameRepresentation("BadgerFish", "SimpleJson")).toBeFalsy();
+            expect(client._isSameRepresentation("SimpleJson", "BadgerFish")).toBeFalsy();
+            expect(client._isSameRepresentation("xml", "BadgerFish")).toBeFalsy();
+            expect(client._isSameRepresentation("SimpleJson", "xml")).toBeFalsy();
+            expect(() => { client._isSameRepresentation("Xml", "Xml") }).toThrow("SDK-000004");
+            expect(() => { client._isSameRepresentation("xml", "Xml") }).toThrow("SDK-000004");
+            expect(() => { client._isSameRepresentation("Xml", "xml") }).toThrow("SDK-000004");
+            expect(() => { client._isSameRepresentation("", "xml") }).toThrow("SDK-000004");
+            expect(() => { client._isSameRepresentation("xml", "") }).toThrow("SDK-000004");
+            expect(() => { client._isSameRepresentation("xml", null) }).toThrow("SDK-000004");
         })
     });
 
@@ -1310,7 +1310,7 @@ describe('ACC Client', function () {
 
     it("User agent string", async () => {
         const client = await Mock.makeClient();
-        const ua = client.getUserAgentString();
+        const ua = client._getUserAgentString();
         expect(ua.startsWith("@adobe/acc-js-sdk/")).toBeTruthy();
         expect(ua.endsWith(" ACC Javascript SDK")).toBeTruthy();
     })

--- a/test/mock.js
+++ b/test/mock.js
@@ -21,14 +21,16 @@ governing permissions and limitations under the License.
  async function makeAnonymousClient(options) {
     const connectionParameters = sdk.ConnectionParameters.ofAnonymousUser("http://acc-sdk:8080", options);
     const client = await sdk.init(connectionParameters);
-    client._transport = jest.fn();
+    if (!options || !options.transport) // allow tests to explicitely set the transport
+        client._transport = jest.fn();
     return client;
 }
 
 async function makeClient(options) {
     const connectionParameters = sdk.ConnectionParameters.ofUserAndPassword("http://acc-sdk:8080", "admin", "admin", options);
     const client = await sdk.init(connectionParameters);
-    client._transport = jest.fn();
+    if (!options || !options.transport) // allow tests to explicitely set the transport
+        client._transport = jest.fn();
     return client;
 }
 

--- a/test/soap.test.js
+++ b/test/soap.test.js
@@ -792,5 +792,18 @@ describe("Campaign exception", () => {
         })
     })
 
+    it("CampaignException should hide sensitive information", () => {
+        const call = makeSoapMethodCall(undefined, "xtk:session", "Date", "$session$", "$security$", "My User Agent");
+        call.finalize("http://ffdamkt:8080/nl/jsp/soaprouter.jsp")
+        const ex = makeCampaignException(call, new Error("Failed"));
+        const req = ex.methodCall.request;
+        expect(req.data.indexOf("$session$")).toBe(-1);
+        expect(req.data.indexOf("$security$")).toBe(-1);
+        expect(req.headers.Cookie.indexOf("$session$")).toBe(-1);
+        expect(req.headers.Cookie.indexOf("$security$")).toBe(-1);
+        expect(req.headers["X-Security-Token"].indexOf("$session$")).toBe(-1);
+        expect(req.headers["X-Security-Token"].indexOf("$security$")).toBe(-1);
+    })
+
 });
 

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -84,6 +84,21 @@ describe('Util', function() {
             expect(Util.trim({hello:`<sessiontoken xsi:type="xsd:string"/><login xsi:type="xsd:string">admin</login><password xsi:type="xsd:string">password</password><parameters xsi:type="ns:Element" SOAP-ENV:encodingStyle="http://xml.apache.org/xml-soap/literalxml"/>`})).toStrictEqual({hello:`<sessiontoken xsi:type="xsd:string"/><login xsi:type="xsd:string">admin</login><password xsi:type="xsd:string">***</password><parameters xsi:type="ns:Element" SOAP-ENV:encodingStyle="http://xml.apache.org/xml-soap/literalxml"/>`});
         })
 
+        it("Should hide X-Security-Token properties", () => {
+            expect(Util.trim({"x-security-token": "Hello"})).toMatchObject({"x-security-token": "***"});
+            expect(Util.trim({"X-Security-Token": "Hello"})).toMatchObject({"X-Security-Token": "***"});
+        })
+
+        it("Should remove session tokens from cookies", () => {
+            expect(Util.trim({"Cookie": "__sessiontoken=ABC"})).toMatchObject({"Cookie": "__sessiontoken=***"});
+            expect(Util.trim({"Cookie": "__sessionToken=ABC"})).toMatchObject({"Cookie": "__sessionToken=***"});
+            expect(Util.trim({"Cookie": "__sessiontoken=ABC;"})).toMatchObject({"Cookie": "__sessiontoken=***;"});
+            expect(Util.trim({"Cookie": "__sessiontoken =ABC"})).toMatchObject({"Cookie": "__sessiontoken =***"});
+            expect(Util.trim({"Cookie": "__sessiontoken ABC"})).toMatchObject({"Cookie": "__sessiontoken ABC"});  // no = sign => no token value
+            expect(Util.trim({"Cookie": "a=b; __sessiontoken =ABC"})).toMatchObject({"Cookie": "a=b; __sessiontoken =***"});  
+            expect(Util.trim({"Cookie": "a=b; __sessiontoken =ABC; c=d"})).toMatchObject({"Cookie": "a=b; __sessiontoken =***; c=d"});
+            expect(Util.trim({"Cookie": "a=b; __token =ABC; c=d"})).toMatchObject({"Cookie": "a=b; __token =ABC; c=d"});
+        })
     })
 
 

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -17,7 +17,7 @@ governing permissions and limitations under the License.
  * 
  *********************************************************************************/
 
-const { Util } = require('../src/util.js');
+const { Util, SafeStorage, Cache } = require('../src/util.js');
 
 
 describe('Util', function() {
@@ -84,6 +84,136 @@ describe('Util', function() {
             expect(Util.trim({hello:`<sessiontoken xsi:type="xsd:string"/><login xsi:type="xsd:string">admin</login><password xsi:type="xsd:string">password</password><parameters xsi:type="ns:Element" SOAP-ENV:encodingStyle="http://xml.apache.org/xml-soap/literalxml"/>`})).toStrictEqual({hello:`<sessiontoken xsi:type="xsd:string"/><login xsi:type="xsd:string">admin</login><password xsi:type="xsd:string">***</password><parameters xsi:type="ns:Element" SOAP-ENV:encodingStyle="http://xml.apache.org/xml-soap/literalxml"/>`});
         })
 
+    })
+
+
+    describe("Safe storage", () => {
+      it("Should support undefined delegate", () => {
+          const storage = new SafeStorage();
+          expect(storage.getItem("Hello")).toBeUndefined();
+          storage.setItem("Hello", { text: "World" });
+          expect(storage.getItem("Hello")).toBeUndefined();
+          storage.setItem("Hello", "World");    // value should be JSON but errors are ignored
+          expect(storage.getItem("Hello")).toBeUndefined();
+          storage.removeItem("Hello");
+          expect(storage.getItem("Hello")).toBeUndefined();
+      })  
+
+      it("Should handle map", () => {
+        const map = {};
+        const delegate = {
+            getItem: (key) => map[key],
+            setItem: (key, value) => { map[key] = value },
+            removeItem: (key) => { delete map[key] }
+        };
+        const storage = new SafeStorage(delegate);
+        expect(storage.getItem("Hello")).toBeUndefined();
+        storage.setItem("Hello", { text: "World" });
+        expect(map["Hello"]).toStrictEqual(JSON.stringify({text: "World"}));
+        expect(storage.getItem("Hello")).toStrictEqual({"text": "World"});
+        storage.setItem("Hello", "World");    // value should be JSON but errors are ignored
+        expect(storage.getItem("Hello")).toBeUndefined();
+        storage.setItem("Hello", { text: "World" });
+        storage.removeItem("Hello");
+        expect(storage.getItem("Hello")).toBeUndefined();
+      })
+
+      it("Should handle root key", () => {
+        const map = {};
+        const delegate = {
+            getItem: (key) => map[key],
+            setItem: (key, value) => { map[key] = value },
+            removeItem: (key) => { delete map[key] }
+        };
+        const storage = new SafeStorage(delegate, "root");
+        expect(storage.getItem("Hello")).toBeUndefined();
+        storage.setItem("Hello", { text: "World" });
+        expect(map["root$Hello"]).toStrictEqual(JSON.stringify({text: "World"}));
+        expect(storage.getItem("Hello")).toStrictEqual({"text": "World"});
+        storage.setItem("Hello", "World");    // value should be JSON but errors are ignored
+        expect(map["root$Hello"]).toBeUndefined();
+        expect(storage.getItem("Hello")).toBeUndefined();
+        storage.setItem("Hello", { text: "World" });
+        storage.removeItem("Hello");
+        expect(map["root$Hello"]).toBeUndefined();
+        expect(storage.getItem("Hello")).toBeUndefined();
+      })
+
+      it("Edge cases", () => {
+        expect(new SafeStorage()._storage).toBeUndefined();
+        expect(new SafeStorage()._rootKey).toBe("");
+        expect(new SafeStorage(null)._storage).toBeUndefined();
+        expect(new SafeStorage(null)._rootKey).toBe("");
+        expect(new SafeStorage(null, "")._storage).toBeUndefined();
+        expect(new SafeStorage(null, "")._rootKey).toBe("");
+      })
+
+      it("Should remove invalid items on get", () => {
+        const map = {};
+        const delegate = {
+            getItem: (key) => map[key],
+            setItem: (key, value) => { map[key] = value },
+            removeItem: (key) => { delete map[key] }
+        };
+        const storage = new SafeStorage(delegate, "root");
+        // value is not valid because not a JSON serialized string
+        map["root$Hello"] = "Invalid";
+        expect(storage.getItem("Hello")).toBeUndefined();
+        // Get should have removed invalid value
+        expect(map["root$Hello"]).toBeUndefined()
+      })
+
+      it("Should handle cache last cleared", () => {
+        const map = {};
+        const delegate = {
+            getItem: (key) => map[key],
+            setItem: (key, value) => { map[key] = value },
+            removeItem: (key) => { delete map[key] }
+        };
+        const cache = new Cache(delegate, "root");
+        cache.put("Hello", "World");
+        expect(JSON.parse(map["root$Hello"])).toMatchObject({ value:"World" });
+        expect(cache.get("Hello")).toBe("World");
+        cache.clear();
+        // Clear could not remove the item from the map
+        expect(JSON.parse(map["root$Hello"])).toMatchObject({ value:"World" });
+        // But get from cache will
+        expect(cache.get("Hello")).toBeUndefined();
+      })
+    })
+
+    it("Should preserve last cleared", () => {
+        const map = {};
+        const delegate = {
+            getItem: (key) => map[key],
+            setItem: (key, value) => { map[key] = value },
+            removeItem: (key) => { delete map[key] }
+        };
+        const cache = new Cache(delegate, "root");
+        expect(cache._lastCleared).toBeUndefined();
+        cache.put("Hello", "World");
+        cache.clear();
+        const lastCleared = cache._lastCleared;
+        expect(lastCleared).not.toBeUndefined();
+        expect(cache.get("Hello")).toBeUndefined();
+        expect(map["root$lastCleared"]).toBe(JSON.stringify({timestamp:lastCleared}));
+        // New cache with same delegate storage should preserve lastCleared date
+        const cache2 = new Cache(delegate, "root");
+        expect(cache2._lastCleared).toBe(lastCleared);
+    })
+
+    it("Should cache in memory value which is in local storage", () => {
+        const map = {};
+        const delegate = {
+            getItem: (key) => map[key],
+            setItem: (key, value) => { map[key] = value },
+            removeItem: (key) => { delete map[key] }
+        };
+        const cache = new Cache(delegate, "root");
+        map["root$Hello"] = JSON.stringify({ value: "World", cachedAt:Date.now() + 99999999 });
+        const value = cache.get("Hello");
+        expect(value).toBe("World");
+        expect(cache._cache["Hello"].value).toBe("World");
     })
 
 });


### PR DESCRIPTION
* Fix an issue in the logon() function which was not always returning a promise. Some authentication methods such as SessionToken we returning synchronously. Made it so that logon always returns a promise. This should not be a breaking change as logon does not actually return a value
* Refactor caches (Options cache, Schemas cache, and Methods cache) to use a generic cache class
* Make sure options parameter of ConnectionParameters constructor is not modified
* Added a persistent cache for schemas, methods, and options using the browser localStorage by default
* Make sure X-Security-Token header is hidden as well as session token cookies
* Added jshint configuration and fixed warnings reported by jshint
* Fixed vulnerability in ansi-regex; upgrade jest-junit to version 13 to fix
* Small jsdoc improvements
