### PR TITLE
Refresh cache when entities are modified

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,7 +4,8 @@ module.exports = {
         "commonjs": true,
         "es2021": true,
         "node": true,
-        "jest": true
+        "jest": true,
+        circus: true
     },
     "extends": "eslint:recommended",
     "parserOptions": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This is a node.js SDK for Campaign API. It exposes the Campaign API exactly like
 
 # Changelog 
 
+## Version 1.1.6
+_2022_08_19_
+
+* New auto-refresh mechanism to keep schemas and option caches up-to-date. See `client.startRefreshCaches` and `client.stopRefreshCaches` functions.
+
 ## Version 1.1.5
 _2022/07/07__
 

--- a/README.md
+++ b/README.md
@@ -693,6 +693,30 @@ It's possible to disable persistent caches using the `noStorage` connection opti
 It is also possible to setup one's own persistent cache, by passing a `storage` object as a connection option. This object should implement 3 methods: `getItem`, `setItem`, and `removeItem` (synchronous)
 
 
+## Auto-refresh caches
+
+The SDK includes a mechnism to maintain the schemas and options caches up-to-date by polling the Campaign server on a regular basis (10 seconds by default). The server returns the list of entities (schemas or options) which have changed since they were cached, and the client removes them from the cache. When a schema changes, the corresponding methods are also removed from the method cache.
+
+This mechanism is not activate by default but can be activated or deactivated by the following functions
+
+```js
+client.startRefreshCaches(30000);   // activate cache auto-refresh mechanism every 30s
+client.stopRefreshCaches();         // de-activate cache auto-refresh
+```
+
+This mechanism is based on the `xtk:session#GetModifiedEntities` SOAP method which is only available in Campaign 8.4 and above only. For other builds of Campaign, the auto-refresh mechanism will not do anything. 
+
+The following changes are handled:
+* If the build number has changed, the whole cache is cleared
+* If more than 10 schemas or options have changed, the whole cache is cleared
+* if less than 10 schemas or options have changed, only those entities are removed from the cache
+
+
+The refresh mechanism includes the following guardrails
+* Both xtk:option and xtk:schema caches are refreshed every n seconds. To avoid issuing two API calls at the same time to the server, the schema cache refresh call is delayed by a few seconds. In the future this delay may change.
+* If the xtk:session#GetModifiedEntities API is not available, the auto refresh mechanism will silently stop automatically
+* If an error occurs while trying to refresh, a warning will be logged to the JavaScript console but the auto refresh will not be stopped. 
+
 ## Passwords
 
 External account passwords can be decrypted using a Cipher. This function is deprecated since version 1.0.0 since it's not guaranteed to work in future versions of Campaign (V8 and above)

--- a/compile.js
+++ b/compile.js
@@ -36,6 +36,7 @@ var resources = [
     { name: "./xtkEntityCache.js" },
     { name: "./methodCache.js" },
     { name: "./optionCache.js" },
+    { name: "./cacheRefresher.js" },
     { name: "./soap.js" },
     { name: "./crypto.js" },
     { name: "./application.js" },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1402,14 +1402,21 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001301",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001301.tgz",
-      "integrity": "sha512-csfD/GpHMqgEL3V3uIgosvh+SVIQvCh43SNu9HRbP1lnxkKm1kjDG4f32PP571JplkLjfS+mg2p1gxR7MYrrIA==",
+      "version": "1.0.30001378",
+      "resolved": "https://artifactory.corp.adobe.com/artifactory/api/npm/npm-adobe-release/caniuse-lite/-/caniuse-lite-1.0.30001378.tgz",
+      "integrity": "sha512-JVQnfoO7FK7WvU4ZkBRbPjaot4+YqxogSDosHv0Hv5mWpUESmN+UubMU6L/hGz8QlQ2aY5U0vR6MOs6j/CXpNA==",
       "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        }
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/catharsis": {
       "version": "0.9.0",
@@ -6147,9 +6154,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001301",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001301.tgz",
-      "integrity": "sha512-csfD/GpHMqgEL3V3uIgosvh+SVIQvCh43SNu9HRbP1lnxkKm1kjDG4f32PP571JplkLjfS+mg2p1gxR7MYrrIA==",
+      "version": "1.0.30001378",
+      "resolved": "https://artifactory.corp.adobe.com/artifactory/api/npm/npm-adobe-release/caniuse-lite/-/caniuse-lite-1.0.30001378.tgz",
+      "integrity": "sha512-JVQnfoO7FK7WvU4ZkBRbPjaot4+YqxogSDosHv0Hv5mWpUESmN+UubMU6L/hGz8QlQ2aY5U0vR6MOs6j/CXpNA==",
       "dev": true
     },
     "catharsis": {

--- a/src/cache.js
+++ b/src/cache.js
@@ -123,6 +123,7 @@ class SafeStorage {
     } catch(ex) { /* Ignore errors in safe class */
     }
   }
+
 }
 
 /**
@@ -243,7 +244,7 @@ class Cache {
 
   /**
    * Put a value from the cache
-   * @param {*} key the key or keys of the value to retreive
+   * @param {*} key the key or keys of the value to retrieve
    * @param {*} value the value to cache
    * @returns {CachedObject} a cached object containing the cached value
    */
@@ -265,6 +266,15 @@ class Cache {
   clear() {
       this._cache = {};
       this._saveLastCleared();
+  }
+
+  /**
+   * Remove a key from the cache
+   * @param {string} key the key to remove
+   */
+  remove(key) {
+      delete this._cache[key];
+      this._remove(key);
   }
 }
 

--- a/src/cacheRefresher.js
+++ b/src/cacheRefresher.js
@@ -1,0 +1,227 @@
+/*
+Copyright 2022 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+(function () {
+    "use strict";
+
+    const { DomUtil } = require("./domUtil.js");
+    const XtkCaster = require('./xtkCaster.js').XtkCaster;
+    const { Cache } = require('./cache.js');
+    const { CampaignException } = require('./campaign.js');
+
+    /**
+     * @private
+     * @class
+     * @constructor
+     * @memberof Campaign
+     */
+    class RefresherStateCache extends Cache {
+
+        /**
+         * A cache to store state of the refresher. Not intended to be used directly,
+         * but an internal cache for the Campaign.Client object
+         * 
+         * Cached object are made of
+         * - the key is the propertie name
+         * - the value is a string
+         * 
+         * @param {Storage} storage is an optional Storage object, such as localStorage or sessionStorage
+         * @param {string} rootKey is an optional root key to use for the storage object
+         * @param {number} ttl is the TTL for objects in ms. Defaults to 5 mins
+         */
+        constructor(storage, rootKey, ttl) {
+            super(storage, rootKey, ttl);
+        }
+
+        /**
+         * Cache a property of the refresh (buildNumber, last refresh time) and its value
+         * 
+         * @param {string} name is the propertie name
+         * @param {string} rawValue string value
+         */
+        put(name, rawValue) {
+            return super.put(name, { value: rawValue });
+        }
+
+        /**
+         * Get the value of a property of the refresh (buildNumber, last refresh time)
+         * 
+         * @param {string} name the propertie name
+         * @returns {*} the value
+         */
+        get(name) {
+            const option = super.get(name);
+            return option ? option.value : undefined;
+        }
+    }
+
+    class CacheRefresher {
+
+        /**
+        * A class to refresh regulary a Cache every n seconds, by sending a query to get the last modified entities.
+        * The refresh mechanism can be activated by calling client.startRefreshCaches().
+        * This mechanism depends on the xtk:session:GetModifiedEntities API which is introduced in ACC 8.4 and above.
+        *
+        * @param {Cache} cache is the cache to refresh
+        * @param {Client} client is the ACC API Client.
+        * @param {string} cacheSchemaId is the id of the schema present in the cache to be refreshed every 10 seconds
+        * @param {string} rootKey is used as the root key of cache items in the refresher state cache
+        */
+        constructor(cache, client, cacheSchemaId, rootKey) {
+            const connectionParameters = client._connectionParameters;
+            this._cache = cache;
+            this._client = client;
+            this._connectionParameters = connectionParameters;
+            this._cacheSchemaId = cacheSchemaId;
+
+            this._storage = connectionParameters._options._storage;
+            this._refresherStateCache  = new RefresherStateCache(this._storage, `${rootKey}.RefresherStateCache`, 1000*3600);
+
+            this._lastTime = undefined;
+            this._buildNumber = undefined;
+            this._intervalId = null;
+            this._running = false;
+        }
+
+        /**
+         * Start auto refresh
+         * @param {integer} refreshFrequency frequency of the refresh in ms (default value is 10,000 ms)
+         */
+        startAutoRefresh(refreshFrequency) {
+            if (this._intervalId != null) {
+                clearInterval(this._intervalId);
+            }
+            this._intervalId = setInterval(() => {
+                this._safeCallAndRefresh();
+            }, refreshFrequency || 10000); // every 10 seconds by default
+        }
+
+        // Protect _callAndRefresh from reentrance
+        async _safeCallAndRefresh() {
+            if (this._running) {
+                // This call is already running and maybe taking a long time to complete. Do not make things
+                // harder and just skip this run
+                return;
+            }
+            this._running = true;
+            try {
+                await this._callAndRefresh();
+            } catch(ex) {
+                if (ex.errorCode === "SDK-000010") {
+                    // client is not logged, this is not an error.
+                    return;
+                }
+                console.warn(`Failed to refresh cache for ${this._cacheSchemaId}`, ex);
+            }
+              finally {
+                this._running = false;
+            }
+        }
+
+        // Get last modified entities for the Campaign server and remove from cache last modified entities
+        async _callAndRefresh() {
+            const that = this;
+            const soapCall = this._client._prepareSoapCall("xtk:session", "GetModifiedEntities", true, this._connectionParameters._options.extraHttpHeaders);
+
+            if (this._lastTime === undefined) {
+                const storedTime = this._refresherStateCache.get("time");
+                if (storedTime != undefined) {
+                    this._lastTime = storedTime;
+                }
+            }
+            if (this._buildNumber === undefined) {
+                const storedBuildNumber = this._refresherStateCache.get("buildNumber");
+                if (storedBuildNumber != undefined) {
+                    this._buildNumber = storedBuildNumber;
+                }
+            }
+
+            // Use Json because xtk:schema does not work directly in DomUtil.parse(`<cache buildNumber="9469" time="2022-06-30T00:00:00.000"><xtk:schema></xtk:schema></cache>`);
+            // due to the colon character
+            let jsonCache;
+            if (this._lastTime === undefined || this._buildNumber === undefined) {
+                jsonCache = {
+                    [this._cacheSchemaId]: {}
+                };
+            } else {
+                jsonCache = {
+                    buildNumber: this._buildNumber,
+                    lastModified: this._lastTime,
+                    [this._cacheSchemaId]: {}
+                };
+            }
+
+            const xmlDoc = DomUtil.fromJSON("cache", jsonCache, 'SimpleJson');
+            soapCall.writeDocument("cacheEntities", xmlDoc);
+
+            // Client is not logged: do not attempt to refresh caches at all
+            if (!this._client.isLogged())
+              throw CampaignException.NOT_LOGGED_IN(soapCall, `Cannot call GetModifiedEntities: session not connected`);
+
+            // Do a soap call GetModifiedEntities instead of xtksession.GetModifiedEnties because we don't want to go through methodCache 
+            // which might not contain the method GetModifiedEntities just after a build updgrade from a old version of acc 
+            return this._client._makeSoapCall(soapCall)
+                .then(() => {
+                    let doc = soapCall.getNextDocument();
+                    soapCall.checkNoMoreArgs();
+                    doc = that._client._toRepresentation(doc, 'xml');
+                    that._lastTime = DomUtil.getAttributeAsString(doc, "time"); // save time to be able to send it as an attribute in the next soap call
+                    that._buildNumber = DomUtil.getAttributeAsString(doc, "buildNumber");
+                    that._refresh(doc);
+                    that._refresherStateCache.put("time", that._lastTime);
+                    that._refresherStateCache.put("buildNumber", that._buildNumber);
+                })
+                .catch((ex) => {
+                    // if the method GetModifiedEntities is not found in this acc version we disable the autoresfresh of the cache
+                    if (soapCall.methodName == "GetModifiedEntities" && ex.errorCode == "SOP-330006") {
+                        this.stopAutoRefresh();
+                    } else {
+                        throw ex;
+                    }
+                });
+        }
+
+        // Refresh Cache : remove entities modified recently listed in xmlDoc
+        _refresh(xmlDoc) {
+            const clearCache = XtkCaster.asBoolean(DomUtil.getAttributeAsString(xmlDoc, "emptyCache"));
+            if (clearCache == true) {
+                this._cache.clear();
+            } else {
+                var child = DomUtil.getFirstChildElement(xmlDoc, "entityCache");
+                while (child) {
+                    const pkSchemaId = DomUtil.getAttributeAsString(child, "pk");
+                    const schemaId = DomUtil.getAttributeAsString(child, "schema");
+                    if (schemaId === this._cacheSchemaId) {
+                        this._cache.remove(pkSchemaId);
+                        // Notify listeners to refresh in SchemaCache
+                        if (schemaId === "xtk:schema") {
+                            const schemaIds = pkSchemaId.split("|");
+                            this._client._notifyCacheChangeListeners(schemaIds[1]);
+                        }
+                    }
+                    child = DomUtil.getNextSiblingElement(child);
+                }
+            }
+        }
+
+        /**
+         * Stop auto refreshing the cache
+         */
+        stopAutoRefresh() {
+            clearInterval(this._intervalId);
+            this._intervalId = null;
+        }
+    }
+
+    // Public exports
+    exports.CacheRefresher = CacheRefresher;
+
+})();

--- a/test/application.test.js
+++ b/test/application.test.js
@@ -1097,7 +1097,6 @@ describe('Application', () => {
                     </GetEntityIfMoreRecentResponse>
                 </SOAP-ENV:Body>
                 </SOAP-ENV:Envelope>`));
-
                 const nodes = await link.joinNodes();
                 expect(nodes).toMatchObject([]);
                 const reverseLink = await link.reverseLink();
@@ -2157,3 +2156,4 @@ describe('Application', () => {
         })
     })
 });
+

--- a/test/cacheRefresher.test.js
+++ b/test/cacheRefresher.test.js
@@ -1,0 +1,338 @@
+/*
+Copyright 2022 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+
+/**********************************************************************************
+ * 
+ * Unit tests for the cache refresher
+ * 
+ *********************************************************************************/
+
+
+const sdk = require('../src/index.js');
+const { Cache } = require('../src/cache.js');
+const Mock = require('./mock.js').Mock;
+const CacheRefresher = require('../src/cacheRefresher.js').CacheRefresher;
+
+
+describe("CacheRefresher cache", function () {
+
+    it('Should call refresh', async () => {
+        const client =  await Mock.makeClient();
+        client._transport.mockReturnValueOnce(Mock.LOGON_RESPONSE);
+
+        await client.NLWS.xtkSession.logon();
+        const cache = new Cache();
+        const cacheRefresher = new CacheRefresher(cache, client, "xtk:schema", "rootkey");
+
+        client._transport.mockReturnValueOnce(Mock.GETMODIFIEDENTITIES_CLEAR_RESPONSE);
+        await cacheRefresher._callAndRefresh();
+        expect(cacheRefresher._refresherStateCache.get("buildNumber")).toBe("9469");
+        expect(cacheRefresher._refresherStateCache.get("time")).toBe("2022-07-28T14:38:55.766Z");
+
+        client._transport.mockReturnValueOnce(Mock.GETMODIFIEDENTITIES_CLEAR_RESPONSE);
+        await cacheRefresher._callAndRefresh();
+        expect(cacheRefresher._refresherStateCache.get("buildNumber")).toBe("9469");
+        expect(cacheRefresher._refresherStateCache.get("time")).toBe("2022-07-28T14:38:55.766Z");
+
+        client._transport.mockReturnValueOnce(Mock.LOGOFF_RESPONSE);
+        await client.NLWS.xtkSession.logoff();
+    });
+
+    it('Should call refresh after 1 seconds', async () => {
+        const connectionParameters = sdk.ConnectionParameters.ofUserAndPassword("http://acc-sdk:8080", "admin", "admin");
+        const client = await sdk.init(connectionParameters);
+        client._transport = jest.fn();
+
+        client._transport.mockReturnValueOnce(Mock.LOGON_RESPONSE);
+
+        await client.NLWS.xtkSession.logon();
+        expect(client.isLogged()).toBeTruthy();
+        const cache = new Cache();
+
+        const cacheRefresher = new CacheRefresher(cache, client, "xtk:schema", "rootkey");
+
+        expect(cacheRefresher._refresherStateCache.get("buildNumber")).toBeUndefined();
+        expect(cacheRefresher._refresherStateCache.get("time")).toBeUndefined();
+        client._transport.mockReturnValue(Promise.resolve(Mock.GETMODIFIEDENTITIES_CLEAR_RESPONSE));
+        jest.useFakeTimers();
+        cacheRefresher.startAutoRefresh(5000);
+        jest.advanceTimersByTime(6000);
+        jest.useRealTimers();
+        
+        // to allow soap call to finish
+        await new Promise(process.nextTick);
+
+        expect(cacheRefresher._refresherStateCache.get("buildNumber")).toBe("9469");
+        expect(cacheRefresher._refresherStateCache.get("time")).toBe("2022-07-28T14:38:55.766Z");
+
+        cacheRefresher.stopAutoRefresh();
+        client._transport.mockReturnValueOnce(Mock.LOGOFF_RESPONSE);
+        await client.NLWS.xtkSession.logoff();
+    });
+
+    it('Should send buildNumber when call refresh', async () => {
+        const client = await Mock.makeClient();
+        const logs = await Mock.withMockConsole(async () => {
+            client.traceAPICalls(true);
+            client._transport.mockReturnValueOnce(Mock.LOGON_RESPONSE);
+
+            await client.NLWS.xtkSession.logon();
+
+            const cache = new Cache();
+
+            const cacheRefresher = new CacheRefresher(cache, client, "xtk:schema", "rootkey");
+            cacheRefresher._refresherStateCache.put("buildNumber", "9469");
+            cacheRefresher._refresherStateCache.put("time", "2022-07-28T14:38:55.766Z");
+
+            client._transport.mockReturnValueOnce(Mock.GETMODIFIEDENTITIES_CLEAR_RESPONSE);
+            await cacheRefresher._callAndRefresh();
+            expect(cacheRefresher._refresherStateCache.get("buildNumber")).toBe("9469");
+            expect(cacheRefresher._refresherStateCache.get("time")).toBe("2022-07-28T14:38:55.766Z");
+
+            client._transport.mockReturnValueOnce(Mock.LOGOFF_RESPONSE);
+
+
+            await client.NLWS.xtkSession.logoff();
+
+        })
+        expect(logs.length).toBe(6);
+        expect(logs[0]).toMatch(/SOAP.*request.*Logon/is)
+        expect(logs[1]).toMatch(/SOAP.*response.*LogonResponse/is)
+        expect(logs[2]).toMatch(/SOAP.*request.*buildNumber.*9469.*2022-07-28T14:38:55.766Z.*GetModifiedEntities*/is)
+        expect(logs[3]).toMatch(/SOAP.*response.*GetModifiedEntitiesResponse/is)
+        expect(logs[4]).toMatch(/SOAP.*request.*Logoff/is)
+        expect(logs[5]).toMatch(/SOAP.*response.*LogoffResponse/is)
+    });
+
+    it('Should refresh cache', async () => {
+        const client = await Mock.makeClient();
+        client._transport.mockReturnValueOnce(Mock.LOGON_RESPONSE);
+
+        await client.NLWS.xtkSession.logon();
+        const cache = new Cache();
+        const cacheRefresher = new CacheRefresher(cache, client, "xtk:schema", "rootkey");
+
+        cache.put("xtk:schema|nms:recipient", "<content recipient>");
+        cache.put("xtk:schema|nms:replicationStrategy", "<content xtk:schema|nms:replicationStrategy>");
+        cache.put("xtk:schema|nms:operation", "<content xtk:schema|nms:operation>");
+        expect(cache.get("xtk:schema|nms:recipient")).toBe("<content recipient>");
+        expect(cache.get("xtk:schema|nms:replicationStrategy")).toBe("<content xtk:schema|nms:replicationStrategy>");
+        expect(cache.get("xtk:schema|nms:operation")).toBe("<content xtk:schema|nms:operation>");
+
+        client._transport.mockReturnValueOnce(Mock.GETMODIFIEDENTITIES_SCHEMA_RESPONSE);
+        await cacheRefresher._callAndRefresh();
+        expect(cacheRefresher._refresherStateCache.get("buildNumber")).toBe("9469");
+        expect(cacheRefresher._refresherStateCache.get("time")).toBe("2022-07-28T15:32:00.785Z");
+        expect(cache.get("xtk:schema|nms:recipient")).toBeUndefined();
+        expect(cache.get("xtk:schema|nms:replicationStrategy")).toBeUndefined();
+        expect(cache.get("xtk:schema|nms:operation")).toBe("<content xtk:schema|nms:operation>");
+
+        client._transport.mockReturnValueOnce(Mock.LOGOFF_RESPONSE);
+        await client.NLWS.xtkSession.logoff();
+    });
+
+    it('Should stop refresh if method not exist', async () => {
+        const client = await Mock.makeClient();
+        client._transport.mockReturnValueOnce(Mock.LOGON_RESPONSE);
+
+        await client.NLWS.xtkSession.logon();
+        const cache = new Cache();
+        const cacheRefresher = new CacheRefresher(cache, client, "xtk:schema", "rootkey");
+
+        cacheRefresher.startAutoRefresh();
+
+        client._transport.mockReturnValueOnce(Mock.GETMODIFIEDENTITIES_UNDEFINED_RESPONSE);
+        await cacheRefresher._callAndRefresh();
+        expect(cacheRefresher._refresherStateCache.get("buildNumber")).toBeUndefined();
+        expect(cacheRefresher._refresherStateCache.get("time")).toBeUndefined();
+        expect(cacheRefresher._intervalId).toBeNull();
+
+        client._transport.mockReturnValueOnce(Mock.LOGOFF_RESPONSE);
+        await client.NLWS.xtkSession.logoff();
+    });
+
+    it('Should not stop refresh if error different from undefined', async () => {
+        const client = await Mock.makeClient();
+        client._transport.mockReturnValueOnce(Mock.LOGON_RESPONSE);
+
+        await client.NLWS.xtkSession.logon();
+        const cache = new Cache();
+        const cacheRefresher = new CacheRefresher(cache, client, "xtk:schema", "rootkey");
+
+        cacheRefresher.startAutoRefresh();
+
+        client._transport.mockReturnValueOnce(Mock.GETMODIFIEDENTITIES_ERROR_RESPONSE);
+        try {
+            await cacheRefresher._callAndRefresh();
+            fail('exception is expected');
+        } catch (e) {
+            expect(e).not.toBeNull();
+        }
+        expect(cacheRefresher._refresherStateCache.get("buildNumber")).toBeUndefined();
+        expect(cacheRefresher._refresherStateCache.get("time")).toBeUndefined();
+        expect(cacheRefresher._intervalId).not.toBeNull();
+
+        cacheRefresher.stopAutoRefresh();
+        client._transport.mockReturnValueOnce(Mock.LOGOFF_RESPONSE);
+        await client.NLWS.xtkSession.logoff();
+    });
+
+    it('Should be able to call start refresh twice', async () => {
+        const client = await Mock.makeClient();
+        client._transport.mockReturnValueOnce(Mock.LOGON_RESPONSE);
+
+        await client.NLWS.xtkSession.logon();
+        const cache = new Cache();
+        const cacheRefresher = new CacheRefresher(cache, client, "xtk:schema", "rootkey");
+
+        jest.useFakeTimers();
+        cacheRefresher.startAutoRefresh(100000);
+        expect(cacheRefresher._intervalId).not.toBeNull();
+        const firstIntervalId = cacheRefresher._intervalId;
+        cacheRefresher.startAutoRefresh(5000);
+        expect(cacheRefresher._intervalId).not.toBeNull();
+        expect(cacheRefresher._intervalId != firstIntervalId);
+
+        client._transport.mockReturnValueOnce(Mock.GETMODIFIEDENTITIES_CLEAR_RESPONSE);
+        
+        jest.advanceTimersByTime(6000);
+        jest.useRealTimers();
+
+        // to allow soap call to finish
+        await new Promise(process.nextTick);
+
+        expect(cacheRefresher._refresherStateCache.get("buildNumber")).toBe("9469");
+        expect(cacheRefresher._refresherStateCache.get("time")).toBe("2022-07-28T14:38:55.766Z");
+
+        cacheRefresher.stopAutoRefresh();
+        client._transport.mockReturnValueOnce(Mock.LOGOFF_RESPONSE);
+        await client.NLWS.xtkSession.logoff();
+    });
+
+    it('Should notify when refresh cache', async () => {
+        const client = await Mock.makeClient();
+        client._transport.mockReturnValueOnce(Mock.LOGON_RESPONSE);
+
+
+        class Listener {
+            constructor() {
+                this._schemas = {};
+            }
+            add(schemaId) {
+                this._schemas[schemaId] = "1";
+            }
+
+            invalidateCacheItem(schemaId) {
+                this._schemas[schemaId] = undefined;
+            }
+            getSchema(schemaId) {
+                return this._schemas[schemaId];
+            }
+        }
+
+        let listener = new Listener();
+        client._registerCacheChangeListener(listener);
+
+        await client.NLWS.xtkSession.logon();
+        const cache = new Cache();
+        const cacheRefresher = new CacheRefresher(cache, client, "xtk:schema", "rootkey");
+
+        cache.put("xtk:schema|nms:recipient", "<content recipient>");
+        cache.put("xtk:schema|nms:replicationStrategy", "<content xtk:schema|nms:replicationStrategy>");
+        cache.put("xtk:schema|nms:operation", "<content xtk:schema|nms:operation>");
+
+        listener.add("nms:recipient");
+
+        client._transport.mockReturnValueOnce(Mock.GETMODIFIEDENTITIES_SCHEMA_RESPONSE);
+        await cacheRefresher._callAndRefresh();
+
+        expect(listener.getSchema("nms:recipient")).toBeUndefined();
+
+        client._transport.mockReturnValueOnce(Mock.LOGOFF_RESPONSE);
+        await client.NLWS.xtkSession.logoff();
+        client._unregisterCacheChangeListener(listener);
+    });
+
+    it('Should protect callAndRefresh from re-entrance', async () => {
+        const client = await Mock.makeClient();
+        client._transport.mockReturnValueOnce(Mock.LOGON_RESPONSE);
+        await client.NLWS.xtkSession.logon();
+        const cache = new Cache();
+        const cacheRefresher = new CacheRefresher(cache, client, "xtk:schema", "rootkey");
+        let count = 0;
+        cacheRefresher._callAndRefresh = jest.fn(() => { count = count + 1 });
+        expect(cacheRefresher._running).toBe(false);
+        await cacheRefresher._callAndRefresh();
+        expect(count).toBe(1);
+        expect(cacheRefresher._running).toBe(false);
+        await cacheRefresher._safeCallAndRefresh();
+        expect(count).toBe(2);
+        expect(cacheRefresher._running).toBe(false);
+
+        cacheRefresher._running = true;
+        await cacheRefresher._safeCallAndRefresh();
+        expect(count).toBe(2); // should not have been called since already executing
+    })
+
+    it('Throw CampaignException when calling _callAndRefresh without logon', async () => {
+        const client = await Mock.makeClient();
+        const cache = new Cache();
+        const cacheRefresher = new CacheRefresher(cache, client, "xtk:schema", "rootkey");
+
+        try {
+            await cacheRefresher._callAndRefresh();
+             fail('exception is expected');
+         } catch (e) {
+             expect(e.name).toBe("CampaignException");
+             expect(e.errorCode).toBe("SDK-000010");
+         }
+    });
+
+    it('Ignore error when calling _safeCallAndRefresh without logon', async () => {
+        const client = await Mock.makeClient();
+        const cache = new Cache();
+        const cacheRefresher = new CacheRefresher(cache, client, "xtk:schema", "rootkey");
+
+        try {
+            await cacheRefresher._safeCallAndRefresh();
+        } catch (e) {
+            fail('exception is not expected');
+         }
+    });
+
+    it('Catch error in soap call GetModifiedEntities and display a warning', async () => {
+        const client = await Mock.makeClient();
+        client._transport.mockReturnValueOnce(Mock.LOGON_RESPONSE);
+
+        await client.NLWS.xtkSession.logon();
+        const cache = new Cache();
+        const cacheRefresher = new CacheRefresher(cache, client, "xtk:schema", "rootkey");
+
+        client._transport.mockReturnValueOnce(Mock.GETMODIFIEDENTITIES_ERROR_RESPONSE);
+        try {
+          jest.useFakeTimers();
+          cacheRefresher.startAutoRefresh(5000);
+          jest.advanceTimersByTime(6000);
+          jest.useRealTimers();
+
+          // to allow soap call to finish
+          await new Promise(process.nextTick);
+        } catch (e) {
+            fail('exception is not expected');
+        }
+
+        cacheRefresher.stopAutoRefresh();
+        client._transport.mockReturnValueOnce(Mock.LOGOFF_RESPONSE);
+        await client.NLWS.xtkSession.logoff();
+    });
+});

--- a/test/caches.test.js
+++ b/test/caches.test.js
@@ -54,7 +54,22 @@ describe('Caches', function() {
             cache.clear();
             expect(cache.get("Hello")).toBeUndefined();
         })
-    })
+
+        it("Should remove key in cache", () => {
+            const cache = new Cache();
+            cache.put("Hello", "World");
+            cache.put("Hi", "A");
+            expect(cache.get("Hello")).toBe("World");
+            expect(cache.get("Hi")).toBe("A");
+            cache.remove("Hello");
+            expect(cache.get("Hello")).toBeUndefined();
+            expect(cache.get("Hi")).toBe("A");
+            // should support removing a key which has already been removed
+            cache.remove("Hello");
+            expect(cache.get("Hello")).toBeUndefined();
+            expect(cache.get("Hi")).toBe("A");
+        })
+    });
 
     describe("Entity cache", function() {
         it("Should cache value", function() {

--- a/test/mock.js
+++ b/test/mock.js
@@ -614,7 +614,67 @@ const GET_HELLO_RESPONSE = Promise.resolve(`<?xml version='1.0'?>
     </SOAP-ENV:Body>
     </SOAP-ENV:Envelope>`);
 
+const GETMODIFIEDENTITIES_RESPONSE = Promise.resolve(`<?xml version='1.0'?>
+    <SOAP-ENV:Envelope xmlns:xsd='http://www.w3.org/2001/XMLSchema' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xmlns:ns='urn:xtk:session' xmlns:SOAP-ENV='http://schemas.xmlsoap.org/soap/envelope/'>
+    <SOAP-ENV:Body>
+        <GetModifiedEntitiesResponse xmlns='urn:xtk:session' SOAP-ENV:encodingStyle='http://schemas.xmlsoap.org/soap/encoding/'>
+           <pdomDirtyEntities xsi:type='ns:Element' SOAP-ENV:encodingStyle='http://xml.apache.org/xml-soap/literalxml'>
+                <cache buildNumber="9468" time="2022-07-27T14:38:55.766Z"/>
+            </pdomDirtyEntities>
+        </GetModifiedEntitiesResponse>
+    </SOAP-ENV:Body>
+    </SOAP-ENV:Envelope>`);
 
+const GETMODIFIEDENTITIES_CLEAR_RESPONSE = Promise.resolve(`<?xml version='1.0'?>
+    <SOAP-ENV:Envelope xmlns:xsd='http://www.w3.org/2001/XMLSchema' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xmlns:ns='urn:xtk:session' xmlns:SOAP-ENV='http://schemas.xmlsoap.org/soap/envelope/'>
+    <SOAP-ENV:Body>
+        <GetModifiedEntitiesResponse xmlns='urn:xtk:session' SOAP-ENV:encodingStyle='http://schemas.xmlsoap.org/soap/encoding/'>
+            <pdomDirtyEntities xsi:type='ns:Element' SOAP-ENV:encodingStyle='http://xml.apache.org/xml-soap/literalxml'>
+                <cache buildNumber="9469" time="2022-07-28T14:38:55.766Z" emptyCache="true"/>
+            </pdomDirtyEntities>
+        </GetModifiedEntitiesResponse>
+    </SOAP-ENV:Body>
+    </SOAP-ENV:Envelope>`);
+
+
+const GETMODIFIEDENTITIES_SCHEMA_RESPONSE = Promise.resolve(`<?xml version='1.0'?>
+    <SOAP-ENV:Envelope xmlns:xsd='http://www.w3.org/2001/XMLSchema' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xmlns:ns='urn:xtk:session' xmlns:SOAP-ENV='http://schemas.xmlsoap.org/soap/envelope/'>
+    <SOAP-ENV:Body>
+        <GetModifiedEntitiesResponse xmlns='urn:xtk:session' SOAP-ENV:encodingStyle='http://schemas.xmlsoap.org/soap/encoding/'>
+           <pdomDirtyEntities xsi:type='ns:Element' SOAP-ENV:encodingStyle='http://xml.apache.org/xml-soap/literalxml'>
+              <cache buildNumber="9469" time="2022-07-28T15:32:00.785Z">
+                 <entityCache lastModified="2022-07-28 15:31:56.331Z" md5="5581959609FEC4B2A9CDBD171BA42E7D" pk="xtk:schema|nms:recipient" schema="xtk:schema"/>
+                 <entityCache lastModified="2022-07-28 15:31:56.353Z" md5="B27CC681D00C3FA85DDA0B210FE76566" pk="xtk:schema|nms:replicationStrategy" schema="xtk:schema"/>
+                 <entityCache lastModified="2022-07-28 15:31:56.478Z" md5="E39D051D4D00805693EBA4F72F5ABD7D" pk="xtk:schema|nms:recipientStg" schema="xtk:schema"/>
+                 <entityCache lastModified="2022-07-28 15:31:56.440Z" md5="23B1FE988F0DCDC88C9F96D06C97FA14" pk="xtk:schema|xxl:xtkFolderXl" schema="xtk:schema"/>
+                 <entityCache lastModified="2022-07-28 15:31:56.440Z" md5="23B1FE988F0DCDC88C9F96D06C97FA14" pk="xtk:schema|nms:extAccount" schema="xtk:schema"/>
+                 <entityCache lastModified="2022-07-28 15:31:56.440Z" md5="23B1FE988F0DCDC88C9F96D06C97FA14" pk="xtk:option|testOption" schema="xtk:option"/>
+              </cache>
+           </pdomDirtyEntities>
+        </GetModifiedEntitiesResponse>
+    </SOAP-ENV:Body>
+    </SOAP-ENV:Envelope>`);
+
+
+const GETMODIFIEDENTITIES_UNDEFINED_RESPONSE = Promise.resolve(`<?xml version='1.0'?>
+    <SOAP-ENV:Envelope xmlns:xsd='http://www.w3.org/2001/XMLSchema' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xmlns:SOAP-ENV='http://schemas.xmlsoap.org/soap/envelope/'>
+    <SOAP-ENV:Body>
+    <SOAP-ENV:Fault>
+       <faultcode>SOAP-ENV:Client</faultcode>
+       <faultstring xsi:type='xsd:string'>SOP-330006 The method 'GetModifiedEntities' is not defined in SOAP service 'xtk:session'.</faultstring>
+    </SOAP-ENV:Fault>
+    </SOAP-ENV:Body>
+    </SOAP-ENV:Envelope>`);
+
+const GETMODIFIEDENTITIES_ERROR_RESPONSE = Promise.resolve(`<?xml version='1.0'?>
+    <SOAP-ENV:Envelope xmlns:xsd='http://www.w3.org/2001/XMLSchema' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xmlns:SOAP-ENV='http://schemas.xmlsoap.org/soap/envelope/'>
+    <SOAP-ENV:Body>
+    <SOAP-ENV:Fault>
+       <faultcode>SOAP-ENV:Client</faultcode>
+       <faultstring xsi:type='xsd:string'>SOP-330011 Error while executing the method 'GetModifiedEntities' of service 'xtk:session'.</faultstring>
+    </SOAP-ENV:Fault>
+    </SOAP-ENV:Body>
+    </SOAP-ENV:Envelope>`);
 
 // Public exports
 exports.Mock = {
@@ -656,5 +716,10 @@ exports.Mock = {
   GET_SETELEMENT_RESPONSE: GET_SETELEMENT_RESPONSE,
   GET_GETSCHEMA_HELLO_RESPONSE: GET_GETSCHEMA_HELLO_RESPONSE,
   GET_HELLO_RESPONSE: GET_HELLO_RESPONSE,
-  LOGON_RESPONSE_NO_USERINFO: LOGON_RESPONSE_NO_USERINFO
+  LOGON_RESPONSE_NO_USERINFO: LOGON_RESPONSE_NO_USERINFO,
+  GETMODIFIEDENTITIES_RESPONSE: GETMODIFIEDENTITIES_RESPONSE,
+  GETMODIFIEDENTITIES_CLEAR_RESPONSE: GETMODIFIEDENTITIES_CLEAR_RESPONSE,
+  GETMODIFIEDENTITIES_SCHEMA_RESPONSE: GETMODIFIEDENTITIES_SCHEMA_RESPONSE,
+  GETMODIFIEDENTITIES_UNDEFINED_RESPONSE: GETMODIFIEDENTITIES_UNDEFINED_RESPONSE,
+  GETMODIFIEDENTITIES_ERROR_RESPONSE: GETMODIFIEDENTITIES_ERROR_RESPONSE
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Send a query to acc nlserver server every 10 seconds to check if an entities has been modified.

## Related Issue

Change on schema are not visible : if a schema is extended , the extension is not visible the old version of the schema is still present

## Motivation and Context

If an entity is modified we have to wait 5 minutes before seeing the change or change is never saw because there is no refresh  behavior

## How Has This Been Tested?

Manual test with the new web ui, with a index.js page.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
