### PR TITLE
Release 1.1.2 Bump version to 1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This is a node.js SDK for Campaign API. It exposes the Campaign API exactly like
 # Changelog 
 
 ## Version 1.1.2
-_2022/03/18_
+_2022/03/22_
 
 * Add support for choosing the representation (XML or JSON) at the method level using NLWS.xml or NLWS.json.
 


### PR DESCRIPTION
Add support for choosing the representation (XML or JSON) at the method level using NLWS.xml or NLWS.json.

The client object is created with a default representation which is used for all API calls in the context of this client. Since version 1.1.2, it is also possible to set the representation at the method level, i.e. use a particular representation for a particular API call.

client.NLWS: use the default representation set at the client level
client.NLWS.xml: use the XML reresentation
client.NLWS.json: use the SimpleJson representation