### PR TITLE
NEO-51318: fix SimpleJson serialization issues

### DIFF
--- a/docs/changeLog.html
+++ b/docs/changeLog.html
@@ -2,6 +2,13 @@
 layout: page
 title: Change Log
 ---
+<section class="changelog"><h1>Version 1.1.13</h1>
+  <h2>Work in progress</h2>
+  
+  <li>Fix an issue with SimpleJson serialization. See <a href="https://opensource.adobe.com/acc-js-sdk/simpleJson.html">SimpleJson documentation</a> for more details/li>
+</section>
+
+
 <section class="changelog"><h1>Version 1.1.12</h1>
   <h2>2022/11/16</h2>
   

--- a/docs/simpleJson.html
+++ b/docs/simpleJson.html
@@ -39,9 +39,9 @@ JSON:    {}
 
 
 <h1>XML Attributes</h1>
-<p>XML attributes are mapped to JSON attributes with the same name, whose litteral value can be a string, number, or boolean. There's no "@" sign in the JSON attribute name.
+<p>XML attributes are mapped to JSON attributes with the same name, whose literal value can be a string, number, or boolean. There's no "@" sign in the JSON attribute name.
 Values in JSON attributes can be either typed (ex: number, boolean), or strings (ex: "3" instead of just 3) depending if the conversion could determine the attribute type or not. 
-API users should expect and handle both value and use the <b>XtkCaster</b> object to ensure proper conversion when using.</p>
+API users should expect and handle both value and use the <b>XtkCaster</b> object to ensure proper conversion.</p>
 
 <pre class="code">
 XML     &lt;root hello="world" count="3" ok="true"/>
@@ -73,7 +73,7 @@ JSON:   { item: [ { id:"1" }, { id:"2" } ] }
 
 
 <h1>Text nodes</h1>
-<p>Text of XML element is handle with the <b>$</b> sign in the JSON attribute name, or with a child JSON object name <b>$</b></p>
+<p>Text of XML element is handled with the <b>$</b> sign in the JSON attribute name, or with a child JSON object name <b>$</b></p>
 
 <p>Text of the root element</p>
 <pre class="code">
@@ -100,7 +100,7 @@ JSON:   { item: { $: "Hello", child: { id:"1" } }
 </p>
 
 <h1>Whitespaces</h1>
-<p>In XML documents, whitespaces can be either significant or insignifficant. The SDK uses the following rules to strip whitespaces, which correspond to how Campaign specifically uses XML</p>
+<p>In XML documents, whitespaces can be either significant or insignificant. The SDK uses the following rules to strip whitespaces, which correspond to how Campaign specifically uses XML</p>
 <p> </p>
 <ul>
 <li>The characters " ", "\t", "\r" and "\n" are considered whitespaces</li>
@@ -112,7 +112,7 @@ JSON:   { item: { $: "Hello", child: { id:"1" } }
 </ul>
 <p> </p>
 <p>
-  Whitespace trimming consist of removing all the leading and trainling whitespaces of each text node and concatenating all text node values. If the resulting value is empty, the text node is ignored. The rationale is to remove insignificant spaces created when formatting XML documents
+  Whitespace trimming consists of removing all the leading and trailing whitespaces of each text node and concatenating all text node values. If the resulting value is empty, the text node is ignored. The rationale is to remove insignificant spaces created when formatting XML documents
 </p>
 
 

--- a/docs/simpleJson.html
+++ b/docs/simpleJson.html
@@ -27,6 +27,7 @@ title: SimpleJson format
 </pre>
 
 
+<h1>XML Root</h1>
 <p>The XML root element tag is automatically determined by the SDK as it's generating the XML, usually from the current schema name.</p>
 
 <pre class="code">
@@ -34,15 +35,21 @@ XML:     &lt;root/>
 JSON:    {}
 </pre>
 
+
+
+
+<h1>XML Attributes</h1>
 <p>XML attributes are mapped to JSON attributes with the same name, whose litteral value can be a string, number, or boolean. There's no "@" sign in the JSON attribute name.
-Values in JSON attributes can be indifferently typed (ex: number, boolean), or strings (ex: "3" instead of just 3) depending if the conversion could determine the attribute type or not. 
-API users should expect and handle both value and use the `XtkCaster` object to ensure proper conversion when using.</p>
+Values in JSON attributes can be either typed (ex: number, boolean), or strings (ex: "3" instead of just 3) depending if the conversion could determine the attribute type or not. 
+API users should expect and handle both value and use the <b>XtkCaster</b> object to ensure proper conversion when using.</p>
 
 <pre class="code">
 XML     &lt;root hello="world" count="3" ok="true"/>
 JSON:   { hello:"world", count:"3", ok:"true" }
 </pre>
 
+
+<h1>XML Elements</h1>
 <p>XML elements are mapped to JSON objects</p>
 
 <pre class="code">
@@ -64,6 +71,8 @@ XML:    &lt;root>&lt;item id=1/>&lt;item id=2/>&lt;/root>
 JSON:   { item: [ { id:"1" }, { id:"2" } ] }
 </pre>
 
+
+<h1>Text nodes</h1>
 <p>Text of XML element is handle with the <b>$</b> sign in the JSON attribute name, or with a child JSON object name <b>$</b></p>
 
 <p>Text of the root element</p>
@@ -86,3 +95,66 @@ XML:    &lt;root>&lt;item>Hello&lt;child id="1"/>
         &lt;/root>
 JSON:   { item: { $: "Hello", child: { id:"1" } }
 </pre>
+
+<p>Normally Campaign will not generate XML with elements containing multiple sibling text nodes. If this should happen, the SDK will consider them as a single text value, i.e. it will concatenate the contents of each text and CDATA node as if there was only one. However, whitespaces are processed independently for each text node.
+</p>
+
+<h1>Whitespaces</h1>
+<p>In XML documents, whitespaces can be either significant or insignifficant. The SDK uses the following rules to strip whitespaces, which correspond to how Campaign specifically uses XML</p>
+<p> </p>
+<ul>
+<li>The characters " ", "\t", "\r" and "\n" are considered whitespaces</li>
+<li>CDATA sections are kept unchanged, i.e. whitespaces are preserved exactly</li>
+<li>For TEXT nodes directly under the root node are, whitespaces will be trimmed as explained below</li>
+<li>For element nodes which only contain text and possibly attributes (for instance &lt;node&gt;value&lt;/node&gt;</li>, the text is kept unchanged, i.e. whitespaces are preserved exactly</li>
+<li>For element nodes which have child elements, whitespaces will be trimmed as explained below</li>
+<li>For the root element, whitespaces are always trimmed</li>
+</ul>
+<p> </p>
+<p>
+  Whitespace trimming consist of removing all the leading and trainling whitespaces of each text node and concatenating all text node values. If the resulting value is empty, the text node is ignored. The rationale is to remove insignificant spaces created when formatting XML documents
+</p>
+
+
+<h1>Exceptions</h1>
+
+<h2>When an attribute has the same name of an element</h2>
+
+<p>If an element contains another element and an attribute which have the same name, the attribute name is prefixed with the "@" character</p>
+<pre class="code">
+XML:    &lt;root timezone="Europe/Paris">
+          &lt;timezone>Europe/Paris&lt;/timezone>
+        &lt;/root>
+JSON:   { "@timezone": "Europe/Paris", 
+          timezone: { "$": "Europe/Paris" } }
+</pre>
+
+
+<h1>Arrays of text elements</h1>
+<pre class="code">
+  XML:    &lt;root>
+            &lt;item>One&lt;/item>
+            &lt;item>Two&lt;/item>
+          &lt;/root>
+  JSON:   { item: [
+            { $: "One" },
+            { $: "Two" }
+          ] }
+  </pre>
+  
+
+
+<h1>Compatibility notes</h1>
+
+<p>
+  A few gaps were identified regarding SimpleJson format when converting from XML to JSON. They were fixed in release 1.1.13 and may introduce some behavior changes for cases which were ambiguous
+</p>
+<p> </p>
+<ul>
+  <li>When XML element has both a text content and attributes or child elements</li>
+  <li>When root element has only text</li>
+  <li>When XML element has both an attribute and a child element with the same name</li>
+  <li>When array contains element which only have text</li>
+  <li>When XML is formatted (and therefore has insignificant whitespaces)</li>
+  <li>XML collections (i.e. when root node ends with “-collection”) would sometimes contain a JSON property “#text”</li>  
+</ul>

--- a/src/domUtil.js
+++ b/src/domUtil.js
@@ -474,11 +474,11 @@ class DomUtil {
             while (child) {
                 if (child.nodeType === 3) { // text 
                     var nodeText = child.nodeValue;
-                    // Whitesapce trimming rule: alwasy trim for the root node, and trim for non-root nodes
+                    // Whitespace trimming rule: always trim for the root node, and trim for non-root nodes
                     // which actually have children elements
                     // Never trim CDATA nodes (nodeType 4)
                     if (!parentJson || hasChildElements)
-                        nodeText = Util.removeXmlWhiteSpaces(nodeText); 
+                        nodeText = nodeText.trim(); 
                     if (nodeText) text = text + nodeText;
                 }    
                 else if (child.nodeType === 4) { // CDATA    

--- a/src/domUtil.js
+++ b/src/domUtil.js
@@ -386,6 +386,7 @@ class DomUtil {
     static _getTextIfTextNode(xml) {
         const child = xml.firstChild;
         if (!child) return null;                   // no children
+        if (xml.hasAttributes()) return null;      // no attributes
         if (child.nextSibling) return null;        // more than 1 child
         if (child.nodeType !== 3 && child.nodeType !== 4) return null;
         const text = child.nodeValue;
@@ -400,29 +401,37 @@ class DomUtil {
      * @param {Element} xml the DOM element to convert to JSON
      * @param {Object} json the object literal to write to
      * @param {string} flavor the JSON flavor: "SimpleJson" or "BadgerFish"
+     * @param {Object} parentJson parent JSON node during recursion. Is undefined for first call
+     * @param {boolean} forceTextAs is set during recursion (SimpleJson format) to force serialization of text nodes using "$: value" syntax 
+     *                  instead of "$name: value" syntax. This is necessary to process collections and arrays of elements which only 
+     *                  contain text nodes.
      */
-    static _toJSON(xml, json, flavor) {
-        if (xml.hasAttributes()) {
-            var attributes = xml.attributes;
-            for (var i=0; i<attributes.length; i++) {
-                var att = attributes[i];
-                var attName = (flavor == "BadgerFish" ? "@" : "") + att.name;
-                json[attName] = att.value;
-            }
-        }
+    static _toJSON(xml, json, flavor, parentJson, forceTextAs$) {
 
         // Heuristic to determine if element is an object or an array
         const isCollection = xml.tagName.length > 11 && xml.tagName.substr(xml.tagName.length-11) == '-collection';
 
+        // Figure out which elements are arrays. Keep a count of elements for each tag name.
+        // When count >1 we consider this tag name to be an array
+        var hasChildElements = false; // Will be set if there is at least one child element
+        const countByTag = {};
         var child = xml.firstChild;
         while (child) {
-            var childName = child.nodeName;
-            if (isCollection && (json[childName] === null || json[childName] === undefined))
-                json[childName] = [ ];
-            var isArray = !!json[childName];
-            if (isArray && !Util.isArray(json[childName]))
-                json[childName] = [ json[childName] ];
-            if (child.nodeType == 1) {  // element
+            if (child.nodeType == 1) {
+                const childName = child.nodeName;
+                if (countByTag[childName] === undefined) countByTag[childName] = 1;
+                else countByTag[childName] = countByTag[childName] + 1;
+                hasChildElements = true;
+            }
+            child = child.nextSibling;
+        }
+        
+        child = xml.firstChild;
+        while (child) {
+            if (child.nodeType == 1) {
+                const childName = child.nodeName;
+                const isArray = isCollection || countByTag[childName] > 1;
+                if (isArray && !json[childName]) json[childName] = [];
                 // In SimpleJson representation, ensure we have proper transformation
                 // of text and CDATA nodes. For instance, the following
                 //  <workflow><desc>Hello</desc></workflow>
@@ -434,12 +443,12 @@ class DomUtil {
                 // from the schema, we cannot know if <desc></desc> should be
                 // transformed into "$desc": "" or into "desc": {}
                 const text = this._getTextIfTextNode(child);
-                if (text !== null && flavor == "SimpleJson") {
+                if (!isArray && text !== null && flavor == "SimpleJson") {
                     json[`$${childName}`] = text;
                 }
                 else {
                     const jsonChild = flavor == "BadgerFish" ? new BadgerFishObject() : {};
-                    this._toJSON(child, jsonChild, flavor);
+                    this._toJSON(child, jsonChild, flavor, json, isArray);
                     if (isArray) 
                         json[childName].push(jsonChild);
                     else
@@ -456,6 +465,46 @@ class DomUtil {
                 }
             }
             child = child.nextSibling;
+        }
+
+        // Proceed with text nodes in SimpleJson format. 
+        if (flavor === "SimpleJson") {
+            var text = "";
+            child = xml.firstChild;
+            while (child) {
+                if (child.nodeType === 3) { // text 
+                    var nodeText = child.nodeValue;
+                    // Whitesapce trimming rule: alwasy trim for the root node, and trim for non-root nodes
+                    // which actually have children elements
+                    // Never trim CDATA nodes (nodeType 4)
+                    if (!parentJson || hasChildElements)
+                        nodeText = Util.removeXmlWhiteSpaces(nodeText); 
+                    if (nodeText) text = text + nodeText;
+                }    
+                else if (child.nodeType === 4) { // CDATA    
+                    const cdataText = child.nodeValue;
+                    if (cdataText) text = text + cdataText;
+                }    
+                child = child.nextSibling;
+            }
+            if (text) {
+                json.$ = text;
+            }
+        }
+
+        // Finally proceed with attributes. They are processed last so that we get a chance to prefix
+        // the attribute name with "@" in SimpleJson format if there's already an element with the
+        // same name
+        if (xml.hasAttributes()) {
+            const attributes = xml.attributes;
+            for (var i=0; i<attributes.length; i++) {
+                const att = attributes[i];
+                var attName = (flavor == "BadgerFish" ? "@" : "") + att.name;
+                if (json[attName] !== undefined && flavor === "SimpleJson")
+                    // There's already an element with the same name as the attribute
+                    attName = "@" + attName;
+                json[attName] = att.value;
+            }
         }
     }
 

--- a/src/util.js
+++ b/src/util.js
@@ -133,6 +133,25 @@ class Util {
     }
     return obj;
   }
+
+  /**
+   * Trims the text value of an XML text node, i.e. remove leading and trailing whitespaces (space, tab, \r and \n)
+   * @param {string} text value of the XML text node
+   * @returns {string} the trimmed value
+   */
+  static removeXmlWhiteSpaces(text) {
+    if (!text) return text;
+      var first = 0, last = text.length - 1;
+      while (first <= last) {
+        var c = text[first];
+        if (c === ' ' || c === '\t' || c === '\n' || c === '\r') { first = first + 1; continue; }
+        c = text[last];
+        if (c === ' ' || c === '\t' || c === '\n' || c === '\r') { last = last - 1; continue; }
+        break;
+    }
+    text = text.substring(first, last + 1);
+    return text;
+  }
 }
 
 /**

--- a/src/util.js
+++ b/src/util.js
@@ -133,25 +133,6 @@ class Util {
     }
     return obj;
   }
-
-  /**
-   * Trims the text value of an XML text node, i.e. remove leading and trailing whitespaces (space, tab, \r and \n)
-   * @param {string} text value of the XML text node
-   * @returns {string} the trimmed value
-   */
-  static removeXmlWhiteSpaces(text) {
-    if (!text) return text;
-      var first = 0, last = text.length - 1;
-      while (first <= last) {
-        var c = text[first];
-        if (c === ' ' || c === '\t' || c === '\n' || c === '\r') { first = first + 1; continue; }
-        c = text[last];
-        if (c === ' ' || c === '\t' || c === '\n' || c === '\r') { last = last - 1; continue; }
-        break;
-    }
-    text = text.substring(first, last + 1);
-    return text;
-  }
 }
 
 /**

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -2592,7 +2592,7 @@ describe('ACC Client', function () {
         </extAccount-collection>`);
         });
 
-        it("Should force an json representation", async () => {
+        it("Should force a json representation", async () => {
             const client = await Mock.makeClient();
             client._transport.mockReturnValueOnce(Mock.LOGON_RESPONSE);
             await client.NLWS.xtkSession.logon();
@@ -2611,7 +2611,7 @@ describe('ACC Client', function () {
             const query = client.NLWS.json.xtkQueryDef.create(queryDef);
             const result = await query.executeQuery();
             const json = JSON.stringify(result);
-            expect(json).toBe('{"#text":[],"extAccount":[{"id":"1816","name":"defaultPopAccount"},{"id":"1818","name":"defaultOther"},{"id":"1849","name":"billingReport"},{"id":"12070","name":"TST_EXT_ACCOUNT_POSTGRESQL"},{"id":"1817","name":"defaultEmailBulk"},{"id":"2087","name":"ffda"},{"id":"2088","name":"defaultEmailMid"}]}');
+            expect(json).toBe('{"extAccount":[{"id":"1816","name":"defaultPopAccount"},{"id":"1818","name":"defaultOther"},{"id":"1849","name":"billingReport"},{"id":"12070","name":"TST_EXT_ACCOUNT_POSTGRESQL"},{"id":"1817","name":"defaultEmailBulk"},{"id":"2087","name":"ffda"},{"id":"2088","name":"defaultEmailMid"}]}');
         });
     });
 

--- a/test/domUtil.test.js
+++ b/test/domUtil.test.js
@@ -177,6 +177,24 @@ describe('DomUtil', function() {
         assert.strictEqual(fromJSON({ "a": undefined }), '<root/>');
     });
 
+    describe('fromJSON (advanced)', function() {
+        function fromJSON(json) {
+            var xml = DomUtil.fromJSON("root", json);
+            return DomUtil.toXMLString(xml);
+        }
+
+        it("Should handle fixes made in version 1.1.3", () => {
+            expect(fromJSON({ $: "Hello" })).toBe("<root>Hello</root>");
+            expect(fromJSON({ "$delivery": "Hello" })).toBe("<root><delivery>Hello</delivery></root>");
+            expect(fromJSON({ "delivery": { $: "Hello" } })).toBe("<root><delivery>Hello</delivery></root>");
+            //expect(fromJSON({ "$delivery": "World", "delivery": { $: "Hello" } })).toBe("<root><delivery>Hello</delivery></root>");
+            expect(fromJSON({delivery: { "transaction": "0", "$": "0" }})).toBe('<root><delivery transaction="0">0</delivery></root>');            
+            expect(fromJSON({delivery: { "$": "Hello", child: { name: "world" } }})).toBe('<root><delivery>Hello<child name="world"/></delivery></root>');
+            expect(fromJSON({delivery: { "$": "Hello", child: { name: "world" } }})).toBe('<root><delivery>Hello<child name="world"/></delivery></root>');
+            expect(fromJSON({ delivery: { $: "HelloWorld", child:{} } })).toBe('<root><delivery>HelloWorld<child/></delivery></root>');
+        });
+    });
+
     describe('toJSON (SimpleJson)', function() {
 
         function toJSON(xml) {
@@ -185,11 +203,13 @@ describe('DomUtil', function() {
             return json;
         }
 
-        assert.deepStrictEqual(toJSON('<root/>'), {});
-        assert.deepStrictEqual(toJSON('<root a="1"/>'), { a:"1" });
-        assert.deepStrictEqual(toJSON('<root a="1" b="2"/>'), { a:"1", b:"2" });
-        assert.deepStrictEqual(toJSON('<root><a/></root>'), { a:{} });
-        assert.deepStrictEqual(toJSON('<root><a/><a/></root>'), { a:[{},{}] });
+        it("Should convert XML to SimpleJSON", () => {
+            assert.deepStrictEqual(toJSON('<root/>'), {});
+            assert.deepStrictEqual(toJSON('<root a="1"/>'), { a:"1" });
+            assert.deepStrictEqual(toJSON('<root a="1" b="2"/>'), { a:"1", b:"2" });
+            assert.deepStrictEqual(toJSON('<root><a/></root>'), { a:{} });
+            assert.deepStrictEqual(toJSON('<root><a/><a/></root>'), { a:[{},{}] });
+        });
     });
 
     describe('fromJSON (invalid flavor)', function() {
@@ -217,6 +237,233 @@ describe('DomUtil', function() {
         
     });
     
+    describe('toJson (SimpleJson, advanced)', function() {
+        function toJSON(xml) {
+            xml = DomUtil.parse(xml);
+            var json = DomUtil.toJSON(xml, "SimpleJson");
+            return json;
+        }
+
+        it("Should handle elements containing both text and other elements", () => {
+            expect(toJSON('<root>Hello</root>')).toEqual({ $: "Hello" });
+            expect(toJSON('<ctx><delivery>Hello</delivery></ctx>')).toEqual({ "$delivery": "Hello" });
+            expect(toJSON('<delivery transaction="0">0</delivery>')).toEqual({ "transaction": "0", "$": "0" });
+            expect(toJSON('<ctx><delivery transaction="0">0</delivery></ctx>')).toEqual({delivery: { "transaction": "0", "$": "0" }});
+            expect(toJSON('<ctx><delivery>Hello<child name="world"/></delivery></ctx>')).toEqual({delivery: { "$": "Hello", child: { name: "world" } }});
+            expect(toJSON('<ctx><delivery><child name="world"/>Hello</delivery></ctx>')).toEqual({delivery: { "$": "Hello", child: { name: "world" } }});
+            expect(toJSON('<root><delivery>Hello<child/>World</delivery></root>')).toEqual({ delivery: { $: "HelloWorld", child:{} } });
+        });
+
+        describe("Should handle insignificant whitespaces", () => {
+            it("Should not remove whitespace for element which does not have any children", () => {
+                expect(toJSON('<root><delivery> \nHello </delivery></root>')).toEqual({ $delivery: " \nHello " });
+            });
+            it("Should remove whitespace for root element even if it does not have any children. Because in SimpleJson we consider that root always has children", () => {
+                expect(toJSON('<root>\n</root>')).toEqual({ });
+                expect(toJSON('<root> \nHello </root>')).toEqual({ $: "Hello" });
+                expect(toJSON('<root> \nHello <delivery/></root>')).toEqual({ $: "Hello", delivery: {} });
+                expect(toJSON('<root> \nHello<delivery/> </root>')).toEqual({ $: "Hello", delivery: {} });
+            });
+            it("Should never remove whitespace in the middle of text", () => {
+                expect(toJSON('<root>Hello World</root>')).toEqual({ $: "Hello World" });
+                expect(toJSON('<root><delivery>Hello World</delivery></root>')).toEqual({ $delivery: "Hello World" });
+                expect(toJSON('<root><delivery>   Hello World </delivery></root>')).toEqual({ $delivery: "   Hello World " });
+                expect(toJSON('<root><delivery>   Hello <child/>World </delivery></root>')).toEqual({ delivery: { $: "HelloWorld", child:{} } });
+                expect(toJSON('<root><delivery>   Hello Cruel W<child/>orld </delivery></root>')).toEqual({ delivery: { $: "Hello Cruel World", child:{} } });
+            });
+
+            it("Should remove insignificant spaces", () => {
+                expect(toJSON('<ctx>\n  <delivery>\n    <target x="2"/>\n  </delivery>\n</ctx>')).toEqual({delivery: { target: { x:"2"} }});    
+            });
+
+            it("Should handle collections", () => {
+                expect(toJSON('<test-collection>\n  <test a="1"></test>\n</test-collection>')).toEqual({test: [ { a:"1" }] });
+                expect(toJSON('<test-collection>\n  <test a="1"></test>\n  <test a="2"></test>\n</test-collection>')).toEqual({test: [ { a:"1" }, { a:"2" }] });
+            });
+
+            it("Should handle collections of text elements", () => {
+                expect(toJSON('<test-collection>\n  <test>One</test>\n</test-collection>')).toEqual({test: [ { $:"One" }] });
+                expect(toJSON('<test-collection>\n  <test>One</test>\n  <test>Two</test>\n</test-collection>')).toEqual({test: [ { $:"One" }, { $:"Two" }] });
+                expect(toJSON('<array>\n  <test>One</test>\n  <test>Two</test>\n</array>')).toEqual({test: [ { $:"One" }, { $:"Two" }] });
+            });
+
+            it("Should never remove whitespaces of CDATA nodes", () => {
+                expect(toJSON('<root><![CDATA[]]></root>')).toEqual({});
+                expect(toJSON('<root><![CDATA[ Hello\tWorld\n  ]]></root>')).toEqual({ $: " Hello\tWorld\n  "});
+                expect(toJSON('<root><![CDATA[ Hello\t]]><![CDATA[World\n  ]]></root>')).toEqual({ $: " Hello\tWorld\n  "});
+            });
+
+            it("Should not handle whitespaces if element containing text has only attributes", () => {
+                // Whitespaces are always removed for the root node
+                expect(toJSON('<delivery transaction="0"> Hello World </delivery>')).toEqual({ "transaction": "0", "$": "Hello World" });
+                // But not for child nodes
+                expect(toJSON('<root><delivery transaction="0"> Hello World </delivery></root>')).toEqual({ delivery: { "transaction": "0", "$": " Hello World " } });
+            });
+        });
+
+        describe("Real payloads", () => {
+            it("Should convert report data payload", () => {
+                const xml = `<ctx lang="en" date="2022-11-18T08:04:06Z" _target="web" webApp-id="1583" _context="selection" _reportContext="deliverySending" _schema="nms:delivery" _hasFilter="false" _selection="12133" _folderModel="nmsDelivery" _folderLinkId="@folder-id" _folderLink="folder" activityHist="@r2rp0BOIZulQ3PcAaXVCr+9of9KxMPqM4MWmTTydhh4/qMVzTGmcRevNzHnoPS0WHvHKH084KIWom6NaVlzR1vCXv47bq3m/dfT3j7MQDSyDwb0rPU/4rD08CeDN3xqR6GazBmh+Lmz+ugo85WCwAaCDUYEJtG/EcqCOO0G+PRtjHlrNOhSrDSxanl4pxonQ4DhDTejA5VjSopu7pvV8U32e5k+fFuk/vvaOMHUP2Zk+VNuMnEytIExnbstFDepeSRDEMuIgmHWuENglhtcdfH3suIcibmqFyBF6Xupcqp2LlicJFFkXHXuM2LgUC7BTGsqMsN4HhNSs6NzW8ZhMPA==">
+                <userInfo datakitInDatabase="true" homeDir="" instanceLocale="en-US" locale="en-US" login="internal" loginCS="Internal account" loginId="0" noConsoleCnx="false" orgUnitId="0" theme="" timezone="Europe/Paris" xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns="urn:xtk:session" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>
+                <timezone current="Europe/Paris" changed="false"/>
+                <_contextFilter>
+                  <where>
+                    <condition enabledIf="$(@_context) = 'selection' and $(@_hasFilter) = false" expr="@id = $noescaping(@_selection)"/>
+                    <condition enabledIf="$(@_context) = 'selection' and $(@_hasFilter) and $(@_locationName) != 'descriptiveAnalysis'" expr="@id" setOperator="IN" subQuery="$(whereCond)"/>
+                  </where>
+                </_contextFilter>
+                <activityHistory>
+                  <activity name="page" type="page"/>
+                  <activity name="query2" type="query"/>
+                  <activity name="script2" type="script"/>
+                  <activity name="query" type="query"/>
+                  <activity name="start" type="start"/>
+                </activityHistory>
+                <data>
+                  <query>
+                    <delivery amount="0" article="0" contactDate="" error="0" estimatedRecipientOpen="0" estimatedTotalRecipientOpen="0" forward="0" label="" mirrorPage="0" newQuarantine="0" optOut="0" personClick="0" recipientClick="0" reject="0" success="0" toDeliver="0" totalRecipientClick="0" totalTarget="0" totalWebPage="0" transaction="0">0</delivery>
+                  </query>
+                </data>
+                <vars>
+                  <operator>0</operator>
+                </vars>
+                <title>Delivery:</title>
+                <query2/>
+                <chart_page_123722795831>
+                  <data>&lt;data/&gt;</data>
+                  <config>&lt;graphConfig accumulate="false" autoScale="true" autoStretch="true" computePercent="false" displayEmptySamples="false" filledOpacity="50" innerPieRadius="0" perspective="true" renderType="pie" reverseSeries="false" reverseStacking="false" showLabels="0" sortMode="2" zoomOnWheel="true"&gt;&lt;onclick action="url" enabledWhenHistory="false" target="_blank"/&gt;&lt;legend layout="right" visible="true"/&gt;&lt;series aggregate="sum" label="" renderGroup="layered" xpath="/dlvExclusion" xpathIndex="@label" xpathValue="@count"/&gt;&lt;/graphConfig&gt;</config>
+                </chart_page_123722795831>
+              </ctx>`;
+                expect(toJSON(xml)).toEqual(
+                    {
+                        userInfo: {
+                          datakitInDatabase: "true",
+                          homeDir: "",
+                          instanceLocale: "en-US",
+                          locale: "en-US",
+                          login: "internal",
+                          loginCS: "Internal account",
+                          loginId: "0",
+                          noConsoleCnx: "false",
+                          orgUnitId: "0",
+                          theme: "",
+                          timezone: "Europe/Paris",
+                          "xmlns:SOAP-ENV": "http://schemas.xmlsoap.org/soap/envelope/",
+                          "xmlns:ns": "urn:xtk:session",
+                          "xmlns:xsd": "http://www.w3.org/2001/XMLSchema",
+                          "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
+                        },
+                        timezone: {
+                          current: "Europe/Paris",
+                          changed: "false",
+                        },
+                        _contextFilter: {
+                          where: {
+                            condition: [
+                              {
+                                enabledIf: "$(@_context) = 'selection' and $(@_hasFilter) = false",
+                                expr: "@id = $noescaping(@_selection)",
+                              },
+                              {
+                                enabledIf: "$(@_context) = 'selection' and $(@_hasFilter) and $(@_locationName) != 'descriptiveAnalysis'",
+                                expr: "@id",
+                                setOperator: "IN",
+                                subQuery: "$(whereCond)",
+                              },
+                            ],
+                          },
+                        },
+                        activityHistory: {
+                          activity: [
+                            {
+                              name: "page",
+                              type: "page",
+                            },
+                            {
+                              name: "query2",
+                              type: "query",
+                            },
+                            {
+                              name: "script2",
+                              type: "script",
+                            },
+                            {
+                              name: "query",
+                              type: "query",
+                            },
+                            {
+                              name: "start",
+                              type: "start",
+                            },
+                          ],
+                        },
+                        data: {
+                          query: {
+                            delivery: {
+                              $: "0",
+                              amount: "0",
+                              article: "0",
+                              contactDate: "",
+                              error: "0",
+                              estimatedRecipientOpen: "0",
+                              estimatedTotalRecipientOpen: "0",
+                              forward: "0",
+                              label: "",
+                              mirrorPage: "0",
+                              newQuarantine: "0",
+                              optOut: "0",
+                              personClick: "0",
+                              recipientClick: "0",
+                              reject: "0",
+                              success: "0",
+                              toDeliver: "0",
+                              totalRecipientClick: "0",
+                              totalTarget: "0",
+                              totalWebPage: "0",
+                              transaction: "0",
+                            },
+                          },
+                        },
+                        vars: {
+                          $operator: "0",
+                        },
+                        $title: "Delivery:",
+                        query2: {
+                        },
+                        chart_page_123722795831: {
+                          $data: "<data/>",
+                          $config: "<graphConfig accumulate=\"false\" autoScale=\"true\" autoStretch=\"true\" computePercent=\"false\" displayEmptySamples=\"false\" filledOpacity=\"50\" innerPieRadius=\"0\" perspective=\"true\" renderType=\"pie\" reverseSeries=\"false\" reverseStacking=\"false\" showLabels=\"0\" sortMode=\"2\" zoomOnWheel=\"true\"><onclick action=\"url\" enabledWhenHistory=\"false\" target=\"_blank\"/><legend layout=\"right\" visible=\"true\"/><series aggregate=\"sum\" label=\"\" renderGroup=\"layered\" xpath=\"/dlvExclusion\" xpathIndex=\"@label\" xpathValue=\"@count\"/></graphConfig>",
+                        },
+                        lang: "en",
+                        date: "2022-11-18T08:04:06Z",
+                        _target: "web",
+                        "webApp-id": "1583",
+                        _context: "selection",
+                        _reportContext: "deliverySending",
+                        _schema: "nms:delivery",
+                        _hasFilter: "false",
+                        _selection: "12133",
+                        _folderModel: "nmsDelivery",
+                        _folderLinkId: "@folder-id",
+                        _folderLink: "folder",
+                        activityHist: "@r2rp0BOIZulQ3PcAaXVCr+9of9KxMPqM4MWmTTydhh4/qMVzTGmcRevNzHnoPS0WHvHKH084KIWom6NaVlzR1vCXv47bq3m/dfT3j7MQDSyDwb0rPU/4rD08CeDN3xqR6GazBmh+Lmz+ugo85WCwAaCDUYEJtG/EcqCOO0G+PRtjHlrNOhSrDSxanl4pxonQ4DhDTejA5VjSopu7pvV8U32e5k+fFuk/vvaOMHUP2Zk+VNuMnEytIExnbstFDepeSRDEMuIgmHWuENglhtcdfH3suIcibmqFyBF6Xupcqp2LlicJFFkXHXuM2LgUC7BTGsqMsN4HhNSs6NzW8ZhMPA==",
+                      }
+                );
+            });
+        });
+
+        it("Should support attribute and element with same name", () => {
+            expect(toJSON('<ctx lang="en" timezone="Europe/Paris"><timezone current="Europe/Paris" changed="false"/></ctx>')).toEqual({
+                lang: "en",
+                "@timezone": "Europe/Paris",
+                "timezone": {
+                    current: "Europe/Paris",
+                    changed: "false",
+                }
+            });
+        });
+
+    });
 
     describe('toXMLString', function() {
 

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -102,21 +102,6 @@ describe('Util', function() {
         })
     })
 
-    describe("Util.removeXmlWhiteSpaces", () => {
-        it("Should remove whitespaces", () => {
-            expect(Util.removeXmlWhiteSpaces("")).toBe("");
-            expect(Util.removeXmlWhiteSpaces(" ")).toBe("");
-            expect(Util.removeXmlWhiteSpaces("\t  ")).toBe("");
-            expect(Util.removeXmlWhiteSpaces(" \r\n  ")).toBe("");
-            expect(Util.removeXmlWhiteSpaces("Hello")).toBe("Hello");
-            expect(Util.removeXmlWhiteSpaces(" Hello")).toBe("Hello");
-            expect(Util.removeXmlWhiteSpaces(" \r\nHello")).toBe("Hello");
-            expect(Util.removeXmlWhiteSpaces(" \r\nHello ")).toBe("Hello");
-            expect(Util.removeXmlWhiteSpaces("Hello ")).toBe("Hello");
-            expect(Util.removeXmlWhiteSpaces("Hello World ")).toBe("Hello World");
-        });
-    });
-
     describe("Safe storage", () => {
       it("Should support undefined delegate", () => {
           const storage = new SafeStorage();

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -17,8 +17,8 @@ governing permissions and limitations under the License.
  * 
  *********************************************************************************/
 
- const { Util, ArrayMap } = require('../src/util.js');
- const { SafeStorage, Cache } = require('../src/cache.js');
+const { Util, ArrayMap } = require('../src/util.js');
+const { SafeStorage, Cache } = require('../src/cache.js');
 
 
 describe('Util', function() {
@@ -102,6 +102,20 @@ describe('Util', function() {
         })
     })
 
+    describe("Util.removeXmlWhiteSpaces", () => {
+        it("Should remove whitespaces", () => {
+            expect(Util.removeXmlWhiteSpaces("")).toBe("");
+            expect(Util.removeXmlWhiteSpaces(" ")).toBe("");
+            expect(Util.removeXmlWhiteSpaces("\t  ")).toBe("");
+            expect(Util.removeXmlWhiteSpaces(" \r\n  ")).toBe("");
+            expect(Util.removeXmlWhiteSpaces("Hello")).toBe("Hello");
+            expect(Util.removeXmlWhiteSpaces(" Hello")).toBe("Hello");
+            expect(Util.removeXmlWhiteSpaces(" \r\nHello")).toBe("Hello");
+            expect(Util.removeXmlWhiteSpaces(" \r\nHello ")).toBe("Hello");
+            expect(Util.removeXmlWhiteSpaces("Hello ")).toBe("Hello");
+            expect(Util.removeXmlWhiteSpaces("Hello World ")).toBe("Hello World");
+        });
+    });
 
     describe("Safe storage", () => {
       it("Should support undefined delegate", () => {


### PR DESCRIPTION
## Description

I discovered a few more issues in the XML to JSON serialization.
More documentation: https://opensource.adobe.com/acc-js-sdk/simpleJson.html
 

when XML element has both a text content and attributes or child elements
when root element has only text
when XML element has both an attribute and a child element with the same name
when array contains element which only have text
when XML is formatted (and therefore has insignificant whitespaces)
XML collections (i.e. when root node ends with “-collection”) would sometimes contain a JSON property “#text”
 

So far the SimpleJSon rules where:

 

XML Attributes are transformed to JSON properties without the “@” prefix. The rationale is that Campaign generally uses attributes, so we make the attribute syntax the most straightforward.
XML Elements are transformed to JSON objects or arrays if the element appears more than once
XML Elements containing only text are transformed to JSON properties with the “$” prefix. The rationale is that Campaign usually does not have XML elements containing both text and children elements and therefore the JSON syntax remains simple in the common case
 

I’m adding the following rules

 

When XML element has both a XML child element and an attribute with the same name, the attribute will have the “@” prefix. This assume that both attribute and element are actually present (possibly empty) in the XML
XML elements containing only text will continue to be transformed to JSON properties with the “$” prefix. Whitespaces in the text content are unchanged.
XML elements containing text and either attributes or children will be transformed to JSON objects having the “$” property which will contain the text. The whitespaces in the text will be removed
When XML element contain multiple XML text nodes, they will be concatenated and seen as one in JSON. This is not recursive. Each text node is considered independently regarding whitespaces
CDATA nodes will be considered as text nodes but for which whitespaces are never removed
Whitespace removal consist on removing the “ “, “\t”, “\n” and “\r” characters at the beginning or the end of the text
 

Here are a few examples of what's expected

 
```
expect(toJSON('<root>Hello</root>')).toEqual({ $: "Hello" });
expect(toJSON('<ctx><delivery>Hello</delivery></ctx>')).toEqual({ "$delivery": "Hello" });
expect(toJSON('<delivery transaction="0">0</delivery>')).toEqual({ "transaction": "0", "$": "0" });
expect(toJSON('<ctx><delivery transaction="0">0</delivery></ctx>')).toEqual({delivery: { "transaction":"0", "$": "0" }});
expect(toJSON('<ctx><delivery>Hello<child name="world"/></delivery></ctx>')).toEqual({delivery: { "$":"Hello", child:
{ name: "world" }
}});
expect(toJSON('<ctx><delivery><child name="world"/>Hello</delivery></ctx>')).toEqual({delivery: { "$":"Hello", child:
{ name: "world" }
}});
expect(toJSON('<root><delivery>Hello<child/>World</delivery></root>')).toEqual({ delivery: { $:"HelloWorld", child:{} } });
```

## Motivation and Context

* Processing report data (see https://github.com/adobe/acc-js-sdk/pull/50)
* The report data payload contain XML element which have both attributes and text content which was not supported before

## How Has This Been Tested?

* New unit tests

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

This change is actually a breaking change since it changes how JSON serialization works. However, it only changes for cases which were missing / buggy / not properly defined. So it should be backwards compatible. If not, the code that it breaks was probably not working / not safe anyways.

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
