### PR TITLE
NEO-50308: no localization id when no label

### DIFF
--- a/src/application.js
+++ b/src/application.js
@@ -669,10 +669,14 @@ class XtkSchemaNode {
             this._localizationId = this._localizationId + "__e____" + this.name;
           }
         }
-        this.labelLocalizationId = this._localizationId + "__@label";
-        this.descriptionLocalizationId = this._localizationId + "__@desc";
-        if (!this.parent) {
-            this.labelSingularLocalizationId = this._localizationId + "__@labelSingular";
+        if (this.label) {
+          this.labelLocalizationId = this._localizationId + "__@label";
+        }
+        if (this.description) {
+          this.descriptionLocalizationId = this._localizationId + "__@desc";
+        }
+        if (!this.parent && this.labelSingular) {
+          this.labelSingularLocalizationId = this._localizationId + "__@labelSingular";
         }
     }
 

--- a/test/application.test.js
+++ b/test/application.test.js
@@ -2061,21 +2061,34 @@ describe('Application', () => {
         });
 
         describe("Translation ids", () => {
-          it("schema should have a correct label localization id", () => {
+          it("schema should not have label localization id when label does not exist", () => {
             const xml = DomUtil.parse("<schema namespace='nms' name='recipient'><element name='recipient' label='Recipients'/></schema>");
+            const schema = newSchema(xml);
+            expect(schema.labelLocalizationId).toBeUndefined();
+            expect(schema.descriptionLocalizationId).toBeUndefined();
+          });
+
+          it("schema should have a correct label localization id", () => {
+            const xml = DomUtil.parse("<schema namespace='nms' name='recipient' label='Recipients' desc='Recipient table(profiles)'><element name='recipient' label='Recipients'/></schema>");
             const schema = newSchema(xml);
             expect(schema.labelLocalizationId).toBe('nms__recipient__@label');
             expect(schema.descriptionLocalizationId).toBe('nms__recipient__@desc');
           });
 
           it("schema should have a correct singular label localization id", () => {
-            const xml = DomUtil.parse("<schema namespace='nms' name='recipient'><element name='recipient' label='Recipients'/></schema>");
+            const xml = DomUtil.parse("<schema namespace='nms' name='recipient' labelSingular='Recipient'><element name='recipient' label='Recipients'/></schema>");
             const schema = newSchema(xml);
             expect(schema.labelSingularLocalizationId).toBe('nms__recipient__@labelSingular');
           });
 
-          it("root node should have a correct label localization id", () => {
+          it("schema should not have singular label localization id when singular label does not exist", () => {
             const xml = DomUtil.parse("<schema namespace='nms' name='recipient'><element name='recipient' label='Recipients'/></schema>");
+            const schema = newSchema(xml);
+            expect(schema.labelSingularLocalizationId).toBeUndefined();
+          });
+
+          it("root node should have a correct label localization id", () => {
+            const xml = DomUtil.parse("<schema namespace='nms' name='recipient'><element name='recipient' label='Recipients' desc='Recipients'/></schema>");
             const schema = newSchema(xml);
             const root = schema.root;
             expect(root.labelLocalizationId).toBe('nms__recipient__e____recipient__@label');
@@ -2083,7 +2096,7 @@ describe('Application', () => {
           });
 
           it("child node should have a correct label localization id", () => {
-            const xml = DomUtil.parse("<schema namespace='nms' name='recipient'><element name='lib' label='library'/><element name='recipient' label='Recipients'/></schema>");
+            const xml = DomUtil.parse("<schema namespace='nms' name='recipient'><element name='lib' label='library' desc='library'/><element name='recipient' label='Recipients'/></schema>");
             const schema = newSchema(xml);
             const lib = schema.children["lib"];
             expect(lib.labelLocalizationId).toBe('nms__recipient__e____lib__@label');
@@ -2093,7 +2106,7 @@ describe('Application', () => {
           it("attribute should have a correct label localization id", () => {
             const xml = DomUtil.parse(`<schema namespace='nms' name='recipient'>
                                             <element name='recipient' label='Recipients'>
-                                                <attribute name='email' type='string' label='email' length='3'/>
+                                                <attribute name='email' type='string' label='email'  desc='email' length='3'/>
                                             </element>
                                         </schema>`);
             const schema = newSchema(xml);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Do not set a localization id when label is not set , same for description and singular label.

## Related Issue
When try to use localization id of a label or a description  in a schema that was implicit set because it does not exist, an error message is logged.

## Motivation and Context

Avoid to log an error message for each implicit set description or label.

## How Has This Been Tested?

Unit test and test in context of the acc web ui.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
