### PR TITLE
* Added documentation about auto-refresh caches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This is a node.js SDK for Campaign API. It exposes the Campaign API exactly like
 
 # Changelog 
 
+## Version 1.1.6
+_2022_08_16_
+
+* New auto-refresh mechanism to keep schemas and option caches up-to-date. See `client.startRefreshCaches` and `client.stopRefreshCaches` functions.
+
 ## Version 1.1.5
 _2022/07/07__
 

--- a/README.md
+++ b/README.md
@@ -695,7 +695,7 @@ It is also possible to setup one's own persistent cache, by passing a `storage` 
 
 ## Auto-refresh caches
 
-The SDK includes a mechnism to maintain the schemas and options caches up-to-date by polling the Campaign server on a regular basis (10 seconds by default). The server returns the list of entities (schemas or options) which have changed since they were cached, and the client removes them from the cache.
+The SDK includes a mechnism to maintain the schemas and options caches up-to-date by polling the Campaign server on a regular basis (10 seconds by default). The server returns the list of entities (schemas or options) which have changed since they were cached, and the client removes them from the cache. When a schema changes, the corresponding methods are also removed from the method cache.
 
 This mechanism is not activate by default but can be activated or deactivated by the following functions
 
@@ -704,6 +704,12 @@ client.startRefreshCaches(30000);   // activate cache auto-refresh mechanism eve
 client.stopRefreshCaches();         // de-activate cache auto-refresh
 ```
 
+This mechanism is based on the `xtk:session#GetModifiedEntities` SOAP method which is only available in Campaign 8.4 and above only. For other builds of Campaign, the auto-refresh mechanism will not do anything. 
+
+The following changes are handled:
+* If the build number has changed, the whole cache is cleared
+* If more than 10 schemas or options have changed, the whole cache is cleared
+* if less than 10 schemas or options have changed, only those entities are removed from the cache
 
 ## Passwords
 

--- a/README.md
+++ b/README.md
@@ -693,6 +693,18 @@ It's possible to disable persistent caches using the `noStorage` connection opti
 It is also possible to setup one's own persistent cache, by passing a `storage` object as a connection option. This object should implement 3 methods: `getItem`, `setItem`, and `removeItem` (synchronous)
 
 
+## Auto-refresh caches
+
+The SDK includes a mechnism to maintain the schemas and options caches up-to-date by polling the Campaign server on a regular basis (10 seconds by default). The server returns the list of entities (schemas or options) which have changed since they were cached, and the client removes them from the cache.
+
+This mechanism is not activate by default but can be activated or deactivated by the following functions
+
+```js
+client.startRefreshCaches(30000);   // activate cache auto-refresh mechanism every 30s
+client.stopRefreshCaches();         // de-activate cache auto-refresh
+```
+
+
 ## Passwords
 
 External account passwords can be decrypted using a Cipher. This function is deprecated since version 1.0.0 since it's not guaranteed to work in future versions of Campaign (V8 and above)

--- a/src/application.js
+++ b/src/application.js
@@ -1241,12 +1241,12 @@ class Application {
         }
     }
 
-    registerCacheChangeListener() {
-        this.client.registerCacheChangeListener(this._schemaCache);
+    _registerCacheChangeListener() {
+        this.client._registerCacheChangeListener(this._schemaCache);
     }
 
-    unregisterCacheChangeListener() {
-        this.client.unregisterCacheChangeListener(this._schemaCache);
+    _unregisterCacheChangeListener() {
+        this.client._unregisterCacheChangeListener(this._schemaCache);
     }
     /**
      * Get a schema by id. This function returns an XtkSchema object or null if the schema is not found.

--- a/src/cacheRefresher.js
+++ b/src/cacheRefresher.js
@@ -65,17 +65,16 @@ governing permissions and limitations under the License.
     class CacheRefresher {
 
         /**
-        * A class to refresh regulary a Cache every 10 seconds, by sending a query to get the last modified entities
-        * it hould be used in a client.
+        * A class to refresh regulary a Cache every 10 seconds, by sending a query to get the last modified entities.
+        * The refresh mechanism can be activated by calling client.startRefreshCaches()
         *
         * @param {Cache} cache is the cache to refresh
         * @param {Client} client is the ACC API Client.
-        * @param {ConnectionParameters} connectionParameters used to created the client provide as parameter
-        * @param {string} cacheSchema is the schema present in the cache to be refreshed every 10 seconds
-        * @param {string} rootKey is an optional root key to use for the storage object
+        * @param {string} cacheSchema is the id of the schema present in the cache to be refreshed every 10 seconds
+        * @param {string} rootKey is used as the root key of cache items in the refresher state cache
         */
-        constructor(cache, client, connectionParameters, cacheSchema, rootKey) {
-
+        constructor(cache, client, cacheSchema, rootKey) {
+            const connectionParameters = client._connectionParameters;
             this._cache = cache;
             this._client = client;
             this._connectionParameters = connectionParameters;
@@ -84,26 +83,24 @@ governing permissions and limitations under the License.
             this._storage = connectionParameters._options._storage;
             this._refresherStateCache  = new RefresherStateCache(this._storage, `${rootKey}.RefresherStateCache`, 1000*3600);
 
-            this._lastTime;
-            this._buildNumber;
+            this._lastTime = undefined;
+            this._buildNumber = undefined;
             this._intervalId = null;
         }
 
         /**
          * Start auto refresh
-         * @param {any} refreshFrequency frequency of the refresh in ms ( default velue is 10 000 ms)
+         * @param {integer} refreshFrequency frequency of the refresh in ms ( default velue is 10 000 ms)
          */
         startAutoRefresh(refreshFrequency) {
             if (this._intervalId != null) {
                 clearInterval(this._intervalId);
             }
-            this._intervalId = setInterval(() => this.callAndRefresh(), refreshFrequency || 10000); // every 10 seconds by default
+            this._intervalId = setInterval(() => this._callAndRefresh(), refreshFrequency || 10000); // every 10 seconds by default
         }
 
-        /**
-         * Get last modified entities and remove from cache last modified entities
-         */
-        callAndRefresh() {
+        // Get last modified entities for the Campaign server and remove from cache last modified entities
+        _callAndRefresh() {
             const that = this;
             const soapCall = this._client._prepareSoapCall("xtk:session", "GetModifiedEntities", true, this._connectionParameters._options.extraHttpHeaders);
 
@@ -126,13 +123,13 @@ governing permissions and limitations under the License.
             if (this._lastTime === undefined || this._buildNumber === undefined) {
                 jsonCache = {
                     [this._cacheSchema]: {}
-                }
+                };
             } else {
                 jsonCache = {
                     buildNumber: this._buildNumber,
                     lastModified: this._lastTime,
                     [this._cacheSchema]: {}
-                }
+                };
             }
 
             const xmlDoc = DomUtil.fromJSON("cache", jsonCache, 'SimpleJson');
@@ -147,7 +144,7 @@ governing permissions and limitations under the License.
                     doc = that._client._toRepresentation(doc, 'xml');
                     that._lastTime = DomUtil.getAttributeAsString(doc, "time"); // save time to be able to send it as an attribute in the next soap call
                     that._buildNumber = DomUtil.getAttributeAsString(doc, "buildNumber");
-                    that.refresh(doc);
+                    that._refresh(doc);
                     that._refresherStateCache.put("time", that._lastTime);
                     that._refresherStateCache.put("buildNumber", that._buildNumber);
                     Promise.resolve();
@@ -163,7 +160,7 @@ governing permissions and limitations under the License.
         }
 
         // Refresh Cache : remove entities modified recently listed in xmlDoc
-        refresh(xmlDoc) {
+        _refresh(xmlDoc) {
             const clearCache = XtkCaster.asBoolean(DomUtil.getAttributeAsString(xmlDoc, "emptyCache"));
             if (clearCache == true) {
                 this._cache.clear();
@@ -185,6 +182,9 @@ governing permissions and limitations under the License.
             }
         }
 
+        /**
+         * Stop auto refreshing the cache
+         */
         stopAutoRefresh() {
             clearInterval(this._intervalId);
             this._intervalId = null;

--- a/src/client.js
+++ b/src/client.js
@@ -533,10 +533,10 @@ class Client {
         const rootKey = `acc.js.sdk.${sdk.getSDKVersion().version}.${instanceKey}.cache`;
 
         this._entityCache = new XtkEntityCache(this._storage, `${rootKey}.XtkEntityCache`, connectionParameters._options.entityCacheTTL);
-        this._entityCacheRefresher = new CacheRefresher(this._entityCache, this, connectionParameters, "xtk:schema", `${rootKey}.XtkEntityCache`);
+        this._entityCacheRefresher = new CacheRefresher(this._entityCache, this, "xtk:schema", `${rootKey}.XtkEntityCache`);
         this._methodCache = new MethodCache(this._storage, `${rootKey}.MethodCache`, connectionParameters._options.methodCacheTTL);
         this._optionCache = new OptionCache(this._storage, `${rootKey}.OptionCache`, connectionParameters._options.optionCacheTTL);
-        this._optionCacheRefresher = new CacheRefresher(this._optionCache, this, connectionParameters, "xtk:option", `${rootKey}.OptionCache`);
+        this._optionCacheRefresher = new CacheRefresher(this._optionCache, this, "xtk:option", `${rootKey}.OptionCache`);
         this.NLWS = new Proxy(this, clientHandler());
 
         this._transport = connectionParameters._options.transport;
@@ -853,7 +853,7 @@ class Client {
             that._sessionToken = credentials._sessionToken;
             that._securityToken = "";
             that.application = new Application(that);
-            that.application.registerCacheChangeListener();
+            that.application._registerCacheChangeListener();
             return Promise.resolve();
         }
         else if (credentials._type == "SecurityToken") {
@@ -862,7 +862,7 @@ class Client {
             that._sessionToken = "";
             that._securityToken = credentials._securityToken;
             that.application = new Application(that);
-            that.application.registerCacheChangeListener();
+            that.application._registerCacheChangeListener();
             return Promise.resolve();
         }
         else if (credentials._type == "UserPassword" || credentials._type == "BearerToken") {
@@ -914,7 +914,7 @@ class Client {
                 that._securityToken = securityToken;
 
                 that.application = new Application(that);
-                that.application.registerCacheChangeListener();
+                that.application._registerCacheChangeListener();
             });
         }
         else {
@@ -940,12 +940,13 @@ class Client {
     logoff() {
         var that = this;
         if (!that.isLogged()) return;
-        that.application.unregisterCacheChangeListener();
+        that.application._unregisterCacheChangeListener();
+        that._unregisterAllCacheChangeListeners();
         this.stopRefreshCaches();
         const credentials = this._connectionParameters._credentials;
         if (credentials._type != "SessionToken" && credentials._type != "AnonymousUser") {
             var soapCall = that._prepareSoapCall("xtk:session", "Logoff", false, this._connectionParameters._options.extraHttpHeaders);
-                return this._makeSoapCall(soapCall).then(function() {
+            return this._makeSoapCall(soapCall).then(function() {
                 that._sessionToken = "";
                 that._securityToken = "";
                 that.application = null;
@@ -1057,11 +1058,14 @@ class Client {
         this._entityCacheRefresher.stopAutoRefresh();
     }
 
-    registerCacheChangeListener(listener) {
+    // Register a callback to be called when a schema has been modified and should be removed
+    // from the caches
+    _registerCacheChangeListener(listener) {
         this._cacheChangeListeners.push(listener);
     }
 
-    unregisterCacheChangeListener(listener) {
+    // Unregister a cache change listener
+    _unregisterCacheChangeListener(listener) {
         for (var i = 0; i < this._cacheChangeListeners.length; i++) {
             if (this._cacheChangeListeners[i] == listener) {
                 this._cacheChangeListeners.splice(i, 1);
@@ -1070,10 +1074,10 @@ class Client {
         }
     }
 
-    unregisterAllCacheChangeListeners() {
+    // Unregister all cache change listener
+    _unregisterAllCacheChangeListeners() {
         this._cacheChangeListeners = [];
     }
-
 
     _notifyCacheChangeListeners(schemaId) {
         this._cacheChangeListeners.map((listener) => listener.refreshCache(schemaId));

--- a/test/cacheRefresher.test.js
+++ b/test/cacheRefresher.test.js
@@ -27,21 +27,20 @@ const CacheRefresher = require('../src/cacheRefresher.js').CacheRefresher;
 describe("CacheRefresher cache", function () {
 
     it('Should call refresh', async () => {
-        const client = await Mock.makeClient();
+        const client =  await Mock.makeClient();
         client._transport.mockReturnValueOnce(Mock.LOGON_RESPONSE);
 
         await client.NLWS.xtkSession.logon();
         const cache = new Cache();
-        const connectionParameters = sdk.ConnectionParameters.ofUserAndPassword("http://acc-sdk:8080", "admin", "admin");
-        const cacheRefresher = new CacheRefresher(cache, client, connectionParameters, "xtk:schema", "rootkey");
+        const cacheRefresher = new CacheRefresher(cache, client, "xtk:schema", "rootkey");
 
         client._transport.mockReturnValueOnce(Mock.GETMODIFIEDENTITIES_CLEAR_RESPONSE);
-        await cacheRefresher.callAndRefresh();
+        await cacheRefresher._callAndRefresh();
         expect(cacheRefresher._refresherStateCache.get("buildNumber")).toBe("9469");
         expect(cacheRefresher._refresherStateCache.get("time")).toBe("2022-07-28T14:38:55.766Z");
 
         client._transport.mockReturnValueOnce(Mock.GETMODIFIEDENTITIES_CLEAR_RESPONSE);
-        await cacheRefresher.callAndRefresh();
+        await cacheRefresher._callAndRefresh();
         expect(cacheRefresher._refresherStateCache.get("buildNumber")).toBe("9469");
         expect(cacheRefresher._refresherStateCache.get("time")).toBe("2022-07-28T14:38:55.766Z");
 
@@ -60,7 +59,7 @@ describe("CacheRefresher cache", function () {
         expect(client.isLogged()).toBeTruthy();
         const cache = new Cache();
 
-        const cacheRefresher = new CacheRefresher(cache, client, connectionParameters, "xtk:schema", "rootkey");
+        const cacheRefresher = new CacheRefresher(cache, client, "xtk:schema", "rootkey");
 
         expect(cacheRefresher._refresherStateCache.get("buildNumber")).toBeUndefined();
         expect(cacheRefresher._refresherStateCache.get("time")).toBeUndefined();
@@ -91,13 +90,12 @@ describe("CacheRefresher cache", function () {
 
             const cache = new Cache();
 
-            const connectionParameters = sdk.ConnectionParameters.ofUserAndPassword("http://acc-sdk:8080", "admin", "admin");
-            const cacheRefresher = new CacheRefresher(cache, client, connectionParameters, "xtk:schema", "rootkey");
+            const cacheRefresher = new CacheRefresher(cache, client, "xtk:schema", "rootkey");
             cacheRefresher._refresherStateCache.put("buildNumber", "9469");
             cacheRefresher._refresherStateCache.put("time", "2022-07-28T14:38:55.766Z");
 
             client._transport.mockReturnValueOnce(Mock.GETMODIFIEDENTITIES_CLEAR_RESPONSE);
-            await cacheRefresher.callAndRefresh();
+            await cacheRefresher._callAndRefresh();
             expect(cacheRefresher._refresherStateCache.get("buildNumber")).toBe("9469");
             expect(cacheRefresher._refresherStateCache.get("time")).toBe("2022-07-28T14:38:55.766Z");
 
@@ -122,8 +120,7 @@ describe("CacheRefresher cache", function () {
 
         await client.NLWS.xtkSession.logon();
         const cache = new Cache();
-        const connectionParameters = sdk.ConnectionParameters.ofUserAndPassword("http://acc-sdk:8080", "admin", "admin");
-        const cacheRefresher = new CacheRefresher(cache, client, connectionParameters, "xtk:schema", "rootkey");
+        const cacheRefresher = new CacheRefresher(cache, client, "xtk:schema", "rootkey");
 
         cache.put("xtk:schema|nms:recipient", "<content recipient>");
         cache.put("xtk:schema|nms:replicationStrategy", "<content xtk:schema|nms:replicationStrategy>");
@@ -133,7 +130,7 @@ describe("CacheRefresher cache", function () {
         expect(cache.get("xtk:schema|nms:operation")).toBe("<content xtk:schema|nms:operation>");
 
         client._transport.mockReturnValueOnce(Mock.GETMODIFIEDENTITIES_SCHEMA_RESPONSE);
-        await cacheRefresher.callAndRefresh();
+        await cacheRefresher._callAndRefresh();
         expect(cacheRefresher._refresherStateCache.get("buildNumber")).toBe("9469");
         expect(cacheRefresher._refresherStateCache.get("time")).toBe("2022-07-28T15:32:00.785Z");
         expect(cache.get("xtk:schema|nms:recipient")).toBeUndefined();
@@ -150,13 +147,12 @@ describe("CacheRefresher cache", function () {
 
         await client.NLWS.xtkSession.logon();
         const cache = new Cache();
-        const connectionParameters = sdk.ConnectionParameters.ofUserAndPassword("http://acc-sdk:8080", "admin", "admin");
-        const cacheRefresher = new CacheRefresher(cache, client, connectionParameters, "xtk:schema", "rootkey");
+        const cacheRefresher = new CacheRefresher(cache, client, "xtk:schema", "rootkey");
 
         cacheRefresher.startAutoRefresh();
 
         client._transport.mockReturnValueOnce(Mock.GETMODIFIEDENTITIES_UNDEFINED_RESPONSE);
-        await cacheRefresher.callAndRefresh();
+        await cacheRefresher._callAndRefresh();
         expect(cacheRefresher._refresherStateCache.get("buildNumber")).toBeUndefined();
         expect(cacheRefresher._refresherStateCache.get("time")).toBeUndefined();
         expect(cacheRefresher._intervalId).toBeNull();
@@ -171,14 +167,13 @@ describe("CacheRefresher cache", function () {
 
         await client.NLWS.xtkSession.logon();
         const cache = new Cache();
-        const connectionParameters = sdk.ConnectionParameters.ofUserAndPassword("http://acc-sdk:8080", "admin", "admin");
-        const cacheRefresher = new CacheRefresher(cache, client, connectionParameters, "xtk:schema", "rootkey");
+        const cacheRefresher = new CacheRefresher(cache, client, "xtk:schema", "rootkey");
 
         cacheRefresher.startAutoRefresh();
 
         client._transport.mockReturnValueOnce(Mock.GETMODIFIEDENTITIES_ERROR_RESPONSE);
         try {
-            await cacheRefresher.callAndRefresh();
+            await cacheRefresher._callAndRefresh();
             fail('exception is expected');
         } catch (e) {
             expect(e).not.toBeNull();
@@ -198,8 +193,7 @@ describe("CacheRefresher cache", function () {
 
         await client.NLWS.xtkSession.logon();
         const cache = new Cache();
-        const connectionParameters = sdk.ConnectionParameters.ofUserAndPassword("http://acc-sdk:8080", "admin", "admin");
-        const cacheRefresher = new CacheRefresher(cache, client, connectionParameters, "xtk:schema", "rootkey");
+        const cacheRefresher = new CacheRefresher(cache, client, "xtk:schema", "rootkey");
 
         jest.useFakeTimers();
         cacheRefresher.startAutoRefresh(100000);
@@ -246,13 +240,12 @@ describe("CacheRefresher cache", function () {
             }
         }
 
-        listener = new Listener();
-        client.registerCacheChangeListener(listener);
+        let listener = new Listener();
+        client._registerCacheChangeListener(listener);
 
         await client.NLWS.xtkSession.logon();
         const cache = new Cache();
-        const connectionParameters = sdk.ConnectionParameters.ofUserAndPassword("http://acc-sdk:8080", "admin", "admin");
-        const cacheRefresher = new CacheRefresher(cache, client, connectionParameters, "xtk:schema", "rootkey");
+        const cacheRefresher = new CacheRefresher(cache, client, "xtk:schema", "rootkey");
 
         cache.put("xtk:schema|nms:recipient", "<content recipient>");
         cache.put("xtk:schema|nms:replicationStrategy", "<content xtk:schema|nms:replicationStrategy>");
@@ -261,12 +254,12 @@ describe("CacheRefresher cache", function () {
         listener.add("nms:recipient");
 
         client._transport.mockReturnValueOnce(Mock.GETMODIFIEDENTITIES_SCHEMA_RESPONSE);
-        await cacheRefresher.callAndRefresh();
+        await cacheRefresher._callAndRefresh();
 
         expect(listener.getSchema("nms:recipient")).toBeUndefined();
 
         client._transport.mockReturnValueOnce(Mock.LOGOFF_RESPONSE);
         await client.NLWS.xtkSession.logoff();
-        client.unregisterCacheChangeListener(listener);
+        client._unregisterCacheChangeListener(listener);
     });
 });

--- a/test/caches.test.js
+++ b/test/caches.test.js
@@ -64,6 +64,10 @@ describe('Caches', function() {
             cache.remove("Hello");
             expect(cache.get("Hello")).toBeUndefined();
             expect(cache.get("Hi")).toBe("A");
+            // should support removing a key which has already been removed
+            cache.remove("Hello");
+            expect(cache.get("Hello")).toBeUndefined();
+            expect(cache.get("Hi")).toBe("A");
         })
     });
 

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -53,8 +53,6 @@ describe('ACC Client', function () {
         it('Should logon and logoff', async () => {
             const client = await Mock.makeClient();
             client._transport.mockReturnValueOnce(Mock.LOGON_RESPONSE);
-            client._transport.mockReturnValueOnce(Mock.GETMODIFIEDENTITIES_RESPONSE);
-            client._transport.mockReturnValueOnce(Mock.GETMODIFIEDENTITIES_RESPONSE);
             client._transport.mockReturnValueOnce(Mock.LOGOFF_RESPONSE);
             await client.NLWS.xtkSession.logon();
             expect(client.isLogged()).toBe(true);
@@ -66,10 +64,10 @@ describe('ACC Client', function () {
 
         it('Should logon and logoff with traces', async () => {
             const client = await Mock.makeClient();
+            client._transport.mockReturnValueOnce(Mock.LOGON_RESPONSE);
+            client._transport.mockReturnValueOnce(Mock.LOGOFF_RESPONSE);
             const logs = await Mock.withMockConsole(async () => {
                 client.traceAPICalls(true);
-                client._transport.mockReturnValueOnce(Mock.LOGON_RESPONSE);
-                client._transport.mockReturnValueOnce(Mock.LOGOFF_RESPONSE);
                 await client.NLWS.xtkSession.logon();
                 expect(client.isLogged()).toBe(true);
                 var sessionInfoXml = client.getSessionInfo("xml");
@@ -2373,7 +2371,7 @@ describe('ACC Client', function () {
             jest.advanceTimersByTime(6000);
             jest.useRealTimers();
 
-            var schema = await client.getSchema("nms:extAccount");
+            schema = await client.getSchema("nms:extAccount");
             expect(schema["namespace"]).toBe("nms");
             expect(schema["name"]).toBe("extAccount");
 
@@ -2399,7 +2397,7 @@ describe('ACC Client', function () {
             jest.advanceTimersByTime(6000);
             jest.useRealTimers();
 
-            var schema = await client.getSchema("nms:extAccount");
+            schema = await client.getSchema("nms:extAccount");
             expect(schema["namespace"]).toBe("nms");
             expect(schema["name"]).toBe("extAccount");
             client.stopRefreshCaches();
@@ -2409,25 +2407,23 @@ describe('ACC Client', function () {
             const client = await Mock.makeClient();
             client._transport.mockReturnValueOnce(Mock.LOGON_RESPONSE);
             await client.NLWS.xtkSession.logon();
-
             client.startRefreshCaches();
             expect(client._optionCacheRefresher._intervalId).not.toBeNull();
             expect(client._entityCacheRefresher._intervalId).not.toBeNull();
             client.stopRefreshCaches();
             expect(client._optionCacheRefresher._intervalId).toBeNull();
             expect(client._entityCacheRefresher._intervalId).toBeNull();
-
         });
 
         it("Should stop refresh when logoff", async () => {
             const client = await Mock.makeClient();
             client._transport.mockReturnValueOnce(Mock.LOGON_RESPONSE);
             await client.NLWS.xtkSession.logon();
-
             client.startRefreshCaches();
             expect(client._optionCacheRefresher._intervalId).not.toBeNull();
             expect(client._entityCacheRefresher._intervalId).not.toBeNull();
-            client.logoff();
+            client._transport.mockReturnValueOnce(Mock.LOGOFF_RESPONSE);
+            await client.logoff();
             expect(client._optionCacheRefresher._intervalId).toBeNull();
             expect(client._entityCacheRefresher._intervalId).toBeNull();
 
@@ -2982,13 +2978,13 @@ describe('ACC Client', function () {
                 }
             }
 
-            client.unregisterAllCacheChangeListeners();
+            client._unregisterAllCacheChangeListeners();
             expect(client._cacheChangeListeners.length).toBe(0);
-            listener = new Listener();
+            const listener = new Listener();
 
-            client.registerCacheChangeListener(listener);
+            client._registerCacheChangeListener(listener);
             expect(client._cacheChangeListeners.length).toBe(1);
-            client.unregisterCacheChangeListener(listener);
+            client._unregisterCacheChangeListener(listener);
             expect(client._cacheChangeListeners.length).toBe(0);
         });
 
@@ -3007,18 +3003,18 @@ describe('ACC Client', function () {
                 }
             }
 
-            client.unregisterAllCacheChangeListeners();
+            client._unregisterAllCacheChangeListeners();
             expect(client._cacheChangeListeners.length).toBe(0);
-            listener = new Listener();
+            const listener = new Listener();
 
-            client.registerCacheChangeListener(listener);
+            client._registerCacheChangeListener(listener);
             expect(client._cacheChangeListeners.length).toBe(1);
 
-            listener2 = new Listener();
+            const listener2 = new Listener();
 
-            client.unregisterCacheChangeListener(listener2);
+            client._unregisterCacheChangeListener(listener2);
             expect(client._cacheChangeListeners.length).toBe(1);
-            client.unregisterAllCacheChangeListeners();
+            client._unregisterAllCacheChangeListeners();
         });
 
         it("Should be notify when register", async () => {
@@ -3042,18 +3038,18 @@ describe('ACC Client', function () {
                 }
             }
 
-            client.unregisterAllCacheChangeListeners();
+            client._unregisterAllCacheChangeListeners();
             
-            listener = new Listener();
+            const listener = new Listener();
             listener.add("nms:recipient");
             listener.add("xtk:operator");
 
-            client.registerCacheChangeListener(listener);
+            client._registerCacheChangeListener(listener);
             client._notifyCacheChangeListeners("nms:recipient");
             expect(listener.getSchema("nms:recipient")).toBeUndefined();
             expect(listener.getSchema("xtk:operator")).toBe("1");
 
-            client.unregisterCacheChangeListener(listener);
+            client._unregisterCacheChangeListener(listener);
         });
     });
 });


### PR DESCRIPTION
* Make registerCacheChangeListener / unregisterCacheChangeListener / callAndRefresh, refresh private (rename with _ prefix)
* Fix a few typos and make sure JsDoc is complete
* Simplify CacheRefresher constructor (remove connectionParameters argument)
* Restore deleted tests for application object
* Fixes a few compilation warnings in cache refresher tests
* Added test for cache remove function: make sure key can be safely removed twice
* Fixed errors and compilation warnings in client.tests
* Fixed linting errors
