### PR TITLE
Fix code scanning alerts. Remove hardcoded secrets

### DIFF
--- a/samples/002 - basics - schemas.js
+++ b/samples/002 - basics - schemas.js
@@ -25,7 +25,7 @@ const utils = require("./utils.js");
     code: async() => {
       return await utils.logon(async (client, NLWS) => {
         const schema = await client.getSchema("xtk:option");
-        console.log(`>> client.getSchema (current representation) => ${JSON.stringify(schema)}`);        
+        console.log(`>> client.getSchema (current representation) : ${JSON.stringify(schema)}`);
       });
     }
   });
@@ -38,7 +38,7 @@ const utils = require("./utils.js");
     code: async() => {
       return await utils.logon(async (client, NLWS) => {
         const schema = await client.getSchema("xtk:option", "xml");
-        console.log(`>> client.getSchema (xml) => ${client.DomUtil.toXMLString(schema)}`);
+        console.log(`>> client.getSchema (xml) : ${client.DomUtil.toXMLString(schema)}`);
       });
     }
   });
@@ -52,7 +52,7 @@ const utils = require("./utils.js");
     code: async() => {
       return await utils.logon(async (client, NLWS) => {
         const schema = await client.getEntityIfMoreRecent("xtk:srcSchema", "nms:rtEvent");
-        console.log(`>> client.getEntityIfMoreRecent => ${JSON.stringify(schema)}`);        
+        console.log(`>> client.getEntityIfMoreRecent : ${JSON.stringify(schema)}`);
       });
     }
   });

--- a/samples/020 - encryption.js
+++ b/samples/020 - encryption.js
@@ -31,11 +31,11 @@ const utils = require("./utils.js");
     code: async() => {
       return await utils.logon(async (client, NLWS) => {
         const password = "Hello, World";
-        console.log(`xtk:session#Encrypt => ${await NLWS.xtkSession.encrypt(password)}`);
-        console.log(`xtk:session#EncryptPassword => ${await NLWS.xtkSession.encryptPassword(password)}`);
-        console.log(`xtk:session#EncryptServerPassword => ${await NLWS.xtkSession.encryptServerPassword(password)}`);
-        console.log(`xtk:session#HashPassword => ${await NLWS.xtkSession.hashPassword(password)}`);
-        console.log(`xtk:session#ReEncryptPassword => ${await NLWS.xtkSession.reEncryptPassword(await NLWS.xtkSession.encryptPassword(password))}`);
+        console.log(`xtk:session#Encrypt : ${await NLWS.xtkSession.encrypt(password)}`);
+        console.log(`xtk:session#EncryptPassword : ${await NLWS.xtkSession.encryptPassword(password)}`);
+        console.log(`xtk:session#EncryptServerPassword : ${await NLWS.xtkSession.encryptServerPassword(password)}`);
+        console.log(`xtk:session#HashPassword : ${await NLWS.xtkSession.hashPassword(password)}`);
+        console.log(`xtk:session#ReEncryptPassword : ${await NLWS.xtkSession.reEncryptPassword(await NLWS.xtkSession.encryptPassword(password))}`);
       });
     }
   });

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -22,6 +22,7 @@ const { Client, ConnectionParameters } = require('../src/client.js');
 const DomUtil = require('../src/domUtil.js').DomUtil;
 const Mock = require('./mock.js').Mock;
 const { HttpError } = require('../src/transport.js');
+const { Cipher } = require('../src/crypto.js');
 
 
 describe('ACC Client', function () {
@@ -604,11 +605,13 @@ describe('ACC Client', function () {
             const client = await Mock.makeClient();
             client._transport.mockReturnValueOnce(Mock.LOGON_RESPONSE);
             await client.NLWS.xtkSession.logon();
+            const key = Mock.makeKey();
+            const encrypted = new Cipher(key).encryptPassword("mid");
 
             client._transport.mockReturnValueOnce(Mock.GET_XTK_QUERY_SCHEMA_RESPONSE);
-            client._transport.mockReturnValueOnce(Mock.GET_MID_EXT_ACCOUNT_RESPONSE);
+            client._transport.mockReturnValueOnce(Mock.GET_MID_EXT_ACCOUNT_RESPONSE(encrypted));
             client._transport.mockReturnValueOnce(Mock.GET_XTK_SESSION_SCHEMA_RESPONSE);
-            client._transport.mockReturnValueOnce(Mock.GET_SECRET_KEY_OPTION_RESPONSE);
+            client._transport.mockReturnValueOnce(Mock.GET_SECRET_KEY_OPTION_RESPONSE(key));
             var connectionParameters = await sdk.ConnectionParameters.ofExternalAccount(client, "defaultEmailMid");
             var midClient = await sdk.init(connectionParameters);
             midClient._transport = jest.fn();
@@ -630,11 +633,13 @@ describe('ACC Client', function () {
             const client = await Mock.makeClient();
             client._transport.mockReturnValueOnce(Mock.LOGON_RESPONSE);
             await client.NLWS.xtkSession.logon();
+            const key = Mock.makeKey();
+            const encrypted = new Cipher(key).encryptPassword("mid");
 
             client._transport.mockReturnValueOnce(Mock.GET_XTK_QUERY_SCHEMA_RESPONSE);
-            client._transport.mockReturnValueOnce(Mock.GET_BAD_EXT_ACCOUNT_RESPONSE);
+            client._transport.mockReturnValueOnce(Mock.GET_BAD_EXT_ACCOUNT_RESPONSE(encrypted));
             client._transport.mockReturnValueOnce(Mock.GET_XTK_SESSION_SCHEMA_RESPONSE);
-            client._transport.mockReturnValueOnce(Mock.GET_SECRET_KEY_OPTION_RESPONSE);
+            client._transport.mockReturnValueOnce(Mock.GET_SECRET_KEY_OPTION_RESPONSE(key));
             await expect(async () => {
                 return sdk.ConnectionParameters.ofExternalAccount(client, "bad");
             }).rejects.toMatchObject({ errorCode: "SDK-000005" });
@@ -642,14 +647,16 @@ describe('ACC Client', function () {
 
         it("Should fail if invalid representation", async () => {
             const client = await Mock.makeClient();
+            const key = Mock.makeKey();
+            const encrypted = new Cipher(key).encryptPassword("mid");
 
             client._transport.mockReturnValueOnce(Mock.LOGON_RESPONSE);
             await client.NLWS.xtkSession.logon();
 
             client._transport.mockReturnValueOnce(Mock.GET_XTK_QUERY_SCHEMA_RESPONSE);
-            client._transport.mockReturnValueOnce(Mock.GET_MID_EXT_ACCOUNT_RESPONSE);
+            client._transport.mockReturnValueOnce(Mock.GET_MID_EXT_ACCOUNT_RESPONSE(encrypted));
             client._transport.mockReturnValueOnce(Mock.GET_XTK_SESSION_SCHEMA_RESPONSE);
-            client._transport.mockReturnValueOnce(Mock.GET_SECRET_KEY_OPTION_RESPONSE);
+            client._transport.mockReturnValueOnce(Mock.GET_SECRET_KEY_OPTION_RESPONSE(key));
 
             await expect(async () => {
                 client._representation = "Dummy";
@@ -663,14 +670,16 @@ describe('ACC Client', function () {
         it("Should fail not fail with SimpleJson representation", async () => {
             const client = await Mock.makeClient();
             client._representation = "SimpleJson";
+            const key = Mock.makeKey();
+            const encrypted = new Cipher(key).encryptPassword("mid");
 
             client._transport.mockReturnValueOnce(Mock.LOGON_RESPONSE);
             await client.NLWS.xtkSession.logon();
 
             client._transport.mockReturnValueOnce(Mock.GET_XTK_QUERY_SCHEMA_RESPONSE);
-            client._transport.mockReturnValueOnce(Mock.GET_MID_EXT_ACCOUNT_RESPONSE);
+            client._transport.mockReturnValueOnce(Mock.GET_MID_EXT_ACCOUNT_RESPONSE(encrypted));
             client._transport.mockReturnValueOnce(Mock.GET_XTK_SESSION_SCHEMA_RESPONSE);
-            client._transport.mockReturnValueOnce(Mock.GET_SECRET_KEY_OPTION_RESPONSE);
+            client._transport.mockReturnValueOnce(Mock.GET_SECRET_KEY_OPTION_RESPONSE(key));
 
             var connectionParameters = await sdk.ConnectionParameters.ofExternalAccount(client, "defaultEmailMid");
             await sdk.init(connectionParameters);
@@ -680,9 +689,10 @@ describe('ACC Client', function () {
             const client = await Mock.makeClient();
             client._transport.mockReturnValueOnce(Mock.LOGON_RESPONSE);
             await client.NLWS.xtkSession.logon();
-
+            const key = Mock.makeKey();
+            
             client._transport.mockReturnValueOnce(Mock.GET_XTK_SESSION_SCHEMA_RESPONSE);
-            client._transport.mockReturnValueOnce(Mock.GET_SECRET_KEY_OPTION_RESPONSE);
+            client._transport.mockReturnValueOnce(Mock.GET_SECRET_KEY_OPTION_RESPONSE(key));
             var cipher = await client._getSecretKeyCipher();
             expect(cipher).not.toBeNull();
             expect(cipher.key).not.toBeNull();

--- a/test/crypto.test.js
+++ b/test/crypto.test.js
@@ -19,61 +19,65 @@ governing permissions and limitations under the License.
 
 const assert = require('assert');
 const crypto = require('../src/crypto.js');
+const { Mock } = require('./mock.js');
 const Cipher = crypto.Cipher;
 
 describe('crypto', function() {
     
     it("Should decrypt password", function() {
-        const cipher = new Cipher("HMLmn6uvWr8wu1Akt8UORr07YbC64u1FVW7ENAxNjpo=");
-        var decrypted = cipher.decryptPassword("@57QS5VHMb9BCsojLVrKI/Q==");
+        const cipher = new Cipher(Mock.makeKey());
+        const encrypted = cipher.encryptPassword("mid");
+        var decrypted = cipher.decryptPassword(encrypted);
         assert.equal(decrypted, "mid");
     });
 
     it("Should fail on invalid encrypted string", function() {
-        const cipher = new Cipher("HMLmn6uvWr8wu1Akt8UORr07YbC64u1FVW7ENAxNjpo=");
+        const cipher = new Cipher(Mock.makeKey());
         assert.throws(function() {
             cipher.decryptPassword("Hello");
         });
     });
 
     it("Should decrypt password twice", function() {
-        const cipher = new Cipher("HMLmn6uvWr8wu1Akt8UORr07YbC64u1FVW7ENAxNjpo=");
-        var decrypted = cipher.decryptPassword("@57QS5VHMb9BCsojLVrKI/Q==");
+        const cipher = new Cipher(Mock.makeKey());
+        const encrypted = cipher.encryptPassword("mid");
+        var decrypted = cipher.decryptPassword(encrypted);
         assert.equal(decrypted, "mid");
-         decrypted = cipher.decryptPassword("@57QS5VHMb9BCsojLVrKI/Q==");
+         decrypted = cipher.decryptPassword(encrypted);
         assert.equal(decrypted, "mid");
     });
 
     it("Should decrypt password after failure", function() {
-        const cipher = new Cipher("HMLmn6uvWr8wu1Akt8UORr07YbC64u1FVW7ENAxNjpo=");
+        const cipher = new Cipher(Mock.makeKey());
         assert.throws(function() {
             cipher.decryptPassword("@Hello");
         });
         // make sure state is valid after failure
-        var decrypted = cipher.decryptPassword("@57QS5VHMb9BCsojLVrKI/Q==");
+        const encrypted = cipher.encryptPassword("mid");
+        var decrypted = cipher.decryptPassword(encrypted);
         assert.equal(decrypted, "mid");
     });
 
     it("Should handle plain text passwords", function() {
-        const cipher = new Cipher("llL97E5mAvLTxgT1fsAH2kjLqZXKCGHfDyR9q0C6Ivs=");
+        const cipher = new Cipher(Mock.makeKey());
         var decrypted = cipher.decryptPassword("__PLAINTEXT__pass");
         assert.equal(decrypted, "pass");
     });
 
     it("Should fail if no marker", function() {
-        const cipher = new Cipher("HMLmn6uvWr8wu1Akt8UORr07YbC64u1FVW7ENAxNjpo=");
+        const cipher = new Cipher(Mock.makeKey());
         expect(() => { cipher.decryptPassword("57QS5VHMb9BCsojLVrKI/Q=="); }).toThrow("SDK-000011");
     });
 
     it("Should support empty passwords", function() {
-        const cipher = new Cipher("HMLmn6uvWr8wu1Akt8UORr07YbC64u1FVW7ENAxNjpo=");
+        const cipher = new Cipher(Mock.makeKey());
         assert.equal(cipher.decryptPassword(""), "");
         assert.equal(cipher.decryptPassword(null), "");
         assert.equal(cipher.decryptPassword(undefined), "");
     });
 
     it("Encrypt - decrypt", function() {
-        const cipher = new Cipher("HMLmn6uvWr8wu1Akt8UORr07YbC64u1FVW7ENAxNjpo=");
+        const cipher = new Cipher(Mock.makeKey());
         expect(cipher.decryptPassword(cipher.encryptPassword(""))).toBe("");
         expect(cipher.decryptPassword(cipher.encryptPassword("1"))).toBe("1");
         expect(cipher.decryptPassword(cipher.encryptPassword("Hello"))).toBe("Hello");

--- a/test/mock.js
+++ b/test/mock.js
@@ -17,10 +17,13 @@ governing permissions and limitations under the License.
  * 
  *********************************************************************************/
  const sdk = require('../src/index.js');
+ const crypto = require("crypto");
 
  const makeKey = () => {
     const a = [];
-    for (let i=0; i<32; i++) { a.push(Math.floor(256*Math.random())); }
+    for (let i=0; i<32; i++) {
+        a.push(Math.floor(crypto.randomInt(0, 256))); 
+    }
     const buffer = Buffer.from(a);
     const s = buffer.toString('base64');
     return s;

--- a/test/mock.js
+++ b/test/mock.js
@@ -18,6 +18,14 @@ governing permissions and limitations under the License.
  *********************************************************************************/
  const sdk = require('../src/index.js');
 
+ const makeKey = () => {
+    const a = [];
+    for (let i=0; i<32; i++) { a.push(Math.floor(256*Math.random())); }
+    const buffer = Buffer.from(a);
+    const s = buffer.toString('base64');
+    return s;
+ }
+
  async function makeAnonymousClient(options) {
     const connectionParameters = sdk.ConnectionParameters.ofAnonymousUser("http://acc-sdk:8080", options);
     const client = await sdk.init(connectionParameters);
@@ -280,37 +288,43 @@ const GET_XTK_QUERY_SCHEMA_RESPONSE = Promise.resolve(`<?xml version='1.0'?>
     </SOAP-ENV:Body>
     </SOAP-ENV:Envelope>`);
 
-const GET_MID_EXT_ACCOUNT_RESPONSE = Promise.resolve(`<?xml version='1.0'?>
+const GET_MID_EXT_ACCOUNT_RESPONSE = (encryptedPassword) => {
+    return  Promise.resolve(`<?xml version='1.0'?>
     <SOAP-ENV:Envelope xmlns:xsd='http://www.w3.org/2001/XMLSchema' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xmlns:ns='urn:xtk:queryDef' xmlns:SOAP-ENV='http://schemas.xmlsoap.org/soap/envelope/'>
     <SOAP-ENV:Body>
         <ExecuteQueryResponse xmlns='urn:xtk:queryDef' SOAP-ENV:encodingStyle='http://schemas.xmlsoap.org/soap/encoding/'>
             <pdomOutput xsi:type='ns:Element' SOAP-ENV:encodingStyle='http://xml.apache.org/xml-soap/literalxml'>
-                <extAccount account="mid" id="2088" name="defaultEmailMid" password="@57QS5VHMb9BCsojLVrKI/Q==" server="http://ffdamid:8080" type="3"/>
+                <extAccount account="mid" id="2088" name="defaultEmailMid" password="${encryptedPassword}" server="http://ffdamid:8080" type="3"/>
             </pdomOutput>
         </ExecuteQueryResponse>
     </SOAP-ENV:Body>
     </SOAP-ENV:Envelope>`);
+}
 
-const GET_BAD_EXT_ACCOUNT_RESPONSE = Promise.resolve(`<?xml version='1.0'?>
+const GET_BAD_EXT_ACCOUNT_RESPONSE = (encryptedPassword) => {
+    return Promise.resolve(`<?xml version='1.0'?>
     <SOAP-ENV:Envelope xmlns:xsd='http://www.w3.org/2001/XMLSchema' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xmlns:ns='urn:xtk:queryDef' xmlns:SOAP-ENV='http://schemas.xmlsoap.org/soap/envelope/'>
     <SOAP-ENV:Body>
         <ExecuteQueryResponse xmlns='urn:xtk:queryDef' SOAP-ENV:encodingStyle='http://schemas.xmlsoap.org/soap/encoding/'>
             <pdomOutput xsi:type='ns:Element' SOAP-ENV:encodingStyle='http://xml.apache.org/xml-soap/literalxml'>
-                <extAccount account="bad" id="2088" name="bad" password="@57QS5VHMb9BCsojLVrKI/Q==" server="http://zz:8080" type="999"/>
+                <extAccount account="bad" id="2088" name="bad" password="${encryptedPassword}" server="http://zz:8080" type="999"/>
             </pdomOutput>
         </ExecuteQueryResponse>
     </SOAP-ENV:Body>
     </SOAP-ENV:Envelope>`);
+}
 
-const GET_SECRET_KEY_OPTION_RESPONSE = Promise.resolve(`<?xml version='1.0'?>
+const GET_SECRET_KEY_OPTION_RESPONSE = (key) => {
+    return Promise.resolve(`<?xml version='1.0'?>
     <SOAP-ENV:Envelope xmlns:xsd='http://www.w3.org/2001/XMLSchema' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xmlns:ns='urn:xtk:session' xmlns:SOAP-ENV='http://schemas.xmlsoap.org/soap/envelope/'>
     <SOAP-ENV:Body>
         <GetOptionResponse xmlns='urn:xtk:session' SOAP-ENV:encodingStyle='http://schemas.xmlsoap.org/soap/encoding/'>
-            <pstrValue xsi:type='xsd:string'>HMLmn6uvWr8wu1Akt8UORr07YbC64u1FVW7ENAxNjpo=</pstrValue>
+            <pstrValue xsi:type='xsd:string'>${key}</pstrValue>
             <pbtType xsi:type='xsd:byte'>6</pbtType>
         </GetOptionResponse>
     </SOAP-ENV:Body>
     </SOAP-ENV:Envelope>`);
+}
 
 const GET_LOGON_MID_RESPONSE = Promise.resolve(`<?xml version='1.0'?>
     <SOAP-ENV:Envelope xmlns:xsd='http://www.w3.org/2001/XMLSchema' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xmlns:ns='urn:xtk:session' xmlns:SOAP-ENV='http://schemas.xmlsoap.org/soap/envelope/'>
@@ -594,6 +608,7 @@ exports.Mock = {
   makeClient: makeClient,
   makeAnonymousClient: makeAnonymousClient,
   withMockConsole: withMockConsole,
+  makeKey: makeKey,
   R_TEST: R_TEST,
   PING: PING,
   MC_PING: MC_PING,


### PR DESCRIPTION
## Description

After enabling codeQL scanning, a few alerts were reported.

* Hardcoded secrets in the test. This was not really an issue as the hardcoded secret is only for tests. This was changed to generate a secret for each test
* Improper code sanitization. Another false alert where the code scanner was thinking we were using string concatenation to generate HTML. In fact, it was not HTML, but a log string with looks like ">> ..... => ${...}`. I suppose the presence of the => is where the scanner was led into thiking we're generating HTML. So changed it to ":"


