### PR TITLE
Run a call back when the session token is expired

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ traceAPICalls|false| Activates tracing of API calls or not
 transport|axios|Overrides the transport layer
 noStorage|false|De-activate using of local storage
 storage|localStorage|Overrides the local storage for caches
+refreshClient|undefined|Async callback to run when the session token is expired
 
 ```js
 const connectionParameters = sdk.ConnectionParameters.ofUserAndPassword(
@@ -217,6 +218,20 @@ await client.logon();
 
 ```js
 await client.logoff();
+```
+
+## refreshClient callback
+The refreshClient is an async callback function with the sdk client as parameter, it is called when the ACC session is expired.
+The callback must refresh te client session and return it. if a SOAP query fails with session expiration error then it will be retried when the callback is defined. 
+
+```js
+const connectionParameters = sdk.ConnectionParameters.ofUserAndPassword(
+                                url, "admin", "admin",
+                                {refreshClient: async (client)=>{
+                                        await client.logon();
+                                        return client;
+                                    }
+                                });
 ```
 
 ## IP Whitelisting

--- a/src/campaign.js
+++ b/src/campaign.js
@@ -37,6 +37,7 @@ const { Util } = require("./util.js");
   static SOAP_UNKNOWN_METHOD(schema, method, details)     { return new CampaignException(undefined, 400, 16384, `SDK-000009 Unknown method '${method}' of schema '${schema}'`, details); }
   static NOT_LOGGED_IN(call, details)                     { return new CampaignException(     call, 400, 16384, `SDK-000010 Cannot call API because client is not logged in`, details); }
   static DECRYPT_ERROR(details)                           { return new CampaignException(undefined, 400, 16384, `SDK-000011 "Cannot decrypt password: password marker is missing`, details); }
+  static SESSION_EXPIRED()                                { return new CampaignException(undefined, 401, 16384, `SDK-000012 "Session has expired or is invalid. Please reconnect.`); }
   
 
   /**
@@ -223,6 +224,9 @@ function makeCampaignException(call, err) {
       faultString = err.data;
       details = undefined;
     }
+    // Session expiration case must return a 401
+    if (err.data && err.data.indexOf(`XSV-350008`) != -1)
+        return CampaignException.SESSION_EXPIRED();
     return new CampaignException(call, err.statusCode, "", faultString, details, err);
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Run a callBack when the session token expire.
const connectionParameters = sdk.ConnectionParameters.ofBearerToken("http://acc-sdk:8080", 
                                                    "$token$", {onSessionExpiration: ()=> console.log("session token expired")});

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Unit tests
Manual tests

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
