### PR TITLE
Add unit test for schema nodes which are mapped as both xml and sql

### DIFF
--- a/docs/application.html
+++ b/docs/application.html
@@ -264,7 +264,7 @@ const root = await node.linkTarget();
     <tr><td><b>isNotNull</b></td><td>Returns a boolean which indicates whether or not the current node can take the null value into account.</td></tr>
     <tr><td><b>isRequired</b></td><td>Returns a boolean which indicates whether or not the value of the current node is mandatory.</td></tr>
     <tr><td><b>isRoot</b></td><td>Indicates if the node is the root node of a schema, i.e. the first child of the schema node, whose name matches the schema name</td></tr>
-    <tr><td><b>isSQL</b></td><td>Returns a boolean which indicates whether the current node is mapped in SQL.</td></tr>
+    <tr><td><b>isSQL</b></td><td>Returns a boolean which indicates whether the current node is mapped in SQL. There are some inconsistencies in ACC schemas, and sometimes attributes may be defined as both sql and xml (for example: nms:delivery/properties/seedProcessed). Such nodes with have both isSql=true and isMappedAsXml=true</td></tr>
     <tr><td><b>isTemporaryTable</b></td><td>Returns a boolean indicating whether the table is a temporary table. The table will not be created during database creation.</td></tr>
     <tr><td><b>unbound</b></td><td>Returns a boolean which indicates whether the current node has an unlimited number of children of the same type.</td></tr>
     <tr><td><b>joins</b></td><td>Element of type "link" has an array of XtkJoin. See <b>joinNodes</b> method.</td></tr>

--- a/test/application.test.js
+++ b/test/application.test.js
@@ -1973,6 +1973,28 @@ describe('Application', () => {
                 expect(node.isSQL).toBe(false);
             });
 
+            it("Should have isSQL even if it also has isXML", async () => {
+                const xml = DomUtil.parse(`<schema namespace='nms' name='delivery' mappingType="sql">
+                    <element name='delivery' sqltable="NmsDelivery">
+                        <element name='properties'>
+                            <attribute name="midAccountUsedName" type="string" xml="true"/>
+                            <attribute name="seedProcessed" sqlname="iSeedProcessed" type="long" xml="true"/>
+                        </element>
+                    </element>
+                </schema>`);
+                const schema = newSchema(xml);
+                const properties = await schema.root.findNode("properties");
+                expect(properties.isSQL).toBe(false);
+                // xml only node is not sql
+                const midAccountUsedName = await properties.findNode("@midAccountUsedName");
+                expect(midAccountUsedName.isSQL).toBe(false);
+                expect(midAccountUsedName.isMappedAsXML).toBe(true);
+                // node may be both xml and sql. If that's the case, it's considered sql
+                const seedProcessed = await properties.findNode("@seedProcessed");
+                expect(seedProcessed.isSQL).toBe(true);
+                expect(seedProcessed.isMappedAsXML).toBe(true);
+            });
+
             it("Should be memo and memo data" , async () => {
                 const xml = DomUtil.parse(`<schema namespace='nms' name='recipient' label="Recipients" labelSingular="Recipient">
                     <element name='recipient' sqltable="NmsRecipient">


### PR DESCRIPTION
## Description

Some ACC attributes are defined as both xml & sql
```
<attribute name="seedProcessed" type="long" label="Seed addresses" desc="Number of seeds inserted" sql="true" xml="true"/>
```

This adds a test to make sure the SDK properly handles such nodes: both isSQL and isMappedAsXml should return true.


## How Has This Been Tested?

New unit test with the nms:delivery/properties/@seedProcessed which is an actual node mapped as both sql and xml

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
