### PR TITLE
Release 1.1.1 - Fixed an issue with charset encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This is a node.js SDK for Campaign API. It exposes the Campaign API exactly like
 
 # Changelog 
 
+## Version 1.1.1
+_2022/03/10_
+
+* Fixed an issue with encoding: make the default charset encoding to be UTF-8 (https://github.com/adobe/acc-js-sdk/issues/26)
+
 ## Version 1.1.0
 _2022/03/05_
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ transport|axios|Overrides the transport layer
 noStorage|false|De-activate using of local storage
 storage|localStorage|Overrides the local storage for caches
 refreshClient|undefined|Async callback to run when the session token is expired
+charset|UTF-8|The charset encoding used for http requests. In version 1.1.1 and above, the default will be UTF-8. It's possible to override (including setting an empty character set) with this option.
 
 ```js
 const connectionParameters = sdk.ConnectionParameters.ofUserAndPassword(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/acc-js-sdk",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "ACC Javascript SDK",
   "main": "src/index.js",
   "homepage": "https://github.com/adobe/acc-js-sdk#readme",

--- a/src/client.js
+++ b/src/client.js
@@ -234,6 +234,8 @@ class Credentials {
     * @property {Utils.Transport} transport - Overrides the transport (i.e. HTTP layer)
     * @property {boolean} noStorage - De-activate using of local storage. By default, and in addition to in-memory cache, entities, methods, and options are also persisted in local storage if there is one.
     * @property {Storage} storage - Overrides the storage interface (i.e. LocalStorage)
+    * @property {function} refreshClient - An async callback function with the SDK client as parameter, which will be called when the ACC session is expired
+    * @property {string} charset - The charset encoding used for http requests. Defaults to UTF-8 since SDK version 1.1.1
     * @memberOf Campaign
  */
  
@@ -297,6 +299,7 @@ class ConnectionParameters {
         }
         this._options._storage = storage;
         this._options.refreshClient = options.refreshClient;
+        this._options.charset = options.charset === undefined ? "UTF-8": options.charset;
     }
 
     /**
@@ -673,7 +676,9 @@ class Client {
      * parameters should be set
      */
     _prepareSoapCall(urn, method, internal) {
-        const soapCall = new SoapMethodCall(this._transport, urn, method, this._sessionToken, this._securityToken, this._getUserAgentString());
+        const soapCall = new SoapMethodCall(this._transport, urn, method, 
+                                            this._sessionToken, this._securityToken, 
+                                            this._getUserAgentString(), this._connectionParameters._options.charset);
         soapCall.internal = !!internal;
         return soapCall;
     }

--- a/src/soap.js
+++ b/src/soap.js
@@ -78,11 +78,12 @@ const NS_XSD = "http://www.w3.org/2001/XMLSchema";
  * @param {string} sessionToken Campaign session token
  * @param {string} securityToken  Campaign security token
  * @param {string} userAgentString The user agent string to use for HTTP requests
+ * @param {string} charset The charset encoding used for http requests, usually UTF-8
  * @memberof SOAP
  */
 class SoapMethodCall {
     
-    constructor(transport, urn, methodName, sessionToken, securityToken, userAgentString) {
+    constructor(transport, urn, methodName, sessionToken, securityToken, userAgentString, charset) {
         this.request = undefined;       // The HTTP request (object litteral passed to the transport layer)
         this.response = undefined;      // The HTTP response object (in case of success)
 
@@ -99,6 +100,7 @@ class SoapMethodCall {
         this._sessionToken = sessionToken || "";
         this._securityToken = securityToken || "";
         this._userAgentString = userAgentString;
+        this._charset = charset || "";
 
         // THe SOAP call being built
         this._doc = undefined;           // XML document for SOAP call
@@ -512,11 +514,12 @@ class SoapMethodCall {
      * @returns {Object} an options object describing the HTTP request, with cookies, headers and body
      */
     _createHTTPRequest(url) {
+
         const options = {
             url: url,
             method: 'POST',
             headers: {
-                'Content-type': 'application/soap+xml',
+                'Content-type': `application/soap+xml${this._charset ? ";charset=" + this._charset : ""}`,
                 'SoapAction': `${this.urn}#${this.methodName}`,
                 'X-Security-Token': this._securityToken
             },

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -2283,15 +2283,15 @@ describe('ACC Client', function () {
         it("Should ignore protocol for local storage root key", async () => {
             var connectionParameters = sdk.ConnectionParameters.ofUserAndPassword("http://acc-sdk:8080", "admin", "admin", {});
             var client = await sdk.init(connectionParameters);
-            expect(client._optionCache._storage._rootKey).toBe("acc.js.sdk.1.1.0.acc-sdk:8080.cache.OptionCache$");
+            expect(client._optionCache._storage._rootKey).toBe("acc.js.sdk.1.1.1.acc-sdk:8080.cache.OptionCache$");
 
             connectionParameters = sdk.ConnectionParameters.ofUserAndPassword("https://acc-sdk:8080", "admin", "admin", {});
             client = await sdk.init(connectionParameters);
-            expect(client._optionCache._storage._rootKey).toBe("acc.js.sdk.1.1.0.acc-sdk:8080.cache.OptionCache$");
+            expect(client._optionCache._storage._rootKey).toBe("acc.js.sdk.1.1.1.acc-sdk:8080.cache.OptionCache$");
 
             connectionParameters = sdk.ConnectionParameters.ofUserAndPassword("acc-sdk:8080", "admin", "admin", {});
             client = await sdk.init(connectionParameters);
-            expect(client._optionCache._storage._rootKey).toBe("acc.js.sdk.1.1.0.acc-sdk:8080.cache.OptionCache$");
+            expect(client._optionCache._storage._rootKey).toBe("acc.js.sdk.1.1.1.acc-sdk:8080.cache.OptionCache$");
         })
 
         it("Should support no storage", async () => {


### PR DESCRIPTION
Release 1.1.1 - Fixed an issue with encoding: make the default charset encoding to be UTF-8.
See https://github.com/adobe/acc-js-sdk/issues/26
