### PR TITLE
NEO-51219: expose attribute instanceLocale in CurrentLogin

### DIFF
--- a/src/application.js
+++ b/src/application.js
@@ -1223,7 +1223,13 @@ class CurrentLogin {
          * @type {string}
          */
         this.timezone = EntityAccessor.getAttributeAsString(userInfo, "timezone");
-        
+       
+        /**
+         * The instance locale
+         * @type { string }
+         */
+        this.instanceLocale = EntityAccessor.getAttributeAsString(userInfo, "instanceLocale");
+
         /**
          * The llist of operator rights
          * @type {string[]}

--- a/test/application.test.js
+++ b/test/application.test.js
@@ -2154,13 +2154,15 @@ describe('Application', () => {
                 loginCS: "Alex",
                 timezone: "Europe/Paris",
                 "login-right": [
-                ]
+                ],
+                instanceLocale: "en"
             })
             expect(op.login).toBe("alex");
             expect(op.id).toBe(12);
             expect(op.computeString).toBe("Alex");
             expect(op.timezone).toBe("Europe/Paris");
             expect(op.rights).toEqual([]);
+            expect(op.instanceLocale).toBe("en");
         })
 
         it("Should support missing 'login-right' node", () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Expose attribute instanceLocale in CurrentLogin

## Related Issue

Ability to get the acc server instance locale to get default label in the locale of the server

## Motivation and Context

Help to check if a OOTB default label has been changed

## How Has This Been Tested?

unit test
test in web ui

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
