### PR TITLE
Support for belongsTo attribute indicating custom/extended schema

### DIFF
--- a/src/application.js
+++ b/src/application.js
@@ -608,6 +608,11 @@ class XtkSchemaNode {
          */
         this.packageStatus = PACKAGE_STATUS[this.packageStatusString];
 
+        /**
+         * Returns a string which indicates the custom/extended entity, attribute belongs to.
+         */
+        this.belongsTo = EntityAccessor.getAttributeAsString(xml, "belongsTo");
+
          // Children (elements and attributes)
         const childNodes = [];
         for (const child of EntityAccessor.getChildElements(xml)) {


### PR DESCRIPTION
Schemas attributes and element have a "belongsTo" attribute which indicates in which source schema this attribute or element was initially declared. This can be used to detect if an attribute is an extension, and if it is a custom attribute.


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
