### PR TITLE
Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1111,6 +1111,34 @@ The `soapCall` parameter is a `SoapMethodCall` object which describes the SOAP c
 * `response` is a string containing the XML result of the SOAP call if the call was successful. It may be undefined if the call was not executed yet or if the call failed
 
 
+In version 1.1.7, the observer interface is extended to listen for internal events of the SDK. The `event` function of the observer, if it exist will be call for each SDK event with 2 parameters: the event itself, and for some events, a parent event. For instance a SOAP response event will have the SOAP request for a parent event.
+```js
+client.registerObserver({
+    event: (event, parentEvent) => { ... },
+});
+```
+
+The following events are available
+
+| event name | comment / description |
+|----|----|
+| SDK//logon | A client logs on |
+| SDK//logoff | A client logs off |
+| CACHE//stats | Regularly sends stats about internal caches |
+| SOAP//request | The SDK executes a SOAP request |
+| SOAP//response | The SDK processes the successful response of a SOAP request |
+| SOAP//failure | A SOAP request failed |
+| HTTP//request | The SDK executes an HTTP request |
+| HTTP//response | The SDK processes the successful response of an HTTP request |
+| HTTP//failure | An HTTP request failed |
+| CACHE_REFRESHER//start | A cache auto-refresher starts |
+| CACHE_REFRESHER//stop | A cache auto-refresher stops |
+| CACHE_REFRESHER//tick | A cache auto-refresh occurs |
+| CACHE_REFRESHER//loggedOff | The cache auto-refresh was triggered whereas the client was logged off |
+| CACHE_REFRESHER//error | The cache auto-refresh failed. Auto-refresh will continue. |
+| CACHE_REFRESHER//abort | The cache auto-refresh failed because the server does not support it. Auto-refresh will stop. |
+| CACHE_REFRESHER//response | The server responded to an auto-refresh request |
+
 # Configuration
 
 ## Tracking all SOAP calls

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "ISC",
       "dependencies": {
         "axios": "^0.25.0",
-        "jsdom": "^19.0.0"
+        "jsdom": "^19.0.0",
+        "uuid": "^8.3.2"
       },
       "devDependencies": {
         "docdash": "^1.2.0",
@@ -4809,9 +4810,9 @@
     },
     "node_modules/uuid": {
       "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "resolved": "https://artifactory.corp.adobe.com/artifactory/api/npm/npm-adobe-release/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
+      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -8751,9 +8752,8 @@
     },
     "uuid": {
       "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true
+      "resolved": "https://artifactory.corp.adobe.com/artifactory/api/npm/npm-adobe-release/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/test/caches.test.js
+++ b/test/caches.test.js
@@ -30,13 +30,16 @@ describe('Caches', function() {
         it("Should cache with default TTL and default key function", () => {
             const cache = new Cache();
             cache.put("Hello", "World");
+            expect(cache._stats).toMatchObject({ reads: 0, writes: 1 });
             expect(cache.get("Hello")).toBe("World");
+            expect(cache._stats).toMatchObject({ reads: 1, writes: 1, memoryHits: 1, storageHits: 0 });
         })
 
         it("Should expires after TTL", () => {
             const cache = new Cache(undefined, undefined, -1);    // negative TTL => will immediately expire
             cache.put("Hello", "World");
             expect(cache.get("Hello")).toBeUndefined();
+            expect(cache._stats).toMatchObject({ reads: 1, writes: 1, memoryHits: 0, storageHits: 0 });
         })
 
         it("Should support custom key function", () => {
@@ -53,6 +56,7 @@ describe('Caches', function() {
             expect(cache.get("Hello")).toBe("World");
             cache.clear();
             expect(cache.get("Hello")).toBeUndefined();
+            expect(cache._stats).toMatchObject({ reads: 2, writes: 1, memoryHits: 1, storageHits: 0, clears: 1 });
         })
 
         it("Should remove key in cache", () => {
@@ -61,9 +65,11 @@ describe('Caches', function() {
             cache.put("Hi", "A");
             expect(cache.get("Hello")).toBe("World");
             expect(cache.get("Hi")).toBe("A");
+            expect(cache._stats).toMatchObject({ reads: 2, writes: 2, memoryHits: 2 });
             cache.remove("Hello");
             expect(cache.get("Hello")).toBeUndefined();
             expect(cache.get("Hi")).toBe("A");
+            expect(cache._stats).toMatchObject({ reads: 4, writes: 2, memoryHits: 3, removals: 1 });
             // should support removing a key which has already been removed
             cache.remove("Hello");
             expect(cache.get("Hello")).toBeUndefined();

--- a/test/observability.test.js
+++ b/test/observability.test.js
@@ -1,0 +1,267 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+
+/**********************************************************************************
+ * 
+ * Unit tests for the ACC client observability hooks
+ * 
+ *********************************************************************************/
+const sdk = require('../src/index.js');
+const Mock = require('./mock.js').Mock;
+
+const makeObservableClient = async(options, callback) => {
+    // No TTL for option cache so that we can test that we send cache stats every 5 mins
+    const client = await Mock.makeClient({ ...options, optionCacheTTL: 999999000 });
+    return [client, new ObservabilityAssertion(client, callback)];
+}
+
+class ObservabilityAssertion {
+    constructor(client, callback) {
+        const that = this;
+        this._callback = callback;
+        client.registerObserver({
+            event: (event, parentEvent) => { return that.onEvent(event, parentEvent); },
+        });
+        this._eventsByName = {};
+    }
+
+    onEvent(event, parentEvent) {
+        if (!this._eventsByName[event.eventName]) this._eventsByName[event.eventName] = [];
+        this._eventsByName[event.eventName].push({ event: event, parentEvent: parentEvent });
+        if (this._callback) this._callback.call(this, event, parentEvent);
+    }
+
+    hasObserved(eventName) {
+        if (!this._eventsByName[eventName]) return false;
+        return this._eventsByName[eventName].length > 0;
+    }
+    
+    getFirstObserved(eventName) {
+        if (!this._eventsByName[eventName]) return;
+        return this._eventsByName[eventName][0];
+    }
+
+    getObserved(eventName) {
+        if (!this._eventsByName[eventName]) [];
+        return this._eventsByName[eventName].filter(o => o.event.eventName === eventName).map(o => o.event);
+    }
+}
+
+describe('ACC Client Observability', function () {
+
+    it('Should observe logon and logoff', async function () {
+        const [client, assertion] = await makeObservableClient();
+
+        client._transport.mockReturnValueOnce(Mock.LOGON_RESPONSE);
+        await client.NLWS.xtkSession.logon();
+        expect(assertion.hasObserved("SDK//logon")).toBe(true);
+        expect(assertion.hasObserved("SDK//logoff")).toBe(false);;
+        const logon = assertion.getFirstObserved("SDK//logon");
+        expect(logon.parentEvent).toBeUndefined();
+        expect(logon.event).toMatchObject({ eventId: 1, eventName: "SDK//logon" });
+        expect(logon.event.timestamp).toBeGreaterThan(0);
+
+        client._transport.mockReturnValueOnce(Mock.LOGOFF_RESPONSE);
+        await client.NLWS.xtkSession.logoff();
+        expect(assertion.hasObserved("SDK//logoff")).toBe(true);
+        const logoff = assertion.getFirstObserved("SDK//logoff");
+        expect(logoff.event).toMatchObject({ eventName: "SDK//logoff" });
+        expect(logoff.event.eventId).toBeGreaterThan(1);
+        expect(logoff.event.timestamp).toBeGreaterThanOrEqual(logon.event.timestamp);
+
+        // there should not be an auto refresh event if auto-refresh mechanism
+        // is off
+        expect(assertion.hasObserved("CACHE_REFRESHER//stop")).toBe(false);
+    });
+
+    it('Should ignore exceptions throws from observer', async () => {
+        const [client, assertion] = await makeObservableClient({}, (event, parentEvent) => {
+            throw new Error("Simulated failure in observer");
+        });
+        client._transport.mockReturnValueOnce(Mock.LOGON_RESPONSE);
+        // logon will send an observability event, but the error will be logged and ignored
+        await client.NLWS.xtkSession.logon();
+        expect(assertion.hasObserved("SDK//logon")).toBe(true);
+    });
+
+    it('Should send internal stats every 5 minutes', async () => {
+        jest.useFakeTimers();
+        const [client, assertion] = await makeObservableClient();
+
+        client._transport.mockReturnValueOnce(Mock.LOGON_RESPONSE);
+        await client.NLWS.xtkSession.logon();
+        expect(assertion.hasObserved("SDK//logon")).toBe(true);
+
+        // Calling get option should generate some cache hits
+        client._transport.mockReturnValueOnce(Mock.GET_XTK_SESSION_SCHEMA_RESPONSE);
+        client._transport.mockReturnValueOnce(Mock.GET_DATABASEID_RESPONSE);
+        var databaseId = await client.getOption("XtkDatabaseId");
+        expect(databaseId).toBe("uFE80000000000000F1FA913DD7CC7C480041161C");
+
+        jest.advanceTimersByTime(310000);
+        client._trackEvent("TEST/dummy", undefined, {});
+        // Note: options cache is written twice: once in the SOAP call itself, and once by the getOption method
+        // entity cache is also written twice: once for xtk:session and once from xtk:persist
+        expect(assertion.getObserved("CACHE//stats")).toEqual(expect.arrayContaining(
+            [
+                expect.objectContaining({ payload: { name: 'entityCache', clears: 0, loads: 1, memoryHits: 0, reads: 1, removals: 0, saves: 2, storageHits: 0, writes: 2 } }),
+                expect.objectContaining({ payload: { name: 'optionCache', clears: 0, loads: 1, memoryHits: 0, reads: 1, removals: 0, saves: 2, storageHits: 0, writes: 2 } }),
+            ]
+        ));
+
+        // Calling get option again should make a cache hit
+        // Only work if options cache TTL is very high
+        databaseId = await client.getOption("XtkDatabaseId");
+        expect(databaseId).toBe("uFE80000000000000F1FA913DD7CC7C480041161C");
+        jest.advanceTimersByTime(310000);
+        client._trackEvent("TEST/dummy", undefined, {});
+        expect(assertion.getObserved("CACHE//stats")).toEqual(expect.arrayContaining(
+            [
+                expect.objectContaining({ payload: { name: 'entityCache', clears: 0, loads: 1, memoryHits: 0, reads: 1, removals: 0, saves: 2, storageHits: 0, writes: 2 } }),
+                expect.objectContaining({ payload: { name: 'optionCache', clears: 0, loads: 1, memoryHits: 1, reads: 2, removals: 0, saves: 2, storageHits: 0, writes: 2 } }),
+            ]
+        ));
+
+        client._transport.mockReturnValueOnce(Mock.LOGOFF_RESPONSE);
+        await client.NLWS.xtkSession.logoff();
+        expect(assertion.hasObserved("SDK//logoff")).toBe(true);
+
+        jest.useRealTimers();
+    });
+
+    it('_trackCacheStats should support cache with no stats', async () => {
+        const [client, assertion] = await makeObservableClient();
+        client._trackEvent = jest.fn();
+        client._trackCacheStats('hello', undefined);
+        expect(client._trackEvent.mock.calls.length).toBe(0);
+        client._trackCacheStats('hello', {});
+        expect(client._trackEvent.mock.calls.length).toBe(0);
+        client._trackCacheStats('hello', { _stats: {} });
+        expect(client._trackEvent.mock.calls.length).toBe(1);
+    });
+
+    it('Should track SOAP calls', async () => {
+        const [client, assertion] = await makeObservableClient();
+
+        client._transport.mockReturnValueOnce(Mock.LOGON_RESPONSE);
+        await client.NLWS.xtkSession.logon();
+        expect(assertion.hasObserved("SDK//logon")).toBe(true);
+
+        // Calling get option should generate some cache hits
+        client._transport.mockReturnValueOnce(Mock.GET_XTK_SESSION_SCHEMA_RESPONSE);
+        client._transport.mockReturnValueOnce(Mock.GET_DATABASEID_RESPONSE);
+        var databaseId = await client.getOption("XtkDatabaseId");
+        expect(databaseId).toBe("uFE80000000000000F1FA913DD7CC7C480041161C");
+        const requests = assertion.getObserved("SOAP//request");
+        expect(requests.length).toBe(3);
+        expect(requests[0].payload).toMatchObject({ internal: false, urn: 'xtk:session', methodName: 'Logon', retry: false, retryCount: 0 });
+        expect(requests[1].payload).toMatchObject({ internal: true, urn: 'xtk:persist', methodName: 'GetEntityIfMoreRecent', retry: false, retryCount: 0 });
+        expect(requests[2].payload).toMatchObject({ internal: false, urn: 'xtk:session', methodName: 'GetOption', retry: false, retryCount: 0 });
+
+        const responses = assertion.getObserved("SOAP//response");
+        expect(responses.length).toBe(3);
+        expect(responses[0].payload).toMatchObject({ });
+        expect(responses[1].payload).toMatchObject({ });
+        expect(responses[2].payload).toMatchObject({ });
+    });
+
+    it('Should track caches auto-refresh (error in GetModifiedEntities API)', async () => {
+        jest.useFakeTimers();
+        const [client, assertion] = await makeObservableClient();
+
+        client._transport.mockReturnValueOnce(Mock.LOGON_RESPONSE);
+        await client.NLWS.xtkSession.logon();
+        expect(assertion.hasObserved("SDK//logon")).toBe(true);
+
+        client.startRefreshCaches();
+        expect(assertion.hasObserved("CACHE_REFRESHER//start")).toBe(true);
+        const start = assertion.getFirstObserved("CACHE_REFRESHER//start");
+        expect(start.event).toMatchObject({ eventName:"CACHE_REFRESHER//start", payload:{ cacheSchemaId: "xtk:option", refreshFrequency: 10000 } });
+
+        // No mock implementation => the API call to get modified entities will fail generating a CACHE_REFRESHER//error event
+        await client._optionCacheRefresher._safeCallAndRefresh();
+        expect(assertion.hasObserved("CACHE_REFRESHER//tick")).toBe(true);
+        const tick = assertion.getFirstObserved("CACHE_REFRESHER//tick");
+        expect(tick.event).toMatchObject({ eventName:"CACHE_REFRESHER//tick", payload:{ cacheSchemaId: "xtk:option" } });
+        expect(assertion.hasObserved("CACHE_REFRESHER//error")).toBe(true);
+        const error = assertion.getFirstObserved("CACHE_REFRESHER//error");
+        expect(error.event).toMatchObject({ eventName:"CACHE_REFRESHER//error", payload:{ cacheSchemaId: "xtk:option" } });
+        // An error in the API should not stop the auto-refresh mechanism
+        expect(assertion.hasObserved("CACHE_REFRESHER//stop")).toBe(false);
+
+        client._transport.mockReturnValueOnce(Mock.LOGOFF_RESPONSE);
+        await client.NLWS.xtkSession.logoff();
+        expect(assertion.hasObserved("SDK//logoff")).toBe(true);
+        expect(assertion.hasObserved("CACHE_REFRESHER//stop")).toBe(true);
+        jest.useRealTimers();
+    });
+
+    it('Should track caches auto-refresh (success in GetModifiedEntities API)', async () => {
+        jest.useFakeTimers();
+        const [client, assertion] = await makeObservableClient();
+
+        client._transport.mockReturnValueOnce(Mock.LOGON_RESPONSE);
+        await client.NLWS.xtkSession.logon();
+        expect(assertion.hasObserved("SDK//logon")).toBe(true);
+
+        client.startRefreshCaches();
+        expect(assertion.hasObserved("CACHE_REFRESHER//start")).toBe(true);
+        const start = assertion.getFirstObserved("CACHE_REFRESHER//start");
+        expect(start.event).toMatchObject({ eventName:"CACHE_REFRESHER//start", payload:{ cacheSchemaId: "xtk:option", refreshFrequency: 10000 } });
+
+        client._transport.mockReturnValue(Promise.resolve(Mock.GETMODIFIEDENTITIES_RESPONSE));
+        await client._optionCacheRefresher._safeCallAndRefresh();
+        expect(assertion.hasObserved("CACHE_REFRESHER//tick")).toBe(true);
+        const tick = assertion.getFirstObserved("CACHE_REFRESHER//tick");
+        expect(tick.event).toMatchObject({ eventName:"CACHE_REFRESHER//tick", payload:{ cacheSchemaId: "xtk:option" } });
+        expect(assertion.hasObserved("CACHE_REFRESHER//error")).toBe(false);
+        expect(assertion.hasObserved("CACHE_REFRESHER//abort")).toBe(false);
+        expect(assertion.hasObserved("CACHE_REFRESHER//stop")).toBe(false);
+
+        client._transport.mockReturnValueOnce(Mock.LOGOFF_RESPONSE);
+        await client.NLWS.xtkSession.logoff();
+        expect(assertion.hasObserved("SDK//logoff")).toBe(true);
+        expect(assertion.hasObserved("CACHE_REFRESHER//stop")).toBe(true);
+        jest.useRealTimers();
+    });
+
+    it('Should track caches auto-refresh (GetModifiedEntities API missing)', async () => {
+        jest.useFakeTimers();
+        const [client, assertion] = await makeObservableClient();
+
+        client._transport.mockReturnValueOnce(Mock.LOGON_RESPONSE);
+        await client.NLWS.xtkSession.logon();
+        expect(assertion.hasObserved("SDK//logon")).toBe(true);
+
+        client.startRefreshCaches();
+        expect(assertion.hasObserved("CACHE_REFRESHER//start")).toBe(true);
+        const start = assertion.getFirstObserved("CACHE_REFRESHER//start");
+        expect(start.event).toMatchObject({ eventName:"CACHE_REFRESHER//start", payload:{ cacheSchemaId: "xtk:option", refreshFrequency: 10000 } });
+
+        client._transport.mockReturnValue(Promise.resolve(Mock.GETMODIFIEDENTITIES_UNDEFINED_RESPONSE));
+        await client._optionCacheRefresher._safeCallAndRefresh();
+        expect(assertion.hasObserved("CACHE_REFRESHER//tick")).toBe(true);
+        const tick = assertion.getFirstObserved("CACHE_REFRESHER//tick");
+        expect(tick.event).toMatchObject({ eventName:"CACHE_REFRESHER//tick", payload:{ cacheSchemaId: "xtk:option" } });
+        expect(assertion.hasObserved("CACHE_REFRESHER//error")).toBe(false);
+        // Should send an abort event and stop the auto-refresher
+        expect(assertion.hasObserved("CACHE_REFRESHER//abort")).toBe(true);
+        expect(assertion.hasObserved("CACHE_REFRESHER//stop")).toBe(true);
+
+        client._transport.mockReturnValueOnce(Mock.LOGOFF_RESPONSE);
+        await client.NLWS.xtkSession.logoff();
+        jest.useRealTimers();
+    });
+
+});
+


### PR DESCRIPTION
Add a mechanism for observability in the SDK. We do not want to depend on any observability framework. Instead, we use the observer mechanism available in the SDK to notify a callback function of internal SDK events, such as soap calls, cache refreshes, etc.
The idea is that a client app can register to those events, and format them / send them to whatever observability framework they want.
See the #Observers section of the README file for more details.

In addition, we've added statistics to all caches, keeping track of how many reads, writes, hits, etc.
