### PR TITLE
Release 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ This is a node.js SDK for Campaign API. It exposes the Campaign API exactly like
 # Changelog 
 
 ## Version 1.1.0
-_2022/03/02_
+_2022/03/05_
 
-Chnages in the metadata api (`application.getSchema`) which was not completely implemented. While this API is meant to be largely compatible with the [ACC JS API](https://docs.adobe.com/content/help/en/campaign-classic/technicalresources/api/c-Application.html), it's not always possible to do so because of the asynchronous nature of the SDK. The JS API is executed inside the Campaign application server can will synchronously and transparently fetch schemas as needed. Howerer the SDK runs outside of the Campaign server. It will synchronously and transparently fetch schemas as needed, but this will be done adynchronously. 
+Changes in the metadata api (`application.getSchema`) which was not completely implemented. While this API is meant to be largely compatible with the [ACC JS API](https://docs.adobe.com/content/help/en/campaign-classic/technicalresources/api/c-Application.html), it's not always possible to do so because of the asynchronous nature of the SDK. The JS API is executed inside the Campaign application server can will synchronously and transparently fetch schemas as needed. Howerer the SDK runs outside of the Campaign server. It will synchronously and transparently fetch schemas as needed, but this will be done adynchronously. 
 
 Differences are document in the `Application` section of the README.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ This is a node.js SDK for Campaign API. It exposes the Campaign API exactly like
 
 # Changelog 
 
+## Version 1.1.0
+_2022/03/02_
+
+Chnages in the metadata api (`application.getSchema`) which was not completely implemented. While this API is meant to be largely compatible with the [ACC JS API](https://docs.adobe.com/content/help/en/campaign-classic/technicalresources/api/c-Application.html), it's not always possible to do so because of the asynchronous nature of the SDK. The JS API is executed inside the Campaign application server can will synchronously and transparently fetch schemas as needed. Howerer the SDK runs outside of the Campaign server. It will synchronously and transparently fetch schemas as needed, but this will be done adynchronously. 
+
+Differences are document in the `Application` section of the README.
+
+* Provide array and map access to XtkSchemaKey.fields, 
+* The order of children of a node has been changed. Beore 1.1.0, it was attributes, then elements. After 1.1.0, it's the order defined in the schema XML
+* New application.getEnumeration function to retreive an enumeration
+* Removed the XtkSchemaNode.hasChild function
+* Support for ref nodes and links: XtkSchemaNode.refTarget(), XtkSchemaNode.linkTarget() functions
+* Reviews XtkSchemaNode.findNode() function to support links, refs, ANY type, etc. and is now asynchronous
+* The name attribute of enumerations (`XtkEnumeration.name`) is now the fully qualified name of the enumeration, i.e. is prefixed by the schema id
+
 ## Version 1.0.9
 _2022/03/02_
 
@@ -24,6 +39,8 @@ _2022/03/02_
   * Changed the toString function to use 4 spaces instead of 3 for indentation and display node label and internal name
   * When label or description is missing from schema nodes or from enumerations, they default to the name value
   * application.getSchema now uses a in-memory cache
+
+For breaking changes see the [migration guide](MIGRATION.md)
 
 
 ## Version 1.0.7

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,160 @@
+# Migration guide
+
+# Version 1.1.0
+
+In version 1.1.0, changes were made in the metadata API. The SDK lets you access schema as JSON objects (method `client.getSchema`) or provides an object model around schemas with typed objects, as in https://experienceleague.adobe.com/developer/campaign-api/api/c-Schema.html, which can be accessed with `application.getSchema`.
+
+
+The following potentially breaking changes were introduced
+
+* Schemas retreived by `application.getSchema` are cached in memory
+* Attributes without an explicit type will be reported as `string` type instead of empty type
+* The `userDescription` property removed from `XtkSchemaNode` and only available on `XtkSchema`
+* The `children` of a `XtkSchemaNode` are now reported in the same order as they appear in the schema
+* Implicit values are propagated for `XtkSchemaNode` and enumeration. It means that empty labels and desciptions not have a non empty value infered from the name attribute
+* The `XtkSchemaNode.hasChild` function has been removed
+* Enumerations of a schema, values of an enumeration, children of a schema node, keys of a schema, and fields of a key are now returned as a `ArrayMap` type instead of a key/value. This change allows to access elements as either an array or a dictionary, or map, filter, iterate through elements.
+* The string representation of schema nodes : `XtkSchema.toString` and `XtkSchemaNode.toString` has changed
+* The `XtkSchemaNode.findNode` method is now asynchronous and its signature has changed
+* The name attribute of enumerations is now always the fully qualified name (ex: `nms:recipient:gender` instead of `gender`). The non qualified name is still available with the `shortName` property.
+
+## In-memory cache
+Schema objects have their own in-memory cache, in addition to the SDK cache
+
+## Attribute type
+Attributes with no type are now reported as `string`.
+
+Before
+```js
+// Deprecated syntax
+if (!attribute.type || attribute.type === "string") ...
+```
+
+After
+```js
+if (attribute.type === "string") ...
+```
+
+or better, use `XtkCaster.isStringType` which will handle all variant of string types, such as `memo`, `html`, etc.
+```js
+if (XtkCaster.isStringType(attribute.type)) ...
+```
+
+## userDescription property
+The `userDescription` property was set on the `XtkSchemaNode` object and has been moved to the `XtkSchema` object
+
+## Order of children
+The order of children of a node has been changed. Beore 1.1.0, it was attributes, then elements. After 1.1.0, it's the order defined in the schema XML
+
+## Propagate implicit values
+Automatically set schema nodes label and description properties if they are not set.
+* Schema node. If a node does not have a label, the SDK will generate a label from the name (with first letter in upper case) instead of returning an empty string. Similarly, the node description property will be set from the label.
+* enumeration label will be set with the same rules
+
+## Removed hasChild function
+The function `XtkSchemaNode.hasChild` has been removed.
+
+Before
+```js
+// Deprecated syntax (will fail at runtime)
+if (node.hasChild("@email")) { ... }
+```
+
+After
+```js
+if (!node.children.get("@email")) { ... }
+```
+
+## ArrayMaps
+Collection of child elements which were accessed as maps are now accessed with a special `ArrayMap` object which allows to access them either as maps of arrays and include convenience functions for iteration
+* fields of a key (`XtkSchemaKey.fields`)
+* chldren of a node (`XtkSchemaNode.children`)
+* keys of a node (`XtkSchemaNode.keys`)
+* values of an enumeration (`XtkEnumeration.values`)
+* enumerations of a schema (`XtkSchema.enumerations`)
+
+As a consequence, it's deprecated to access the properties above by name. It still works in most of the cases, but will fail for object whose name collides with JavaScript function names. For exampl, for an element named 'forEach'.
+
+Instead, use one of the following constructs.
+
+To iterate over a collection, use `map`, `forEach`, or a `for ... of` loop. Do not use the for ... in loop.
+
+Before
+```js
+// Not supported anymore. Will only work in some cases
+for (key in node.children) { const child = node.children[key]; ... }
+```
+
+After
+```js
+node.children.forEach(child => ...);
+node.children.map(child => ...);
+for (child of node.children) { ... }
+for (let i=0 i<node.children.lenght; i++) { const child = node.children[i]; ... }
+```
+
+Collection items can be accessed by name or index with the `get` function, or with an array index.
+
+Before
+```js
+// Not supported anymore. Will only work in some cases
+const child = node.children["@email"];
+```
+
+After
+
+```js
+const child = node.children[3];
+const child = node.children.get(3);
+const child = node.children.get("@email");
+```
+
+
+## Schema and SchemaNode toString
+The `toString` function has been changed to better display a node structure. In general, this function is mostly for debugging purpose, and you should not rely on the exact output.
+
+## XtkSchemaNode.findNode
+The `findNode` function has been modified in multiple ways.
+
+* The function is now **asynchronous** and returns a Promise. The reason is that in order to support all the use cases supported in Campaign JS API, findNode needs to follow references and links, and therefore may have to dynamically load schemas.
+
+* The function now supports `ref` nodes. Ref nodes are schema nodes having a `ref` property which is a reference to another node, possibly in a different schema. 
+    * If the xpath passed to the function ends with a ref node, the ref node itself will be returned. We're not following the reference. You can use the `refTarget` method to explicitely follow the reference
+    * If the xpath traverse intermediate nodes which are ref nodes, the `findNode` method will follow the reference. For instance, the start activity in a workflow is a reference. Finding the xpath "start/@img" will follow the start reference and find the @img attribute from there
+
+* Support of type `ANY`. The type `ANY` in Campaign is used to describe a node which can contain arbitrary child nodes, without any strongly defined structure. The `findNode` function will only be able to return direct children of a node of `ANY` type.
+
+* Support for links. If the xpath parameter contains links, `findNode` will follow the link target with the same rules as for reference nodes. To get the target of a link, use the `linkTarget` method instead of `refTarget`.
+
+* The `findNode` function now takes only one parameter: the xpath to search for. The `strict` and `mustExist` parameters were removed. The function is now always in strict mode, i.e. will not try to guess if you're searching for an element or attribute. The function will only throw if the schema it's working on are malformed. For instance, if the target property of a link is not a syntaxically correct schema id. If however, the node you're looking for does not exist, or if an intermediate node or schema does not exist, findNode will simply return null or undefined, and will not throw. The `mustExist` param may be reintroduced in the future for better error reporting.
+
+
+Basic usage of `findNode`
+
+
+Before
+```js
+// Deprecated, will not work anymore
+try {
+  const email = schema.root.findNode("@email");
+} catch(error) {
+  // maybe @email does not exist, or maybe the schema is invalid
+}
+```
+
+After
+```js
+try {
+  const email = await schema.root.findNode("@email");
+  if (!email) {
+    // @email does not exist
+  }
+} catch(error) {
+  // schema is invalid
+}
+```
+
+
+## Enumeration name
+
+* The name attribute of enumerations (`XtkEnumeration.name`) is now the fully qualified name of the enumeration, i.e. is prefixed by the schema id

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adobe/acc-js-sdk",
-  "version": "1.0.8",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@adobe/acc-js-sdk",
-      "version": "1.0.8",
+      "version": "1.1.0",
       "license": "ISC",
       "dependencies": {
         "axios": "^0.25.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/acc-js-sdk",
-  "version": "1.0.9",
+  "version": "1.1.0",
   "description": "ACC Javascript SDK",
   "main": "src/index.js",
   "homepage": "https://github.com/adobe/acc-js-sdk#readme",

--- a/src/application.js
+++ b/src/application.js
@@ -99,12 +99,47 @@ class SchemaCache {
 class XtkSchemaKey {
 
     constructor(schema, xml, schemaNode) {
+
+        /**
+         * The schema this key belongs to
+         * @type {Campaign.XtkSchema}
+         */
         this.schema = schema;
+
+        /**
+         * The name of the key
+         * @type {string}
+         */
         this.name = EntityAccessor.getAttributeAsString(xml, "name");
+
+        /**
+         * A human friendly name for they key
+         * @type {string}
+         */
         this.label = EntityAccessor.getAttributeAsString(xml, "label");
+
+         /**
+         * A longer, human friendly description for they key
+         * @type {string}
+         */
         this.description = EntityAccessor.getAttributeAsString(xml, "desc");
+
+        /**
+         * Indicates if the key is internal or not
+         * @type {boolean}
+         */
         this.isInternal = EntityAccessor.getAttributeAsBoolean(xml, "internal");
+
+        /**
+         * Indicates if the fields (parts) of a composite key may be empty (null). At least one part must always be populated
+         * @type {boolean}
+         */
         this.allowEmptyPart = EntityAccessor.getAttributeAsString(xml, "allowEmptyPart");
+
+        /**
+         * The fields making up the key
+         * @type {Utils.ArrayMap<Campaign.XtkSchemaNode>}
+         */
         this.fields = new ArrayMap();
 
         for (var child of EntityAccessor.getChildElements(xml, "keyfield")) {
@@ -121,7 +156,6 @@ class XtkSchemaKey {
             this.fields._push(xpathString, keyNode);
         }
     }
-
 }
 
 /**
@@ -136,10 +170,21 @@ class XtkSchemaKey {
  class XtkJoin {
 
     constructor(xml) {
+
+        /**
+         * The xpath of the join condition on the source table
+         * @type {string}
+         */
         this.src = EntityAccessor.getAttributeAsString(xml, "xpath-src");
-        this.dst = EntityAccessor.getAttributeAsString(xml, "xpath-dst");
+
+        /**
+         * The xpath of the join condition on the destination table
+         * @type {string}
+         */
+         this.dst = EntityAccessor.getAttributeAsString(xml, "xpath-dst");
     }
 }
+
 // ========================================================================================
 // Schema nodes
 // ========================================================================================
@@ -228,7 +273,12 @@ class XtkSchemaNode {
          * @type {string}
          */
         this.img = EntityAccessor.getAttributeAsString(xml, "img");
-        this.image = this.img;
+
+        /**
+         * An optional image for the node (alias to the img property)
+         * @type {string}
+         */
+         this.image = this.img;
 
         /**
          * Returns the name of the image of the current node in the form of a string of characters.
@@ -237,42 +287,47 @@ class XtkSchemaNode {
          this.enumerationImage = EntityAccessor.getAttributeAsString(xml, "enumImage");
 
         /**
-         * The node type
+         * The node type. Attribute nodes without an explicitedly defined type will be reported as "string"
          * @type {string}
          */
         this.type = EntityAccessor.getAttributeAsString(xml, "type");
         if (!this.type && isAttribute) this.type = "string";
 
         /**
-         * The node target
+         * For link type nodes, the target of the link
          * @type {string}
          */
         this.target = EntityAccessor.getAttributeAsString(xml, "target");
 
-         /**
+        /**
          * The node integrity
          * @type {string}
          */
         this.integrity = EntityAccessor.getAttributeAsString(xml, "integrity");
 
-         /**
+        /**
          * The node data length (applicable for string-types only)
          * @type {number}
          */
         this.length = EntityAccessor.getAttributeAsLong(xml, "length");
+
+        /**
+         * The node data length (applicable for string-types only)
+         * @type {number}
+         */
         this.size = this.length;
 
         /**
          * The enum of the node
          * @type {string}
          */
-         this.enum = EntityAccessor.getAttributeAsString(xml, "enum");
+        this.enum = EntityAccessor.getAttributeAsString(xml, "enum");
 
         /**
          * Returns a string of characters which is the name of the user enumeration used by the current node.
          * @type {string}
          */
-         this.userEnumeration = EntityAccessor.getAttributeAsString(xml, "userEnum");
+        this.userEnumeration = EntityAccessor.getAttributeAsString(xml, "userEnum");
 
         /**
          * Returns a boolean which indicates whether the value of the current node is linked to a user enumeration.
@@ -291,6 +346,11 @@ class XtkSchemaNode {
          * @type {boolean}
          */
         this.unbound = EntityAccessor.getAttributeAsBoolean(xml, "unbound");
+
+        /**
+         * Has an unlimited number of children of the same type
+         * @type {boolean}
+         */
         this.isCollection = this.unbound;
 
         /**
@@ -308,9 +368,9 @@ class XtkSchemaNode {
         /**
          * Children of the node. This is a object whose key are the names of the children nodes (without the "@"
          * character for attributes) 
-         * @type {Object.<string, Campaign.XtkSchemaNode>}
+         * @type {Utils.ArrayMap.<Campaign.XtkSchemaNode>}
          */
-         this.children = new ArrayMap();
+        this.children = new ArrayMap();
 
         /**
          * Count the children of a node
@@ -326,9 +386,9 @@ class XtkSchemaNode {
 
         /**
          * Schema root elements may have a list of keys. This is a dictionary whose names are the key names and values the keys
-         * @type {Object<string, XtkSchemaKey>}
+         * @type {ArrayNode<Campaign.XtkSchemaKey>}
          */
-         this.keys = new ArrayMap();
+        this.keys = new ArrayMap();
 
         /**
          * The full path of the node
@@ -349,25 +409,25 @@ class XtkSchemaNode {
          * Returns a boolean which indicates whether the current node is ordinary.
          * @type {boolean}
          */
-         this.isAnyType = this.type === "ANY";
+        this.isAnyType = this.type === "ANY";
 
         /**
          * Returns a boolean which indicates whether the node is a link.
          * @type {boolean}
          */
-         this.isLink = this.type === "link";
+        this.isLink = this.type === "link";
 
         /**
          * Returns a boolean which indicates whether the value of the current node is linked to an enumeration.
          * @type {boolean}
          */
-         this.hasEnumeration = this.enum !== "";
+        this.hasEnumeration = this.enum !== "";
 
         /**
          * Returns a boolean which indicates whether the current node is linked to an SQL table.
          * @type {boolean}
          */
-         this.hasSQLTable = this.sqlTable !== '';
+        this.hasSQLTable = this.sqlTable !== '';
 
          /**
           * The SQL name of the field. The property is an empty string if the object isn't an SQL type field.
@@ -385,7 +445,7 @@ class XtkSchemaNode {
          * Returns a boolean indicating whether the table is a temporary table. The table will not be created during database creation.
          * @type {boolean}
          */
-         this.isTemporaryTable = EntityAccessor.getAttributeAsBoolean(xml, "temporaryTable");
+        this.isTemporaryTable = EntityAccessor.getAttributeAsBoolean(xml, "temporaryTable");
 
         /**
          * Returns a boolean which indicates whether the current node is a logical sub-division of the schema.
@@ -404,39 +464,39 @@ class XtkSchemaNode {
          * True if the node is a link and if the join is external.
          * @type {boolean}
          */
-         this.isExternalJoin = EntityAccessor.getAttributeAsBoolean(xml, "externalJoin");
+        this.isExternalJoin = EntityAccessor.getAttributeAsBoolean(xml, "externalJoin");
 
         /**
          * Returns a boolean which indicates whether the current node is mapped by a Memo.
          * @type {boolean}
          */
-         this.isMemo = this.type === "memo" || this.type === "CDATA";
+        this.isMemo = this.type === "memo" || this.type === "CDATA";
 
         /**
          * Returns a boolean which indicates whether the current node is mapped by a MemoData.
          * @type {boolean}
          */
-         this.isMemoData = this.isMemo && this.name === 'data';
+        this.isMemoData = this.isMemo && this.name === 'data';
 
         /**
          * Returns a boolean which indicates whether the current node is a BLOB.
          * @type {boolean}
          */
-         this.isBlob = this.type === "blob";
+        this.isBlob = this.type === "blob";
 
         /**
          * Returns a boolean which indicates whether the current node is mapped from CDATA type XML.
          * @type {boolean}
          */
-         this.isCDATA = this.type === "CDATA";
+        this.isCDATA = this.type === "CDATA";
 
+        const notNull = EntityAccessor.getAttributeAsString(xml, "notNull");
+        const sqlDefault = EntityAccessor.getAttributeAsString(xml, "sqlDefault");
+        const notNullOverriden = notNull || sqlDefault === "NULL";
         /**
          * Returns a boolean which indicates whether or not the current node can take the null value into account.
          * @type {boolean}
          */
-        const notNull = EntityAccessor.getAttributeAsString(xml, "notNull");
-        const sqlDefault = EntityAccessor.getAttributeAsString(xml, "sqlDefault");
-        const notNullOverriden = notNull || sqlDefault === "NULL"
         this.isNotNull = notNullOverriden ? XtkCaster.asBoolean(notNull) : this.type === "int64" || this.type === "short" ||
             this.type === "long" || this.type === "byte" || this.type === "float" || this.type === "double" ||
             this.type === "money" || this.type === "percent" || this.type === "time" || this.type === "boolean";
@@ -451,7 +511,7 @@ class XtkSchemaNode {
          * Returns a boolean which indicates whether the current node is mapped in SQL.
          * @type {boolean}
          */
-         this.isSQL = !!this.SQLName || !!this.SQLTable || (this.isLink && this.schema.mappingType === 'sql' && !this.isMappedAsXML);
+        this.isSQL = !!this.SQLName || !!this.SQLTable || (this.isLink && this.schema.mappingType === 'sql' && !this.isMappedAsXML);
 
          /**
           * The SQL name of the field. The property is an empty string if the object isn't an SQL type field.
@@ -469,20 +529,20 @@ class XtkSchemaNode {
          * Returns a boolean which indicates whether the value of the current node is the result of a calculation.
          * @type {boolean}
          */
-         this.isCalculated = false;
+        this.isCalculated = false;
 
         /**
           * Expression associated with the node
           * @type {string}
           */
-         this.expr = EntityAccessor.getAttributeAsString(xml, "expr");
+        this.expr = EntityAccessor.getAttributeAsString(xml, "expr");
         if (this.expr) this.isCalculated = true;
 
         /**
          * Returns a boolean which indicates whether the value of the current node is incremented automatically.
          * @type {boolean}
          */
-         this.isAutoIncrement = EntityAccessor.getAttributeAsBoolean(xml, "autoIncrement");
+        this.isAutoIncrement = EntityAccessor.getAttributeAsBoolean(xml, "autoIncrement");
 
         /**
          * Returns a boolean which indicates whether the current node is a primary key.
@@ -585,7 +645,10 @@ class XtkSchemaNode {
         return new XPath(path);
     }
 
-    // Find the real target
+    /**
+     * Find the target of a ref node.
+     * @returns {Promise<Campaign.XtkNode>} the target node, or undefined if not found
+     */
     async refTarget() {
         if (!this.ref) return;
         const index = this.ref.lastIndexOf(':');
@@ -608,7 +671,11 @@ class XtkSchemaNode {
         }
     }
 
-    async linkTarget() {
+    /**
+     * Find the target of a link node.
+     * @returns {Promise<Campaign.XtkNode>} the target node, or undefined if not found
+     */
+     async linkTarget() {
         if (this.type !== "link") return this.schema.root;
         let schemaId = this.target;
         let xpath = "";
@@ -631,10 +698,11 @@ class XtkSchemaNode {
     }
 
     /**
-     * Returns an instance of XtkSchemaNode or null if the node doesn't exist and the mustExist parameter is set to false.
+     * Returns an instance of XtkSchemaNode or null if the node doesn't exist. In version 1.1.0 and above, this function is
+     * asynchronous (returns a Promise)
      *
      * @param {XML.XPath|string} path XPath represents the name of the node to be searched
-     * @returns Returns a XtkSchemaNode instance if the node can be found, or null if the mustExist parameter is set to false.
+     * @returns {Promise<XtkSchemaNode>} Returns a XtkSchemaNode instance if the node can be found
     */
      async findNode(path) {
         if (typeof path == "string") path = new XPath(path);
@@ -693,6 +761,10 @@ class XtkSchemaNode {
         return s;
     }
 
+    /**
+     * Return the XtkSchemaNodes making up the join of a link-type node
+     * @returns {Promise<Array>} returns an array of joins. Each join is an element having a source and destination attributes, whose value is the corresponding XtkSchemaNode
+     */
     async joinNodes() {
         if (!this.isLink) return;
         const joinParts = [];
@@ -710,6 +782,10 @@ class XtkSchemaNode {
         return joinParts;
     }
 
+    /**
+     * Returns the reverse link node of a link-type node
+     * @returns {Promise<Campaign.XtkSchemaNode>}
+     */
     async reverseLink() {
         if (!this.isLink) return;
         const target = await this.linkTarget();
@@ -718,7 +794,11 @@ class XtkSchemaNode {
         return revLink;
     }
 
-    async computeString() {
+    /**
+     * Returns the compute string of a node. As the node can be a link or a reference, this function is asynchronous
+     * @returns {Promise<string>}
+     */
+     async computeString() {
         if (this.expr) return this.expr;
          // if we are a ref: ask the target of the ref
          if (this.ref) {
@@ -737,6 +817,8 @@ class XtkSchemaNode {
 
     /**
      * Returns an Enumeration object which is the enumeration linked to the current node or null if there is no enumeration.
+     * @param {string} an optional enumeration name. If none is specified, the node `enum` property will be used
+     * @returns Promise<Campaign.XtkEnumeration>
      */
     async enumeration(optionalName) {
         const name = optionalName || this.enum;
@@ -745,14 +827,26 @@ class XtkSchemaNode {
         return enumaration;
     }
 
+    /**
+     * Get the first internal key (if there is one)
+     * @returns {Campaign.XtkSchemaKey}
+     */
     firstInternalKeyDef() {
         return this.keys.find((k) => k.isInternal);
     }
     
+    /**
+     * Get the first external key (if there is one)
+     * @returns {Campaign.XtkSchemaKey}
+     */
     firstExternalKeyDef() {
         return this.keys.find((k) => !k.isInternal);
     }
     
+    /**
+     * Get the first key (internal first)
+     * @returns {Campaign.XtkSchemaKey}
+     */
     firstKeyDef() {
         let key = this.firstInternalKeyDef();
         if (!key) key = this.firstExternalKeyDef();
@@ -846,29 +940,34 @@ class XtkEnumeration {
          * @type {string}
          */
         this.label = EntityAccessor.getAttributeAsString(xml, "label");
+
         /**
          * A human friendly long description of the enumeration
          * @type {string}
          */
         this.description = EntityAccessor.getAttributeAsString(xml, "desc");
+
         /**
-         * The type of the enumeration
+         * The type of the enumeration, usually "string" or "byte"
          * @type {Campaign.XtkEnumerationType}
          */
         this.baseType = EntityAccessor.getAttributeAsString(xml, "basetype");
+
         /**
          * The default value of the enumeration
          * @type {Campaign.XtkEnumerationValue}
          */
         this.default = null;
+
         /**
          * Indicates if the enumeration has an image, i.e. if any of its values has an image
          * @type {boolean}
          */
         this.hasImage = false;
+
         /**
          * The enumerations values 
-         * @type {Object<string, Campaign.XtkEnumerationValue>}
+         * @type {Utils.ArrayMap<Campaign.XtkEnumerationValue>}
          */
          this.values = new ArrayMap();
 
@@ -884,7 +983,12 @@ class XtkEnumeration {
         }
 
         propagateImplicitValues(this, true);
-        this.shortName = this.name;
+
+        /**
+         * The system enumeration name, without the schema id prefix
+         * @type {string}
+         */
+         this.shortName = this.name;
         this.name = `${schemaId}:${this.shortName}`;
     }
 }
@@ -914,32 +1018,38 @@ class XtkSchema extends XtkSchemaNode {
          * @type {string}
          */
         this.namespace = EntityAccessor.getAttributeAsString(xml, "namespace");
+
         /**
          * The schema id, in the form "namespace:name"
          * @type {string}
          */
         this.name = EntityAccessor.getAttributeAsString(xml, "name");
         this.id = `${this.namespace}:${this.name}`;
+
         /**
          * Indicates whether the schema is a library schema or not
          * @type {boolean}
          */
         this.isLibrary = EntityAccessor.getAttributeAsBoolean(xml, "library");
+
         /**
          * A human name for the schema, in singular
          * @type {string}
          */
         this.labelSingular = EntityAccessor.getAttributeAsString(xml, "labelSingular");
+
         /**
          * The schema mappgin type, following the xtk:srcSchema:mappingType enumeration
          * @type {Campaign.XtkSchemaMappingType}
          */
         this.mappingType = EntityAccessor.getAttributeAsString(xml, "mappingType");
+
         /**
-         * The MD5 code of the schema in the form of a hexadecimal string
+         * The MD5 checksum of the schema in the form of a hexadecimal string
          * @type {string}
          */
         this.md5 = EntityAccessor.getAttributeAsString(xml, "md5");
+
         /**
          * The schema definition
          * @private
@@ -964,7 +1074,7 @@ class XtkSchema extends XtkSchemaNode {
         /**
          * Enumerations in this schema, as a dictionary whose keys are enumeration names and values are the
          * corresponding enumeration definitions
-         * @type {Object<string, XtkEnumeration>}
+         * @type {Utils.ArrayMap<Campaign.XtkEnumeration>}
          */
          this.enumerations = new ArrayMap();
          for (var child of EntityAccessor.getChildElements(xml, "enumeration")) {
@@ -1011,21 +1121,25 @@ class CurrentLogin {
          * @type {string}
          */
         this.login = EntityAccessor.getAttributeAsString(userInfo, "login");
+
         /**
          * The operator login id
          * @type {number}
          */
         this.id = EntityAccessor.getAttributeAsLong(userInfo, "loginId");
+        
         /**
          * A human friendly string naming the operator (compute string)
          * @type {string}
          */
         this.computeString = EntityAccessor.getAttributeAsString(userInfo, "loginCS");
+        
         /**
          * The operator timezone
          * @type {string}
          */
         this.timezone = EntityAccessor.getAttributeAsString(userInfo, "timezone");
+        
         /**
          * The llist of operator rights
          * @type {string[]}
@@ -1148,6 +1262,13 @@ class Application {
         return false;
     }
 
+    /**
+     * Get a system enumeration
+     * 
+     * @param {string} enumerationName The name of the enumeration, which can be fully qualified (ex: "nms:recipient:gender") or not (ex: "gender")
+     * @param {string} schemaOrSchemaId An optional schema id. If the enumerationName is not qualified, the search for the enumeration will be done in this schema
+     * @returns {XtkEnumeration} the enumeration
+     */
     async getSysEnum(enumerationName, schemaOrSchemaId) {
         const index = enumerationName.lastIndexOf(':');
         if (index === -1) {

--- a/src/index.js
+++ b/src/index.js
@@ -191,7 +191,7 @@ class SDK {
      * Convert a javascript value into an xtk constant with proper quoting
      * @param {any} value the value to convert
      * @param {string} type the xtk type
-     * @returns 
+     * @returns {string} the text literal which can be used in a Xtk expression or condition
      */
     xtkConstText(value, type) {
         if (!type || type === 'string' || type === 'memo') {

--- a/src/util.js
+++ b/src/util.js
@@ -137,7 +137,12 @@ class Util {
 
 /**
  * The ArrayMap object is used to access elements as either an array or a map
+ * 
+ * @class
+ * @constructor
+ * @memberof Utils
  */
+
 class ArrayMap {
   constructor() {
       // List of items, as an ordered array. Use defineProperty to make it non-enumerable
@@ -200,33 +205,78 @@ class ArrayMap {
       this._items.push(value);
       this.length = this._items.length;
   }
+
+  /**
+   * Executes a provided function once for each array element.
+   * @param {*} callback Function that is called for every element of the array
+   * @param {*} thisArg Optional value to use as this when executing the callback function.
+   * @returns a new array
+   */
   forEach(callback, thisArg) {
       return this._items.forEach(callback, thisArg);
   }
+
+  /**
+   * Returns the first element that satisfies the provided testing function. If no values satisfy the testing function, undefined is returned.
+   * @param {*} callback Function that is called for every element of the array
+   * @param {*} thisArg Optional value to use as this when executing the callback function.
+   * @returns the first element matching the testing function
+   */
   find(callback, thisArg) {
     return this._items.find(callback, thisArg);
   }
-  filter(callback, thisArg) {
+
+  /**
+   * creates a new array with all elements that pass the test implemented by the provided function.
+   * @param {*} callback Function that is called for every element of the array
+   * @param {*} thisArg Optional value to use as this when executing the callback function.
+   * @returns an array containing elements passing the test function
+   */
+   filter(callback, thisArg) {
     return this._items.filter(callback, thisArg);
   }
+
+  /**
+   * Get a element by either name (access as a map) or index (access as an array). Returns undefined if the element does not exist or
+   * if the array index is out of range.
+   * @param {string|number} indexOrKey the name or index of the element
+   * @returns the element matching the name or index
+   */
   get(indexOrKey) {
     if (typeof indexOrKey === 'number') return this._items[indexOrKey];
     return this._map[indexOrKey];
   }
+
+  /**
+   * Creates a new array populated with the results of calling a provided function on every element in the calling array.
+   * @param {*} callback Function that is called for every element of the array
+   * @param {*} thisArg Optional value to use as this when executing the callback function.
+   * @returns a new array
+   */
   map(callback, thisArg) {
     return this._items.map(callback, thisArg);
   }
+
+  /**
+   * Returns a new array formed by applying a given callback function to each element of the array, and then flattening the result by one level. 
+   * @param {*} callback Function that is called for every element of the array
+   * @param {*} thisArg Optional value to use as this when executing the callback function.
+   * @returns a new array
+   */
   flatMap(callback, thisArg) {
     return this._items.flatMap(callback, thisArg);
   }
-  // Support for ... of
+
+  /**
+   * Iterates over all the elements using the for ... of syntax.
+   * @returns returns each element one after the other
+   */
   *[Symbol.iterator] () {
       for (const item of this._items) {
           yield item;
       }
   }
 }
-
 
 // Public expots
 exports.Util = Util;

--- a/src/xtkCaster.js
+++ b/src/xtkCaster.js
@@ -431,15 +431,30 @@ class XtkCaster {
         return timespan;
     }
 
+    /**
+     * Tests if a given type is a date or time type
+     * @param {string|number} type the type name
+     * @returns {boolean} true if the type is a date and/or time type
+     */
     static isTimeType(type) {
         return type === "datetime" || type === "datetimetz" || type === "datetimenotz" || type === "timestamp" || type === "date" || type === "time" || type === "timespan" || type === 7 || type === 10 || type === 14;
     }
 
-    static isStringType(type) {
+    /**
+     * Tests if a given type is a string type
+     * @param {string|number} type the type name
+     * @returns {boolean} true if the type is a string type
+     */
+     static isStringType(type) {
         return type === "string" || type === "memo" || type === 6 || type === 12 || type === 13 || type === "blob" || type === "html" || type === "CDATA";
     }
 
-    static isNumericType(type) {
+    /**
+     * Tests if a given type is a numeric type
+     * @param {string|number} type the type name
+     * @returns {boolean} true if the type is a numeric type
+     */
+     static isNumericType(type) {
         return type === "byte" || type === 1 || type === "short" || type === 2 || type === "int" || type === "long" || type === 3 || type === "float" || type === 4 || type === "double" || type === 5 || type === "timespan" || type === 14;
     }
 }

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -2283,15 +2283,15 @@ describe('ACC Client', function () {
         it("Should ignore protocol for local storage root key", async () => {
             var connectionParameters = sdk.ConnectionParameters.ofUserAndPassword("http://acc-sdk:8080", "admin", "admin", {});
             var client = await sdk.init(connectionParameters);
-            expect(client._optionCache._storage._rootKey).toBe("acc.js.sdk.1.0.7.acc-sdk:8080.cache.OptionCache$");
+            expect(client._optionCache._storage._rootKey).toBe("acc.js.sdk.1.0.8.acc-sdk:8080.cache.OptionCache$");
 
             connectionParameters = sdk.ConnectionParameters.ofUserAndPassword("https://acc-sdk:8080", "admin", "admin", {});
             client = await sdk.init(connectionParameters);
-            expect(client._optionCache._storage._rootKey).toBe("acc.js.sdk.1.0.7.acc-sdk:8080.cache.OptionCache$");
+            expect(client._optionCache._storage._rootKey).toBe("acc.js.sdk.1.0.8.acc-sdk:8080.cache.OptionCache$");
 
             connectionParameters = sdk.ConnectionParameters.ofUserAndPassword("acc-sdk:8080", "admin", "admin", {});
             client = await sdk.init(connectionParameters);
-            expect(client._optionCache._storage._rootKey).toBe("acc.js.sdk.1.0.7.acc-sdk:8080.cache.OptionCache$");
+            expect(client._optionCache._storage._rootKey).toBe("acc.js.sdk.1.0.8.acc-sdk:8080.cache.OptionCache$");
         })
 
         it("Should support no storage", async () => {

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -2283,15 +2283,15 @@ describe('ACC Client', function () {
         it("Should ignore protocol for local storage root key", async () => {
             var connectionParameters = sdk.ConnectionParameters.ofUserAndPassword("http://acc-sdk:8080", "admin", "admin", {});
             var client = await sdk.init(connectionParameters);
-            expect(client._optionCache._storage._rootKey).toBe("acc.js.sdk.1.0.9.acc-sdk:8080.cache.OptionCache$");
+            expect(client._optionCache._storage._rootKey).toBe("acc.js.sdk.1.1.0.acc-sdk:8080.cache.OptionCache$");
 
             connectionParameters = sdk.ConnectionParameters.ofUserAndPassword("https://acc-sdk:8080", "admin", "admin", {});
             client = await sdk.init(connectionParameters);
-            expect(client._optionCache._storage._rootKey).toBe("acc.js.sdk.1.0.9.acc-sdk:8080.cache.OptionCache$");
+            expect(client._optionCache._storage._rootKey).toBe("acc.js.sdk.1.1.0.acc-sdk:8080.cache.OptionCache$");
 
             connectionParameters = sdk.ConnectionParameters.ofUserAndPassword("acc-sdk:8080", "admin", "admin", {});
             client = await sdk.init(connectionParameters);
-            expect(client._optionCache._storage._rootKey).toBe("acc.js.sdk.1.0.9.acc-sdk:8080.cache.OptionCache$");
+            expect(client._optionCache._storage._rootKey).toBe("acc.js.sdk.1.1.0.acc-sdk:8080.cache.OptionCache$");
         })
 
         it("Should support no storage", async () => {


### PR DESCRIPTION
Changes in the metadata api (`application.getSchema`) which was not completely implemented. While this API is meant to be largely compatible with the [ACC JS API](https://docs.adobe.com/content/help/en/campaign-classic/technicalresources/api/c-Application.html), it's not always possible to do so because of the asynchronous nature of the SDK. The JS API is executed inside the Campaign application server can will synchronously and transparently fetch schemas as needed. Howerer the SDK runs outside of the Campaign server. It will synchronously and transparently fetch schemas as needed, but this will be done adynchronously. 

Differences are document in the `Application` section of the README.

* Provide array and map access to XtkSchemaKey.fields, 
* The order of children of a node has been changed. Beore 1.1.0, it was attributes, then elements. After 1.1.0, it's the order defined in the schema XML
* New application.getEnumeration function to retreive an enumeration
* Removed the XtkSchemaNode.hasChild function
* Support for ref nodes and links: XtkSchemaNode.refTarget(), XtkSchemaNode.linkTarget() functions
* Reviews XtkSchemaNode.findNode() function to support links, refs, ANY type, etc. and is now asynchronous
* The name attribute of enumerations (`XtkEnumeration.name`) is now the fully qualified name of the enumeration, i.e. is prefixed by the schema id