### PR TITLE
NEO-50592 : Correction of a false positive session expiration error

### DIFF
--- a/src/soap.js
+++ b/src/soap.js
@@ -218,7 +218,7 @@ class SoapMethodCall {
      * @param {string} tag the parameter name
      * @param {*} value the parameter value, which will be casted to a int32 according to xtk rules
      */
-     writeLong(tag, value) {
+    writeLong(tag, value) {
         value = XtkCaster.asLong(value);
         this._addNode(tag, "xsd:int", XtkCaster.asString(value), SOAP_ENCODING_NATIVE);
     }
@@ -356,7 +356,7 @@ class SoapMethodCall {
      * 
      * @returns {string} the string result value
      */
-     getNextString() {
+    getNextString() {
         this._checkTypeMatch("xsd:string");
         var value = DomUtil.elementValue(this.elemCurrent);
         this.elemCurrent = DomUtil.getNextSiblingElement(this.elemCurrent);
@@ -368,7 +368,7 @@ class SoapMethodCall {
      * 
      * @returns {string} the primary key string result value
      */
-     getNextPrimaryKey() {
+    getNextPrimaryKey() {
         this._checkTypeMatch("xsd:primarykey");
         var value = DomUtil.elementValue(this.elemCurrent);
         this.elemCurrent = DomUtil.getNextSiblingElement(this.elemCurrent);
@@ -630,8 +630,6 @@ class SoapMethodCall {
         const that = this;
         const promise = this._transport(this.request, this.requestOptions);
         return promise.then(function(body) {
-            if (body.indexOf(`XSV-350008`) != -1)
-                throw CampaignException.SESSION_EXPIRED();
             that.response = body;
             // Response is a serialized XML document with the following structure
             //
@@ -685,7 +683,9 @@ class SoapMethodCall {
             }
         })
         .catch(function(err) {
-            throw makeCampaignException(that, err);
+            if (that.response && that.response.indexOf(`XSV-350008`) != -1)
+              throw CampaignException.SESSION_EXPIRED();
+            else throw makeCampaignException(that, err);
         });
     }
 

--- a/test/soap.test.js
+++ b/test/soap.test.js
@@ -539,6 +539,19 @@ describe('SOAP', function() {
             });
         });
 
+        it("Should not throw sesion expired exception", function() {
+          const transport = function() { 
+              return Promise.resolve(makeSOAPResponse("Date", 
+                  "p", "xsd:string", "XSV-350008 Session has expired or is invalid. Please reconnect.",
+              )); 
+          };
+          const call = makeSoapMethodCall(transport, "xtk:session", "Date", "$session$", "$security$");
+          call.finalize(URL);
+          return call.execute().then(() => {
+              expect(call.getNextString()).toBe("XSV-350008 Session has expired or is invalid. Please reconnect.");
+          });
+      });
+
         it("Should should read Element response", function() {
             const xml = '<root att="Hello"><child/></root>';
             const transport = function() { 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
If Delivery preparation job logs queryDef response contains session expiration error string as a log error message then the old code consider that the SOAP response is on error which is not correct.
The fixe checks the session expiration error only when the response is not an XML (Raw text).

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
