### PR TITLE
Release 1.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This is a node.js SDK for Campaign API. It exposes the Campaign API exactly like
 * Fix a bug causing API calls having a input parameter of type "int" to fail. Usually the type is described as "long", but sometimes "int" is used instead, such as, for instance, in the nms:extAccount#UpdateMCSynchWkf method.
 * When using XML representations and DOMDocument method parameter type, the SDK expects to be passed an actual DOM document. Now it supports being passed a DOM element too. This is a common case when using the nms:delivery#createFromModel API followed by a xtk:session#Write API call.
 * Avoid the error 'Cannot transform entity to xml because no XML root name was given' by using SOAP method parameter name as the default for XML document root when no other root is available
+* Document how to set the password of an external account
 
 ## Version 1.1.2
 _2022/03/22_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This is a node.js SDK for Campaign API. It exposes the Campaign API exactly like
 # Changelog 
 
 * Fix a bug in client.hasPackage which was returning an incorrect result when passed a single parameter (it would always return false). Fixed the corresponding unit test too.
+* Fix a bug causing API calls having a input parameter of type "int" to fail. Usually the type is described as "long", but sometimes "int" is used instead, such as, for instance, in the nms:extAccount#UpdateMCSynchWkf method.
 
 ## Version 1.1.2
 _2022/03/22_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This is a node.js SDK for Campaign API. It exposes the Campaign API exactly like
 
 * Fix a bug in client.hasPackage which was returning an incorrect result when passed a single parameter (it would always return false). Fixed the corresponding unit test too.
 * Fix a bug causing API calls having a input parameter of type "int" to fail. Usually the type is described as "long", but sometimes "int" is used instead, such as, for instance, in the nms:extAccount#UpdateMCSynchWkf method.
+* When using XML representations and DOMDocument method parameter type, the SDK expects to be passed an actual DOM document. Now it supports being passed a DOM element too. This is a common case when using the nms:delivery#createFromModel API followed by a xtk:session#Write API call.
 
 ## Version 1.1.2
 _2022/03/22_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This is a node.js SDK for Campaign API. It exposes the Campaign API exactly like
 * Fix a bug in client.hasPackage which was returning an incorrect result when passed a single parameter (it would always return false). Fixed the corresponding unit test too.
 * Fix a bug causing API calls having a input parameter of type "int" to fail. Usually the type is described as "long", but sometimes "int" is used instead, such as, for instance, in the nms:extAccount#UpdateMCSynchWkf method.
 * When using XML representations and DOMDocument method parameter type, the SDK expects to be passed an actual DOM document. Now it supports being passed a DOM element too. This is a common case when using the nms:delivery#createFromModel API followed by a xtk:session#Write API call.
+* Avoid the error 'Cannot transform entity to xml because no XML root name was given' by using SOAP method parameter name as the default for XML document root when no other root is available
 
 ## Version 1.1.2
 _2022/03/22_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This is a node.js SDK for Campaign API. It exposes the Campaign API exactly like
 
 # Changelog 
 
+## Version 1.1.3
+_2022/05/30_
+
 * Fix a bug in client.hasPackage which was returning an incorrect result when passed a single parameter (it would always return false). Fixed the corresponding unit test too.
 * Fix a bug causing API calls having a input parameter of type "int" to fail. Usually the type is described as "long", but sometimes "int" is used instead, such as, for instance, in the nms:extAccount#UpdateMCSynchWkf method.
 * When using XML representations and DOMDocument method parameter type, the SDK expects to be passed an actual DOM document. Now it supports being passed a DOM element too. This is a common case when using the nms:delivery#createFromModel API followed by a xtk:session#Write API call.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This is a node.js SDK for Campaign API. It exposes the Campaign API exactly like
 
 # Changelog 
 
+* Fix a bug in client.hasPackage which was returning an incorrect result when passed a single parameter (it would always return false). Fixed the corresponding unit test too.
+
 ## Version 1.1.2
 _2022/03/22_
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This is a node.js SDK for Campaign API. It exposes the Campaign API exactly like
 * When using XML representations and DOMDocument method parameter type, the SDK expects to be passed an actual DOM document. Now it supports being passed a DOM element too. This is a common case when using the nms:delivery#createFromModel API followed by a xtk:session#Write API call.
 * Avoid the error 'Cannot transform entity to xml because no XML root name was given' by using SOAP method parameter name as the default for XML document root when no other root is available
 * Document how to set the password of an external account
+* By default, SDK will send additional HTTP headers to help troubleshooting and usage tracking
+* Add the ability to pass extra HTTP headers to API calls, either globally (to all HTTP headers), or locally, i.e. for a specific method
 
 ## Version 1.1.2
 _2022/03/22_

--- a/README.md
+++ b/README.md
@@ -696,8 +696,19 @@ const password = cipher.decryptPassword(encryptedPassword);
 ````
 
 > **warning** This function is deprecated in version 1.0.0 of the SDK because it may break as we deploy Vault.
+In order to set the password of an external account, you can use the `encryptPassword` API as follow
 
-
+```js
+const password = await this._client.NLWS.xtkSession.encryptPassword('password');
+const account = {
+    xtkschema: "nms:extAccount",
+    name: name,
+    account: 'admin',
+    server: server,
+    password: password,
+};
+await this._client.NLWS.xtkSession.Write(account);
+```
 
 # Samples
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,9 @@ noStorage|false|De-activate using of local storage
 storage|localStorage|Overrides the local storage for caches
 refreshClient|undefined|Async callback to run when the session token is expired
 charset|UTF-8|The charset encoding used for http requests. In version 1.1.1 and above, the default will be UTF-8. It's possible to override (including setting an empty character set) with this option.
-
+extraHttpHeaders|[string]:string|An optional dictionary (key/value pairs) of extra HTTP headers to pass to all API calls.
+clientApp|string|An optional string describing the name and version of the SDK client application. It will be passed to the server in the ACC-SDK-Client-App HTTP header
+noSDKHeaders|boolean|Can be set to disable passing ACC-SDK-* HTTP headers to the server
 ```js
 const connectionParameters = sdk.ConnectionParameters.ofUserAndPassword(
                                     "https://myInstance.campaign.adobe.com", 
@@ -696,6 +698,7 @@ const password = cipher.decryptPassword(encryptedPassword);
 ````
 
 > **warning** This function is deprecated in version 1.0.0 of the SDK because it may break as we deploy Vault.
+
 In order to set the password of an external account, you can use the `encryptPassword` API as follow
 
 ```js
@@ -709,6 +712,52 @@ const account = {
 };
 await this._client.NLWS.xtkSession.Write(account);
 ```
+
+
+## HTTP Headers
+
+### Out-of-the-box headers
+In version 1.1.3 and above, the SDK will pass additional HTTP headers automatically
+
+Header | Description
+-------|------------
+SOAPAction| name of the schema and SOAP method (ex: xtk:query#ExecuteQuery)
+ACC-SDK-Version| Version of the SDK making the scores
+ACC-SDK-Auth| Authentification type and ACC user
+ACC-SDK-Client-App| Name of the application calling the client SDK
+ACC-SDK-Call-RetryCount| In case an API call is retried, indicates the number of retries
+ACC-SDK-Call-Internal| Indicates that an API call is performed byt the SDK for its own purpose
+
+The `ACC-SDK` headers can be removed using the connection parameter `noSDKHeaders`.
+
+### Custom HTTP headers
+In version 1.1.3 and above, it is possible to pass additional HTTP headers or override HTTP headers set by the SDK. This can be done globally (i.e. for all API calls), or locally, i.e. just for a particular call, or both.
+
+Http headers are passed through an object whose keys represent the header name and values the corresponding header value. Nothing particular is done in term of case sensitivity, headers will be passed as passed.
+
+To set global HTTP headers for all API calls of a client, pass an http headers array in the connection parameters
+```js
+const connectionParameters = sdk.ConnectionParameters.ofUserAndPassword(
+                                    "https://myInstance.campaign.adobe.com", 
+                                    "admin", "admin",
+                                    { extraHttpHeaders: {
+                                        "X-ACC-JS-SDK-LBSAFE": "1",
+                                        "X-ACC-WEBUI-VERSION: "1.2"
+                                    } });
+```
+
+Subsequent API calls will have the corresponding headers set.
+
+To set more HTTP headers for a particular API call, use the "headers" method of the NLWS object.
+
+```js
+const query = client.NLWS
+    .headers({'X-Test': 'hello'})
+    .xtkQueryDef.create(queryDef);
+await query.executeQuery();
+```
+
+
 
 # Samples
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adobe/acc-js-sdk",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@adobe/acc-js-sdk",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "license": "ISC",
       "dependencies": {
         "axios": "^0.25.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/acc-js-sdk",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "ACC Javascript SDK",
   "main": "src/index.js",
   "homepage": "https://github.com/adobe/acc-js-sdk#readme",

--- a/samples/utils.js
+++ b/samples/utils.js
@@ -47,7 +47,9 @@ async function run(main) {
  */
 async function logon(callback) {
   var main = async () => {
-    const connectionParameters = sdk.ConnectionParameters.ofUserAndPassword(url, user, password);
+    const connectionParameters = sdk.ConnectionParameters.ofUserAndPassword(url, user, password, {
+      clientApp: 'acc-js-sdk sample'
+    });
     const client = await sdk.init(connectionParameters);
     const NLWS = client.NLWS;
   

--- a/src/client.js
+++ b/src/client.js
@@ -267,7 +267,7 @@ class Credentials {
     * @property {Storage} storage - Overrides the storage interface (i.e. LocalStorage)
     * @property {function} refreshClient - An async callback function with the SDK client as parameter, which will be called when the ACC session is expired
     * @property {string} charset - The charset encoding used for http requests. Defaults to UTF-8 since SDK version 1.1.1
-    * @property {[string]: string} extraHttpHeaders - optional key/value pair of HTTP header (will override any other headers)
+    * @property {{ name:string, value:string}} extraHttpHeaders - optional key/value pair of HTTP header (will override any other headers)
     * @property {string} clientApp - optional name/version of the application client of the SDK. This will be passed in HTTP headers for troubleshooting
     * @property {boolean} noSDKHeaders - set to disable "ACC-SDK" HTTP headers
     * @memberOf Campaign

--- a/src/client.js
+++ b/src/client.js
@@ -1184,6 +1184,7 @@ class Client {
                             const index = xtkschema.indexOf(":");
                             docName = xtkschema.substr(index+1);
                         }
+                        if (!docName) docName = paramName; // Use te parameter name as the XML root element
                         var xmlValue = that._fromRepresentation(docName, paramValue, callContext.representation);
                         if (type == "DOMDocument")
                             soapCall.writeDocument(paramName, xmlValue);

--- a/src/client.js
+++ b/src/client.js
@@ -977,11 +977,11 @@ class Client {
      * @returns {boolean} a boolean indicating if the package is installed or not
      */
     hasPackage(packageId, optionalName) {
-    if (optionalName === undefined)
-        packageId = `${packageId}:${optionalName}`;
-    if (!this.isLogged())
-        throw CampaignException.NOT_LOGGED_IN(undefined, `Cannot call hasPackage: session not connected`);
-    return this._installedPackages[packageId] !== undefined;
+        if (optionalName !== undefined)
+            packageId = `${packageId}:${optionalName}`;
+        if (!this.isLogged())
+            throw CampaignException.NOT_LOGGED_IN(undefined, `Cannot call hasPackage: session not connected`);
+        return this._installedPackages[packageId] !== undefined;
     }
 
     /**

--- a/src/client.js
+++ b/src/client.js
@@ -1158,6 +1158,8 @@ class Client {
                         soapCall.writeByte(paramName, XtkCaster.asByte(paramValue));
                     else if (type == "short")
                         soapCall.writeShort(paramName, XtkCaster.asShort(paramValue));
+                    else if (type == "int")
+                        soapCall.writeLong(paramName, XtkCaster.asLong(paramValue));
                     else if (type == "long")
                         soapCall.writeLong(paramName, XtkCaster.asLong(paramValue));
                     else if (type == "int64")

--- a/src/client.js
+++ b/src/client.js
@@ -124,7 +124,7 @@ const clientHandler = (representation, headers) => {
                 if (headers) for (let h in headers) newHeaders[h] = headers[h];
                 if (methodHeaders) for (let h in methodHeaders) newHeaders[h] = methodHeaders[h];
                 return new Proxy(client, clientHandler(representation, newHeaders));
-            }
+            };
 
             return new Proxy({ client:client, namespace:namespace}, {
                 get: function(callContext, methodName) {

--- a/src/soap.js
+++ b/src/soap.js
@@ -299,7 +299,8 @@ class SoapMethodCall {
     writeDocument(tag, document) {
         const node = this._addNode(tag, "", null, SOAP_ENCODING_XML);
         if (document !== null && document !== undefined) {
-            const child = this._doc.importNode(document.documentElement, true);
+            const element = document.nodeType === 1 ? document : document.documentElement;
+            const child = this._doc.importNode(element, true);
             node.appendChild(child);
         }
     }

--- a/src/soap.js
+++ b/src/soap.js
@@ -79,7 +79,7 @@ const NS_XSD = "http://www.w3.org/2001/XMLSchema";
  * @param {string} securityToken  Campaign security token
  * @param {string} userAgentString The user agent string to use for HTTP requests
  * @param {string} charset The charset encoding used for http requests, usually UTF-8
- * @param {[string]: string} extraHttpHeaders key/value pair of HTTP header (will override any other headers)
+ * @param {{ name:string, value:string}} extraHttpHeaders key/value pair of HTTP header (will override any other headers)
  * @memberof SOAP
  */
 class SoapMethodCall {

--- a/test/client.hasPackage.test.js
+++ b/test/client.hasPackage.test.js
@@ -56,12 +56,12 @@ describe('ACC Client (has package)', () => {
     client._transport.mockReturnValueOnce(LOGON_RESPONSE);
     await client.NLWS.xtkSession.logon();
 
-    expect(client.hasPackage("nms:campaign"));
-    expect(client.hasPackage("nms", "campaign"));
-    expect(!client.hasPackage("nms:mrm"));
-    expect(!client.hasPackage("nms", "mrm"));
-    expect(client.hasPackage("nms:core"));
-    expect(client.hasPackage("nms", "core"));
+    expect(client.hasPackage("nms:campaign")).toBeTruthy();
+    expect(client.hasPackage("nms", "campaign")).toBeTruthy();
+    expect(client.hasPackage("nms:mrm")).toBeFalsy();
+    expect(client.hasPackage("nms", "mrm")).toBeFalsy();
+    expect(client.hasPackage("nms:core")).toBeTruthy();
+    expect(client.hasPackage("nms", "core")).toBeTruthy();
   });
 
   it('should fail when unlogged', async () => {

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -2283,15 +2283,15 @@ describe('ACC Client', function () {
         it("Should ignore protocol for local storage root key", async () => {
             var connectionParameters = sdk.ConnectionParameters.ofUserAndPassword("http://acc-sdk:8080", "admin", "admin", {});
             var client = await sdk.init(connectionParameters);
-            expect(client._optionCache._storage._rootKey).toBe("acc.js.sdk.1.1.2.acc-sdk:8080.cache.OptionCache$");
+            expect(client._optionCache._storage._rootKey).toBe("acc.js.sdk.1.1.3.acc-sdk:8080.cache.OptionCache$");
 
             connectionParameters = sdk.ConnectionParameters.ofUserAndPassword("https://acc-sdk:8080", "admin", "admin", {});
             client = await sdk.init(connectionParameters);
-            expect(client._optionCache._storage._rootKey).toBe("acc.js.sdk.1.1.2.acc-sdk:8080.cache.OptionCache$");
+            expect(client._optionCache._storage._rootKey).toBe("acc.js.sdk.1.1.3.acc-sdk:8080.cache.OptionCache$");
 
             connectionParameters = sdk.ConnectionParameters.ofUserAndPassword("acc-sdk:8080", "admin", "admin", {});
             client = await sdk.init(connectionParameters);
-            expect(client._optionCache._storage._rootKey).toBe("acc.js.sdk.1.1.2.acc-sdk:8080.cache.OptionCache$");
+            expect(client._optionCache._storage._rootKey).toBe("acc.js.sdk.1.1.3.acc-sdk:8080.cache.OptionCache$");
         })
 
         it("Should support no storage", async () => {

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -2474,4 +2474,43 @@ describe('ACC Client', function () {
             expect(json).toBe('{"#text":[],"extAccount":[{"id":"1816","name":"defaultPopAccount"},{"id":"1818","name":"defaultOther"},{"id":"1849","name":"billingReport"},{"id":"12070","name":"TST_EXT_ACCOUNT_POSTGRESQL"},{"id":"1817","name":"defaultEmailBulk"},{"id":"2087","name":"ffda"},{"id":"2088","name":"defaultEmailMid"}]}');
         });
     });
+
+    describe('Support for int type parameters such as nms:extAccount#UpdateMCSynchWkf', () => {
+        it("Should call nms:extAccount#UpdateMCSynchWkf", async () => {
+            const client = await Mock.makeClient();
+            client._transport.mockReturnValueOnce(Mock.LOGON_RESPONSE);
+            await client.NLWS.xtkSession.logon();
+
+            client._transport.mockReturnValueOnce(Promise.resolve(`<?xml version='1.0'?>
+            <SOAP-ENV:Envelope xmlns:xsd='http://www.w3.org/2001/XMLSchema' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xmlns:ns='urn:wpp:default' xmlns:SOAP-ENV='http://schemas.xmlsoap.org/soap/envelope/'>
+            <SOAP-ENV:Body>
+                <GetEntityIfMoreRecentResponse xmlns='urn:wpp:default' SOAP-ENV:encodingStyle='http://schemas.xmlsoap.org/soap/encoding/'>
+                    <pdomDoc xsi:type='ns:Element' SOAP-ENV:encodingStyle='http://xml.apache.org/xml-soap/literalxml'>
+                        <schema name="extAccount" namespace="nms" xtkschema="xtk:schema">
+                            <element name="extAccount"></element>
+                            <methods>
+                                <method library="nms:messageCenter.js" name="UpdateMCSynchWkf" static="true" hidden="true">
+                                <parameters>
+                                    <param name="extAccountId" type="int" desc="Message Center external account identifier"/>
+                                </parameters>
+                            </method>
+                            </methods>
+                        </schema>
+                    </pdomDoc>
+                </GetEntityIfMoreRecentResponse>
+            </SOAP-ENV:Body>
+            </SOAP-ENV:Envelope>`));
+
+            client._transport.mockReturnValueOnce(Promise.resolve(`<?xml version='1.0'?>
+            <SOAP-ENV:Envelope xmlns:xsd='http://www.w3.org/2001/XMLSchema' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xmlns:ns='urn:nms:extAccount' xmlns:SOAP-ENV='http://schemas.xmlsoap.org/soap/envelope/'>
+            <SOAP-ENV:Body>
+            <UpdateMCSynchWkfResponse xmlns='urn:nms:extAccount' SOAP-ENV:encodingStyle='http://schemas.xmlsoap.org/soap/encoding/'>
+            </UpdateMCSynchWkfResponse>
+            </SOAP-ENV:Body>
+            </SOAP-ENV:Envelope>`));
+
+            await client.NLWS.nmsExtAccount.updateMCSynchWkf(1);
+        })
+
+    });
 });

--- a/test/soap.test.js
+++ b/test/soap.test.js
@@ -388,6 +388,22 @@ describe('SOAP', function() {
             expect(actualElement.getAttribute("att")).toBe("Hello");
         });
 
+        it('Should support passing DOM elements instead of document parameters', function() {
+            const xml = '<root att="Hello"><child/></root>';
+            const doc = DomUtil.parse(xml);
+
+            const call = makeSoapMethodCall(undefined, "xtk:session", "Document", "$session$", "$security$");
+            call.writeDocument("p", doc.documentElement);
+            const request = call._createHTTPRequest(URL);
+            const env = DomUtil.parse(request.data).documentElement;
+            const body = hasChildElement(env, "SOAP-ENV:Body");
+            const method = hasChildElement(body, "m:Document");
+            const param = hasChildElement(method, "p");
+            const actualElement = hasChildElement(param, "root");
+            expect(actualElement).toBeTruthy();
+            expect(actualElement.getAttribute("att")).toBe("Hello");
+        });
+
         it('Should write null document', function() {
             const call = makeSoapMethodCall(undefined, "xtk:session", "Document", "$session$", "$security$");
             call.writeDocument("p", null);

--- a/test/soap.test.js
+++ b/test/soap.test.js
@@ -25,8 +25,8 @@ const sdk = require('../src/index.js');
 
 const URL = "https://soap-test/nl/jsp/soaprouter.jsp";
 
-function makeSoapMethodCall(transport, urn, methodName, sessionToken, securityToken, userAgentString, optionalCharset) {
-    const call = new SoapMethodCall(transport, urn, methodName, sessionToken, securityToken, userAgentString, optionalCharset);
+function makeSoapMethodCall(transport, urn, methodName, sessionToken, securityToken, userAgentString, optionalCharset, charset, extraHttpHeaders) {
+    const call = new SoapMethodCall(transport, urn, methodName, sessionToken, securityToken, userAgentString, optionalCharset, charset, extraHttpHeaders);
     return call;
 }
 
@@ -865,6 +865,24 @@ describe("Campaign exception", () => {
         expect(req.headers["X-Security-Token"].indexOf("$session$")).toBe(-1);
         expect(req.headers["X-Security-Token"].indexOf("$security$")).toBe(-1);
     })
+
+    describe('Extra Http headers', () => {
+        it("Should take additional headers", () => {
+            const call = makeSoapMethodCall(undefined, "xtk:session", "Date", "$session$", "$security$", "My User Agent", undefined, { 'X-ACC-UI-Version': '1.0' });
+            const request = call._createHTTPRequest(URL);
+            expect(request.headers['User-Agent']).toBe("My User Agent");
+            expect(request.headers['X-ACC-UI-Version']).toBe("1.0");
+            expect(request.headers['SoapAction']).toBe("xtk:session#Date");
+        });
+
+        it("Should override default headers headers", () => {
+            const call = makeSoapMethodCall(undefined, "xtk:session", "Date", "$session$", "$security$", "My User Agent", undefined, { 'X-ACC-UI-Version': '1.0', 'SoapAction': 'My soap action' });
+            const request = call._createHTTPRequest(URL);
+            expect(request.headers['User-Agent']).toBe("My User Agent");
+            expect(request.headers['X-ACC-UI-Version']).toBe("1.0");
+            expect(request.headers['SoapAction']).toBe("My soap action");
+        });
+    });
 
 });
 


### PR DESCRIPTION
Release 1.1.3

* Fix a bug in client.hasPackage which was returning an incorrect result when passed a single parameter (it would always return false). Fixed the corresponding unit test too.
* Fix a bug causing API calls having a input parameter of type "int" to fail. Usually the type is described as "long", but sometimes "int" is used instead, such as, for instance, in the nms:extAccount#UpdateMCSynchWkf method.
* When using XML representations and DOMDocument method parameter type, the SDK expects to be passed an actual DOM document. Now it supports being passed a DOM element too. This is a common case when using the nms:delivery#createFromModel API followed by a xtk:session#Write API call.
* Avoid the error 'Cannot transform entity to xml because no XML root name was given' by using SOAP method parameter name as the default for XML document root when no other root is available
* Document how to set the password of an external account
* By default, SDK will send additional HTTP headers to help troubleshooting and usage tracking
* Add the ability to pass extra HTTP headers to API calls, either globally (to all HTTP headers), or locally, i.e. for a specific method