### PR TITLE
File upload: Replace incorrect property body with data passed to _makeHttpCall

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -548,7 +548,7 @@ const fileUploader = (client) => {
                         processData: false,
                         credentials: 'include',
                         method: 'POST',
-                        body: data,
+                        data: data,
                         headers: {
                             'x-security-token': client._securityToken,
                             'Cookie': '__sessiontoken=' + client._sessionToken,

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -3224,6 +3224,17 @@ describe('ACC Client', function () {
                 type: 'text/html',
                 size: 12345
             })
+            expect(client._transport).toHaveBeenNthCalledWith(2,
+                expect.objectContaining({
+                    data: expect.anything(),
+                    url: expect.any(String),
+                    method: 'POST',
+                    processData: false,
+                    credentials: 'include',
+                    headers: expect.anything(),
+                })
+            );
+
             expect(result).toMatchObject({
                 md5: "d8e8fca2dc0f896fd7cb4cb0031ba249",
                 name: "test.txt",


### PR DESCRIPTION
`client._makeHttpCall` API needs the property passed as `data` instead of `body`. Fixing that in file upload.

## Description

Bug fix

## Related Issue
File upload doesn't work.

## How Has This Been Tested?

Modified a test to detect the issue.
Tested acc-js-sdk in a browser.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
