### PR TITLE
Add id to Schema for globalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,16 @@ This is a node.js SDK for Campaign API. It exposes the Campaign API exactly like
 
 # Changelog 
 
+## Version 1.1.8
+_2022_09_26_
+
+* added translation ids (`labelTranslationId`,`descriptionTranslationId`, `labelSingularTranslationId`) for `XtkSchema`, `XtkSchemaNode`, `XtkEnumerationValue` and `XtkEnumeration`
+
 ## Version 1.1.7
 _2022_08_30_
 
 * New listener interface to be notified of internal events from the SDK. Can be used to integrate with observability frameworks. See the "Observers" section of the README file.
 * Experimental file upload feature. Will require server-side changes to work, and is currently limited to be used with browsers only.
-
 
 ## Version 1.1.6
 _2022_08_19_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This is a node.js SDK for Campaign API. It exposes the Campaign API exactly like
 ## Version 1.1.8
 _2022_09_26_
 
-* added translation ids (`labelTranslationId`,`descriptionTranslationId`, `labelSingularTranslationId`) for `XtkSchema`, `XtkSchemaNode`, `XtkEnumerationValue` and `XtkEnumeration`
+* added translation ids (`labelLocalizationId`,`descriptionLocalizationId`, `labelSingularLocalizationId`) for `XtkSchema`, `XtkSchemaNode`, `XtkEnumerationValue` and `XtkEnumeration`
 
 ## Version 1.1.7
 _2022_08_30_

--- a/README.md
+++ b/README.md
@@ -1753,7 +1753,9 @@ const root = await node.linkTarget();
 | **namespace** | The namespace of the schema. For instance "nms"
 | **name** | The name of the schema (internal name)
 | **label** | The label (i.e. human readable, localised) name of the node.
+| **labelTranslationId** | The translation id of the label of the node.
 | **labelSingular** | The singular label (i.e. human readable, localised) name of the schema. The label of a schema is typically a plural.
+| **labelSingularTranslationId** | The translation id of the label of the node of the singular label.
 | **isLibrary** | For schemas, indicates if the schema is a library
 | **mappingType** |Schema mapping type. Usually "sql"
 | **md5** | The MD5 code of the schema in the form of a hexadecimal string
@@ -1771,6 +1773,7 @@ A schema is also a `XtkSchemaNode` and the corresponding properties/methods are 
 | **children** | A array/map of children of the node. See note on the ArrayMap structure below
 | **dataPolicy** | Returns a string of characters which provides the data policy of the current node.
 | **description** | A long, human readable, description of the node
+| **descriptionTranslationId** | The translation id of the description of the node.
 | **editType** |Returns a string of characters which specifies the editing type of the current node.
 | **enum** | The name of the enumeration for the node, or an empty string if the node does node have an enumeration. See `enumeration()` method to get the corresponding `XtkSchemaNode`
 | **enumerationImage** | Returns the name of the image of the current node in the form of a string of characters.
@@ -1810,6 +1813,7 @@ A schema is also a `XtkSchemaNode` and the corresponding properties/methods are 
 | **unbound** | Returns a boolean which indicates whether the current node has an unlimited number of children of the same type.
 | **joins** | Element of type "link" has an array of XtkJoin. See `joinNodes` method.
 | **label** | The label (i.e. human readable, localised) name of the node.
+| **labelTranslationId** | The translation id of the label of the node.
 | **name** | The name of the node (internal name)
 | **nodePath**  | The xpath of the node
 | **parent** | The parent node (a `XtkSchemaNode` object). Will be null for schema nodes
@@ -1862,7 +1866,9 @@ A schema is also a `XtkSchemaNode` and the corresponding properties/methods are 
 |---|---|
 | **name** |  The name of the enumeration, fully qualified, i.e. prefixed with the schema id
 | **label** | The label (i.e. human readable, localised) name of the key
+| **labelTranslationId** | The translation id of the label of the key.
 | **description** | A long, human readable, description of the key
+| **descriptionTranslationId** | The translation id of the description of the key.
 | **baseType** | The base type of the enumeration, usually "string" or "byte"
 | **default** | The default value of the enumeration, casted to the enumeration type
 | **hasImage** | If the enumeration has an image
@@ -1874,7 +1880,9 @@ A schema is also a `XtkSchemaNode` and the corresponding properties/methods are 
 |---|---|
 | **name** |  The name of the key (internal name)
 | **label** | The label (i.e. human readable, localised) name of the key
+| **labelTranslationId** | The translation id of the label of the key.
 | **description** | A long, human readable, description of the key
+| **descriptionTranslationId** | The translation id of the description of the key.
 | **image** |
 | **enabledIf** |
 | **applicableIf** |

--- a/README.md
+++ b/README.md
@@ -1882,7 +1882,7 @@ A schema is also a `XtkSchemaNode` and the corresponding properties/methods are 
 | **label** | The label (i.e. human readable, localised) name of the key
 | **labelLocalizationId** | The translation id of the label of the key.
 | **description** | A long, human readable, description of the key
-| **descriptionLocalizationIddescriptionLocalizationId** | The translation id of the description of the key.
+| **descriptionLocalizationId** | The translation id of the description of the key.
 | **image** |
 | **enabledIf** |
 | **applicableIf** |

--- a/README.md
+++ b/README.md
@@ -1753,7 +1753,7 @@ const root = await node.linkTarget();
 | **namespace** | The namespace of the schema. For instance "nms"
 | **name** | The name of the schema (internal name)
 | **label** | The label (i.e. human readable, localised) name of the node.
-| **labelTranslationId** | The translation id of the label of the node.
+| **labelLocalizationId** | The translation id of the label of the node.
 | **labelSingular** | The singular label (i.e. human readable, localised) name of the schema. The label of a schema is typically a plural.
 | **labelSingularTranslationId** | The translation id of the label of the node of the singular label.
 | **isLibrary** | For schemas, indicates if the schema is a library
@@ -1773,7 +1773,7 @@ A schema is also a `XtkSchemaNode` and the corresponding properties/methods are 
 | **children** | A array/map of children of the node. See note on the ArrayMap structure below
 | **dataPolicy** | Returns a string of characters which provides the data policy of the current node.
 | **description** | A long, human readable, description of the node
-| **descriptionTranslationId** | The translation id of the description of the node.
+| **descriptionLocalizationId** | The translation id of the description of the node.
 | **editType** |Returns a string of characters which specifies the editing type of the current node.
 | **enum** | The name of the enumeration for the node, or an empty string if the node does node have an enumeration. See `enumeration()` method to get the corresponding `XtkSchemaNode`
 | **enumerationImage** | Returns the name of the image of the current node in the form of a string of characters.
@@ -1813,7 +1813,7 @@ A schema is also a `XtkSchemaNode` and the corresponding properties/methods are 
 | **unbound** | Returns a boolean which indicates whether the current node has an unlimited number of children of the same type.
 | **joins** | Element of type "link" has an array of XtkJoin. See `joinNodes` method.
 | **label** | The label (i.e. human readable, localised) name of the node.
-| **labelTranslationId** | The translation id of the label of the node.
+| **labelLocalizationId** | The translation id of the label of the node.
 | **name** | The name of the node (internal name)
 | **nodePath**  | The xpath of the node
 | **parent** | The parent node (a `XtkSchemaNode` object). Will be null for schema nodes
@@ -1866,9 +1866,9 @@ A schema is also a `XtkSchemaNode` and the corresponding properties/methods are 
 |---|---|
 | **name** |  The name of the enumeration, fully qualified, i.e. prefixed with the schema id
 | **label** | The label (i.e. human readable, localised) name of the key
-| **labelTranslationId** | The translation id of the label of the key.
+| **labelLocalizationId** | The translation id of the label of the key.
 | **description** | A long, human readable, description of the key
-| **descriptionTranslationId** | The translation id of the description of the key.
+| **descriptionLocalizationId** | The translation id of the description of the key.
 | **baseType** | The base type of the enumeration, usually "string" or "byte"
 | **default** | The default value of the enumeration, casted to the enumeration type
 | **hasImage** | If the enumeration has an image
@@ -1880,9 +1880,9 @@ A schema is also a `XtkSchemaNode` and the corresponding properties/methods are 
 |---|---|
 | **name** |  The name of the key (internal name)
 | **label** | The label (i.e. human readable, localised) name of the key
-| **labelTranslationId** | The translation id of the label of the key.
+| **labelLocalizationId** | The translation id of the label of the key.
 | **description** | A long, human readable, description of the key
-| **descriptionTranslationId** | The translation id of the description of the key.
+| **descriptionLocalizationIddescriptionLocalizationId** | The translation id of the description of the key.
 | **image** |
 | **enabledIf** |
 | **applicableIf** |

--- a/src/application.js
+++ b/src/application.js
@@ -422,13 +422,7 @@ class XtkSchemaNode {
          */
         this.nodePath = this._getNodePath(true)._path;
 
-        if (this.isRoot != undefined) {
-          this._buildLocalizationIds();
-        } else {
-          this._translationId = this.schema.id.replace(":", "__");
-          this.labelTranslationId = this._translationId + "__@label";
-          this.descriptionTranslationId = this._translationId + "__@desc";
-        }
+        this._buildLocalizationIds();
 
         /**
          * Element of type "link" has an array of XtkJoin
@@ -642,43 +636,26 @@ class XtkSchemaNode {
         propagateImplicitValues(this);
     }
 
-   /**
-    * Get the translation id of the label of the node
-    *
-    * @returns {string} the translation id of the label
-    */
-    getLabelTranslationId() {
-        return this.labelTranslationId;
-    }
-
-   /**
-    * Get the translation id of the description of the label of the node
-    *
-    * @returns {string} the translation id of the description
-    */
-    getDescriptionTranslationId() {
-        return this.descriptionTranslationId;
-    }
-
     /* create two ids that are identifying in an unique way the node label and 
      * the node description */
     _buildLocalizationIds() {
-        if (this.isRoot) {
-          this._translationId = this.schema.id.replace(":", "__");
+        if (this.isRoot == undefined || this.isRoot) {
+          this._localizationId = this.schema.id.replace(":", "__");
         } else {
-          this._translationId = this.parent._translationId;
+          this._localizationId = this.parent._localizationId;
         }
 
-        // Separate each element of the path with a double _
-        if (this.isAttribute) {
-          this._translationId = this._translationId + "__" + this.name.replace('@', '');
-        } else {
-          // node is not an attribute so it is an element add "e____"
-          this._translationId = this._translationId + "__e____" + this.name;
+        if (this.isRoot != undefined) {
+          // Separate each element of the path with a double _
+          if (this.isAttribute) {
+            this._localizationId = this._localizationId + "__" + this.name.replace('@', '');
+          } else {
+            // node is not an attribute so it is an element add "e____"
+            this._localizationId = this._localizationId + "__e____" + this.name;
+          }
         }
-
-        this.labelTranslationId = this._translationId + "__@label";
-        this.descriptionTranslationId = this._translationId + "__@desc";
+        this.labelLocalizationId = this._localizationId + "__@label";
+        this.descriptionLocalizationId = this._localizationId + "__@desc";
     }
 
     /**
@@ -965,11 +942,11 @@ function XtkEnumerationValue(xml, baseType, parentTranslationId) {
     /**
      * Unique identifier for the translation of the label
      * */
-    this.labelTranslationId = parentTranslationId + '__' + this.name + '__@label';
+    this.labelLocalizationId = parentTranslationId + '__' + this.name + '__@label';
     /**
      * Unique identifier for the tran,slation of the description of the label
      * */
-    this.descriptionTranslationId = parentTranslationId + '__' + this.name + '__@desc';
+    this.descriptionLocalizationId = parentTranslationId + '__' + this.name + '__@desc';
     /**
      * A human friendly long description of the value
      * @type {string}
@@ -1054,10 +1031,10 @@ class XtkEnumeration {
          this.values = new ArrayMap();
 
          var defaultValue = EntityAccessor.getAttributeAsString(xml, "default");
-         this._translationId = `${schemaId}__${this.name}`.replace(':','__');
+         this._localizationId = `${schemaId}__${this.name}`.replace(':','__');
 
          for (var child of EntityAccessor.getChildElements(xml, "value")) {
-             const e = new XtkEnumerationValue(child, this.baseType, this._translationId);
+             const e = new XtkEnumerationValue(child, this.baseType, this._localizationId);
              this.values._push(e.name, e);
              if (e.image != "") this.hasImage = true;
              const stringValue = EntityAccessor.getAttributeAsString(child, "value");
@@ -1065,8 +1042,8 @@ class XtkEnumeration {
                  this.default = e;
          }
 
-         this.labelTranslationId = this._translationId + "__@label";
-         this.descriptionTranslationId = this._translationId + "__@desc";
+         this.labelLocalizationId = this._localizationId + "__@label";
+         this.descriptionLocalizationId = this._localizationId + "__@desc";
          propagateImplicitValues(this, true);
 
         /**

--- a/src/application.js
+++ b/src/application.js
@@ -643,13 +643,13 @@ class XtkSchemaNode {
      * nms__recipient__e____recipient__mobilePhone__@label 
      * */
     _buildLocalizationIds() {
-        if (this.isRoot == undefined || this.isRoot) {
+        if (!this.parent) {
           this._localizationId = this.schema.id.replace(":", "__");
         } else {
           this._localizationId = this.parent._localizationId;
         }
 
-        if (this.isRoot != undefined) {
+        if (this.parent) {
           // Separate each element of the path with a double _
           if (this.isAttribute) {
             this._localizationId = this._localizationId + "__" + this.name.replace('@', '');
@@ -660,6 +660,9 @@ class XtkSchemaNode {
         }
         this.labelLocalizationId = this._localizationId + "__@label";
         this.descriptionLocalizationId = this._localizationId + "__@desc";
+        if (!this.parent) {
+            this.labelSingularLocalizationId = this._localizationId + "__@labelSingular"
+        }
     }
 
     /**
@@ -1104,11 +1107,6 @@ class XtkSchema extends XtkSchemaNode {
          * @type {string}
          */
         this.labelSingular = EntityAccessor.getAttributeAsString(xml, "labelSingular");
-        /**
-         * The id for translation of the singular label
-         * @type {string}
-         */
-        this.labelSingularLocalizationId = this.id.replace(":", "__") + "__@labelSingular"
         /**
          * The schema mappgin type, following the xtk:srcSchema:mappingType enumeration
          * @type {Campaign.XtkSchemaMappingType}

--- a/src/application.js
+++ b/src/application.js
@@ -637,7 +637,11 @@ class XtkSchemaNode {
     }
 
     /* create two ids that are identifying in an unique way the node label and 
-     * the node description */
+     * the node description 
+     * examples:
+     * nms__recipient__e____recipient__emailFormat__@desc
+     * nms__recipient__e____recipient__mobilePhone__@label 
+     * */
     _buildLocalizationIds() {
         if (this.isRoot == undefined || this.isRoot) {
           this._localizationId = this.schema.id.replace(":", "__");

--- a/src/application.js
+++ b/src/application.js
@@ -1104,7 +1104,7 @@ class XtkSchema extends XtkSchemaNode {
          * The id for translation of the singular label
          * @type {string}
          */
-        this.labelSingularTranslationId = this.id.replace(":", "__") + "__@labelSingular"
+        this.labelSingularLocalizationId = this.id.replace(":", "__") + "__@labelSingular"
         /**
          * The schema mappgin type, following the xtk:srcSchema:mappingType enumeration
          * @type {Campaign.XtkSchemaMappingType}

--- a/src/application.js
+++ b/src/application.js
@@ -425,7 +425,7 @@ class XtkSchemaNode {
         if (this.isRoot != undefined) {
           this._buildLocalizationIds();
         } else {
-          this._translationId = this.schema.id.replaceAll(":", "__");
+          this._translationId = this.schema.id.replace(":", "__");
           this.labelTranslationId = this._translationId + "__@label";
           this.descriptionTranslationId = this._translationId + "__@desc";
         }
@@ -642,10 +642,20 @@ class XtkSchemaNode {
         propagateImplicitValues(this);
     }
 
+   /**
+    * Get the translation id of the label of the node
+    *
+    * @returns {string} the translation id of the label
+    */
     getLabelTranslationId() {
         return this.labelTranslationId;
     }
 
+   /**
+    * Get the translation id of the description of the label of the node
+    *
+    * @returns {string} the translation id of the description
+    */
     getDescriptionTranslationId() {
         return this.descriptionTranslationId;
     }
@@ -654,14 +664,14 @@ class XtkSchemaNode {
      * the node description */
     _buildLocalizationIds() {
         if (this.isRoot) {
-          this._translationId = this.schema.id.replaceAll(":", "__");
+          this._translationId = this.schema.id.replace(":", "__");
         } else {
           this._translationId = this.parent._translationId;
         }
 
         // Separate each element of the path with a double _
         if (this.isAttribute) {
-          this._translationId = this._translationId + "__" + this.name.replaceAll('@', '');
+          this._translationId = this._translationId + "__" + this.name.replace('@', '');
         } else {
           // node is not an attribute so it is an element add "e____"
           this._translationId = this._translationId + "__e____" + this.name;
@@ -959,7 +969,7 @@ function XtkEnumerationValue(xml, baseType, parentTranslationId) {
     /**
      * Unique identifier for the tran,slation of the description of the label
      * */
-    this.descriptionTranslationid = parentTranslationId + '__' + this.name + '__@desc';
+    this.descriptionTranslationId = parentTranslationId + '__' + this.name + '__@desc';
     /**
      * A human friendly long description of the value
      * @type {string}
@@ -1044,7 +1054,7 @@ class XtkEnumeration {
          this.values = new ArrayMap();
 
          var defaultValue = EntityAccessor.getAttributeAsString(xml, "default");
-         this._translationId = `${schemaId}__${this.name}`.replaceAll(':','__');
+         this._translationId = `${schemaId}__${this.name}`.replace(':','__');
 
          for (var child of EntityAccessor.getChildElements(xml, "value")) {
              const e = new XtkEnumerationValue(child, this.baseType, this._translationId);
@@ -1117,7 +1127,7 @@ class XtkSchema extends XtkSchemaNode {
          * The id for translation of the singular label
          * @type {string}
          */
-        this.labelSingularTranslationId = this.id.replaceAll(":", "__") + "__@labelSingular"
+        this.labelSingularTranslationId = this.id.replace(":", "__") + "__@labelSingular"
         /**
          * The schema mappgin type, following the xtk:srcSchema:mappingType enumeration
          * @type {Campaign.XtkSchemaMappingType}

--- a/src/application.js
+++ b/src/application.js
@@ -661,7 +661,7 @@ class XtkSchemaNode {
         this.labelLocalizationId = this._localizationId + "__@label";
         this.descriptionLocalizationId = this._localizationId + "__@desc";
         if (!this.parent) {
-            this.labelSingularLocalizationId = this._localizationId + "__@labelSingular"
+            this.labelSingularLocalizationId = this._localizationId + "__@labelSingular";
         }
     }
 

--- a/src/application.js
+++ b/src/application.js
@@ -422,6 +422,12 @@ class XtkSchemaNode {
          */
         this.nodePath = this._getNodePath(true)._path;
 
+        if (this.isRoot != undefined) {
+            this.labelid = "schema." + this.schema.id.replaceAll(":", "").replaceAll("/", ".") + this.nodePath.replaceAll("/",".") + ".label";
+            console.log(this.labelid);
+            this.descriptionid = "schema." + this.schema.id.replaceAll(":", "").replaceAll("/", ".") + this.nodePath.replaceAll("/", ".") + ".desc";
+        }
+
         /**
          * Element of type "link" has an array of XtkJoin
          * @type {XtkJoin[]}
@@ -903,7 +909,7 @@ class XtkSchemaNode {
  * @param {Campaign.XtkEnumerationType} baseType the enumeration type (often "string" or "byte")
  * @memberof Campaign
  */
-function XtkEnumerationValue(xml, baseType) {
+function XtkEnumerationValue(xml, baseType, parentlabelid) {
     /**
      * The value (unique) name
      * @type {string}
@@ -914,6 +920,7 @@ function XtkEnumerationValue(xml, baseType) {
      * @type {string}
      */
     this.label = EntityAccessor.getAttributeAsString(xml, "label");
+    this.labelid = parentlabelid + '.' + this.name + '.label';
     /**
      * A human friendly long description of the value
      * @type {string}
@@ -997,25 +1004,28 @@ class XtkEnumeration {
          */
          this.values = new ArrayMap();
 
-        var defaultValue = EntityAccessor.getAttributeAsString(xml, "default");
+         var defaultValue = EntityAccessor.getAttributeAsString(xml, "default");
+         this.labelid = `${schemaId}.${this.name}`.replaceAll(':','');
 
-        for (var child of EntityAccessor.getChildElements(xml, "value")) {
-            const e = new XtkEnumerationValue(child, this.baseType);
-            this.values._push(e.name, e);
-            if (e.image != "") this.hasImage = true;
-            const stringValue = EntityAccessor.getAttributeAsString(child, "value");
-            if (defaultValue == stringValue)
-                this.default = e;
-        }
+         for (var child of EntityAccessor.getChildElements(xml, "value")) {
+             const e = new XtkEnumerationValue(child, this.baseType, this.labelid);
+             this.values._push(e.name, e);
+             if (e.image != "") this.hasImage = true;
+             const stringValue = EntityAccessor.getAttributeAsString(child, "value");
+             if (defaultValue == stringValue)
+                 this.default = e;
+         }
 
-        propagateImplicitValues(this, true);
+         this.labelid = `${schemaId}.${this.name}.label`.replaceAll(':', '');
+         propagateImplicitValues(this, true);
 
         /**
          * The system enumeration name, without the schema id prefix
          * @type {string}
          */
          this.shortName = this.name;
-        this.name = `${schemaId}:${this.shortName}`;
+         this.name = `${schemaId}:${this.shortName}`;
+         
     }
 }
 

--- a/test/application.test.js
+++ b/test/application.test.js
@@ -2021,6 +2021,71 @@ describe('Application', () => {
                 expect(schema.userDescription).toBe("recipient");
             });
         });
+
+        describe("Translation ids", () => {
+          it("schema should have a correct label translation id", () => {
+            var xml = DomUtil.parse("<schema namespace='nms' name='recipient'><element name='recipient' label='Recipients'/></schema>");
+            var schema = newSchema(xml);
+            expect(schema.getLabelTranslationId()).toBe('nms__recipient__@label');
+            expect(schema.getDescriptionTranslationId()).toBe('nms__recipient__@desc');
+          });
+
+          it("root node should have a correct label translation id", () => {
+            var xml = DomUtil.parse("<schema namespace='nms' name='recipient'><element name='recipient' label='Recipients'/></schema>");
+            var schema = newSchema(xml);
+            var root = schema.root;
+            expect(root.getLabelTranslationId()).toBe('nms__recipient__e____recipient__@label');
+            expect(root.getDescriptionTranslationId()).toBe('nms__recipient__e____recipient__@desc');
+          });
+
+          it("child node should have a correct label translation id", () => {
+            var xml = DomUtil.parse("<schema namespace='nms' name='recipient'><element name='lib' label='library'/><element name='recipient' label='Recipients'/></schema>");
+            var schema = newSchema(xml);
+            var lib = schema.children["lib"];
+            expect(lib.getLabelTranslationId()).toBe('nms__recipient__e____lib__@label');
+            expect(lib.getDescriptionTranslationId()).toBe('nms__recipient__e____lib__@desc');
+          });
+
+          it("attribut should have a correct label translation id", () => {
+            var xml = DomUtil.parse(`<schema namespace='nms' name='recipient'>
+                                            <element name='recipient' label='Recipients'>
+                                                <attribute name='email' type='string' label='email' length='3'/>
+                                            </element>
+                                        </schema>`);
+            var schema = newSchema(xml);
+            var root = schema.root;
+            expect(root.children.get("@email").getLabelTranslationId()).toBe('nms__recipient__e____recipient__email__@label');
+            expect(root.children.get("@email").getDescriptionTranslationId()).toBe('nms__recipient__e____recipient__email__@desc');
+          });
+
+          it("Enumeration should have a correct label translation id", () => {
+            var xml = DomUtil.parse(`<schema namespace='nms' name='recipient'>
+                                            <enumeration name="gender" basetype="byte"/>
+                                            <element name='recipient' label='Recipients'></element>
+                                        </schema>`);
+            var schema = newSchema(xml);
+            var enumerations = schema.enumerations;
+            expect(enumerations.gender.labelTranslationId).toBe('nms__recipient__gender__@label');
+            expect(enumerations.gender.descriptionTranslationId).toBe('nms__recipient__gender__@desc');
+          });
+
+          it("Enumeration value should have a correct label translation id", () => {
+            var xml = DomUtil.parse(`<schema namespace='nms' name='recipient'>
+                                            <enumeration name="gender" basetype="byte">
+                                                <value name="male" value="0"/>
+                                                <value name="female" value="1"/>                                    
+                                            </enumeration>
+                                            <element name='recipient' label='Recipients'>
+                                            <attribute advanced="true" desc="Recipient sex" enum="nms:recipient:gender"
+                                                label="Gender" name="gender" sqlname="iGender" type="byte"/>
+                                            </element>
+                                        </schema>`);
+            var schema = newSchema(xml);
+            var enumerations = schema.enumerations;
+            expect(enumerations.gender.values.male.labelTranslationId).toBe('nms__recipient__gender__male__@label');
+            expect(enumerations.gender.values.male.descriptionTranslationId).toBe('nms__recipient__gender__male__@desc');
+          })
+        });
     });
 
     describe("CurrentLogin", () => {

--- a/test/application.test.js
+++ b/test/application.test.js
@@ -2030,6 +2030,12 @@ describe('Application', () => {
             expect(schema.descriptionLocalizationId).toBe('nms__recipient__@desc');
           });
 
+          it("schema should have a correct singular label localization id", () => {
+            const xml = DomUtil.parse("<schema namespace='nms' name='recipient'><element name='recipient' label='Recipients'/></schema>");
+            const schema = newSchema(xml);
+            expect(schema.labelSingularLocalizationId).toBe('nms__recipient__@labelSingular');
+          });
+
           it("root node should have a correct label localization id", () => {
             const xml = DomUtil.parse("<schema namespace='nms' name='recipient'><element name='recipient' label='Recipients'/></schema>");
             const schema = newSchema(xml);

--- a/test/application.test.js
+++ b/test/application.test.js
@@ -2023,54 +2023,54 @@ describe('Application', () => {
         });
 
         describe("Translation ids", () => {
-          it("schema should have a correct label translation id", () => {
-            var xml = DomUtil.parse("<schema namespace='nms' name='recipient'><element name='recipient' label='Recipients'/></schema>");
-            var schema = newSchema(xml);
-            expect(schema.getLabelTranslationId()).toBe('nms__recipient__@label');
-            expect(schema.getDescriptionTranslationId()).toBe('nms__recipient__@desc');
+          it("schema should have a correct label localization id", () => {
+            const xml = DomUtil.parse("<schema namespace='nms' name='recipient'><element name='recipient' label='Recipients'/></schema>");
+            const schema = newSchema(xml);
+            expect(schema.labelLocalizationId).toBe('nms__recipient__@label');
+            expect(schema.descriptionLocalizationId).toBe('nms__recipient__@desc');
           });
 
-          it("root node should have a correct label translation id", () => {
-            var xml = DomUtil.parse("<schema namespace='nms' name='recipient'><element name='recipient' label='Recipients'/></schema>");
-            var schema = newSchema(xml);
-            var root = schema.root;
-            expect(root.getLabelTranslationId()).toBe('nms__recipient__e____recipient__@label');
-            expect(root.getDescriptionTranslationId()).toBe('nms__recipient__e____recipient__@desc');
+          it("root node should have a correct label localization id", () => {
+            const xml = DomUtil.parse("<schema namespace='nms' name='recipient'><element name='recipient' label='Recipients'/></schema>");
+            const schema = newSchema(xml);
+            const root = schema.root;
+            expect(root.labelLocalizationId).toBe('nms__recipient__e____recipient__@label');
+            expect(root.descriptionLocalizationId).toBe('nms__recipient__e____recipient__@desc');
           });
 
-          it("child node should have a correct label translation id", () => {
-            var xml = DomUtil.parse("<schema namespace='nms' name='recipient'><element name='lib' label='library'/><element name='recipient' label='Recipients'/></schema>");
-            var schema = newSchema(xml);
-            var lib = schema.children["lib"];
-            expect(lib.getLabelTranslationId()).toBe('nms__recipient__e____lib__@label');
-            expect(lib.getDescriptionTranslationId()).toBe('nms__recipient__e____lib__@desc');
+          it("child node should have a correct label localization id", () => {
+            const xml = DomUtil.parse("<schema namespace='nms' name='recipient'><element name='lib' label='library'/><element name='recipient' label='Recipients'/></schema>");
+            const schema = newSchema(xml);
+            const lib = schema.children["lib"];
+            expect(lib.labelLocalizationId).toBe('nms__recipient__e____lib__@label');
+            expect(lib.descriptionLocalizationId).toBe('nms__recipient__e____lib__@desc');
           });
 
-          it("attribut should have a correct label translation id", () => {
-            var xml = DomUtil.parse(`<schema namespace='nms' name='recipient'>
+          it("attribute should have a correct label localization id", () => {
+            const xml = DomUtil.parse(`<schema namespace='nms' name='recipient'>
                                             <element name='recipient' label='Recipients'>
                                                 <attribute name='email' type='string' label='email' length='3'/>
                                             </element>
                                         </schema>`);
-            var schema = newSchema(xml);
-            var root = schema.root;
-            expect(root.children.get("@email").getLabelTranslationId()).toBe('nms__recipient__e____recipient__email__@label');
-            expect(root.children.get("@email").getDescriptionTranslationId()).toBe('nms__recipient__e____recipient__email__@desc');
+            const schema = newSchema(xml);
+            const root = schema.root;
+            expect(root.children.get("@email").labelLocalizationId).toBe('nms__recipient__e____recipient__email__@label');
+            expect(root.children.get("@email").descriptionLocalizationId).toBe('nms__recipient__e____recipient__email__@desc');
           });
 
-          it("Enumeration should have a correct label translation id", () => {
-            var xml = DomUtil.parse(`<schema namespace='nms' name='recipient'>
+          it("Enumeration should have a correct label localization id", () => {
+            const xml = DomUtil.parse(`<schema namespace='nms' name='recipient'>
                                             <enumeration name="gender" basetype="byte"/>
                                             <element name='recipient' label='Recipients'></element>
                                         </schema>`);
-            var schema = newSchema(xml);
-            var enumerations = schema.enumerations;
-            expect(enumerations.gender.labelTranslationId).toBe('nms__recipient__gender__@label');
-            expect(enumerations.gender.descriptionTranslationId).toBe('nms__recipient__gender__@desc');
+            const schema = newSchema(xml);
+            const enumerations = schema.enumerations;
+            expect(enumerations.gender.labelLocalizationId).toBe('nms__recipient__gender__@label');
+            expect(enumerations.gender.descriptionLocalizationId).toBe('nms__recipient__gender__@desc');
           });
 
-          it("Enumeration value should have a correct label translation id", () => {
-            var xml = DomUtil.parse(`<schema namespace='nms' name='recipient'>
+          it("Enumeration value should have a correct label localization id", () => {
+            const xml = DomUtil.parse(`<schema namespace='nms' name='recipient'>
                                             <enumeration name="gender" basetype="byte">
                                                 <value name="male" value="0"/>
                                                 <value name="female" value="1"/>                                    
@@ -2080,10 +2080,10 @@ describe('Application', () => {
                                                 label="Gender" name="gender" sqlname="iGender" type="byte"/>
                                             </element>
                                         </schema>`);
-            var schema = newSchema(xml);
-            var enumerations = schema.enumerations;
-            expect(enumerations.gender.values.male.labelTranslationId).toBe('nms__recipient__gender__male__@label');
-            expect(enumerations.gender.values.male.descriptionTranslationId).toBe('nms__recipient__gender__male__@desc');
+            const schema = newSchema(xml);
+            const enumerations = schema.enumerations;
+            expect(enumerations.gender.values.male.labelLocalizationId).toBe('nms__recipient__gender__male__@label');
+            expect(enumerations.gender.values.male.descriptionLocalizationId).toBe('nms__recipient__gender__male__@desc');
           })
         });
     });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add translation ids when building XtkSchema, XtkSchemaNodes, XtkEnumeration and XtkEnumerationValue in order to by the intl library for translation.

## Related Issue

In acc web ui schema is still in English for changing the language.

## Motivation and Context

to have the schema content localized

## How Has This Been Tested?

added unit tests
Tested on web ui side.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
