### PR TITLE
NEO-51282: Add support for xtk:jobInterface methods

### DIFF
--- a/compile.js
+++ b/compile.js
@@ -31,6 +31,7 @@ var resources = [
     { name: "./transport.js" },
     { name: "./xtkCaster.js" },
     { name: "./domUtil.js" },
+    { name: "./xtkJob.js" },
     { name: "./cache.js" },
     { name: "./entityAccessor.js" },
     { name: "./xtkEntityCache.js" },

--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -81,6 +81,8 @@
       link: methodLevelRepresentation.html
     - name: XTK Interfaces
       link: xtkInterface.html
+    - name: XTK Jobs
+      link: xtkJob.html
     - name: Handling timeouts
       link: timeouts.html
     - name: HTTP Headers

--- a/docs/xtkInterface.html
+++ b/docs/xtkInterface.html
@@ -17,4 +17,4 @@ const delivery = client.NLWS.nmsDelivery.create({ label: "Hello" });
 await delivery.newInstance();
 </pre>
 
-<p>There are 2 common interfaces: <a href="{{ site.baseurl }}/xtkPersist.html">xtk:persist</a> and <a href="">xtk:jobInterface</a> which are documented below.</p>
+<p>There are 2 common interfaces: <a href="{{ site.baseurl }}/xtkPersist.html">xtk:persist</a> and <a href="{{ site.baseurl }}/xtkJob.html">xtk:jobInterface</a> which are documented below.</p>

--- a/docs/xtkJob.html
+++ b/docs/xtkJob.html
@@ -1,0 +1,131 @@
+---
+layout: page
+title: XTK Jobs (xkt:job, xkt:jobInterface)
+---
+<p>This section describes how long running jobs are handled in ACC and ACC api. There are 2 schemas for jobs</p>
+<ul>
+  <li>xtk:job which represents an acutal job, and which is implemented by several objects such as nms:delivery</li>
+  <li>xtk:jobInterface which contains methods to submit jobs and get their statuses. Other schemas do not actually implement the xtk:jobInterface interface</li>
+</ul>
+
+<p>In term of SOAP calls, running a job is simply executing a SOAP call synchronously or asynchronously in a separate thread or process. However, calls must be made on both the xtk:jobInterface and job entity schema. The SDK provides a helper interface to submit and handle jobs</p>
+
+<h1>Simple Jobs</h1>
+  
+<p>
+  Simple jobs are non-static methods with no parameters, such as the nms:delivery#Prepare method which is used to prepare a delivery. 
+  Such jobs can be executed synchronously (xtk:jobInterface#Execute) or asynchronously (xtk:jobInterface#Submit). Both methods return
+  a job id which can be used to retreive (poll) more about the job.
+<p>
+    
+<p>
+  First, we need to retreive a delivery, which is the object upon which to run the Prepare method, but also implements xtk:job interface. 
+  The Prepare method requires a complete delivery object, so we use SelectAll
+</p>
+
+<pre class="code">
+  const  queryDef = {
+    schema: "nms:delivery",
+    operation: "get",
+    select: { node: [ { expr: "@id" } ] },
+    where: { condition: [ { expr:`@internalName='DM19'` } ] }
+  }
+  const  query = NLWS.xtkQueryDef.create(queryDef);
+  await query.selectAll();
+  const delivery = await query.executeQuery();
+</pre>
+
+<p>
+  Now we can create a job for the Prepare method using the <b>client.jobInterface</b> function which returns a XtkJobInterface object. 
+  We pass it a job specification containing the schema, method, and object
+</p>
+
+<pre class="code">
+  const job = await client.jobInterface({
+    xtkschema: 'nms:delivery',
+    method: 'Prepare',
+    object: delivery
+  });
+</pre>
+
+<p>
+  Finally we can submit the job and get it's status, progress, result, etc.
+</p>
+
+<pre class="code">
+  await job.submit();
+  var status = await job.getStatus();
+</pre>
+
+
+<h1>Soap calls</h1>
+<p>
+  The <b>SubmitSoapCall</b> method allows to run more complex jobs with parameters. The principle is the same, for instance calling the <b>PrepareProof</b> method
+  which takes a boolean parameter
+</p>
+
+<pre class="code">
+  const job = await client.jobInterface({
+    xtkschema: 'nms:delivery',
+    method: 'PrepareProof',
+    object: delivery,
+    args: [ false ]
+  });
+</pre>
+
+
+<h1>Job Status</h1>
+<p>
+  The status of a job is made of 3 pieces of information
+</p>
+<ul>
+  <li>The job status code</li>
+  <li>Job logs</li>
+  <li>Job properties which are arbitrary key value pairs and also contain progress information</li>
+</ul>
+
+<p>
+  For convenience, the SDK provides a <b>getStatus</b> function which will fetch and return the full job status object with strong
+  typing. When getStatus is called several time, each call will fetch the most recent status, and new logs since the previous call.
+</p>
+
+<table>
+  <thead>
+    <tr><th>Status code</th><th>Description</th></tr>
+  </thead>
+  <tbody>
+    <tr><td><b>0</b></td><td>Being edited</td></tr>
+    <tr><td><b>2</b></td><td>Running: execution is in progress</td></tr>
+    <tr><td><b>3</b></td><td>Canceling: a cancel request was submitted and the job will be canceld as soon as possible</td></tr>
+    <tr><td><b>4</b></td><td>Canceled</td></tr>
+    <tr><td><b>5</b></td><td>Finished: the job has finished successfully and getResult can be called</td></tr>
+    <tr><td><b>6</b></td><td>Error: the job failed. Details about the error can be found in the logs</td></tr>
+    <tr><td><b>7</b></td><td>Pause pending: a pause request was submitted and the job will be paused as soon as possible</td></tr>
+    <tr><td><b>8</b></td><td>Pause: the job is paused</td></tr>
+    <tr><td><b>9</b></td><td>Purge pending: a purge request was submitted and the job will be purged as soon as possible</td></tr>
+  </tbody>
+</table>
+
+
+<h1>Job Progress</h1>
+<p>
+  The progress of a job is available as 2 integers: current and max which represent the current progression and max value for progression.
+  Both values are returned by the getStatus call as properties (i.e. <b>properties.progress.current</b> and <b>properties.progress.max</b>).
+  The SDK provides the <b>getProgress</b> function to retreive the progress as a percentage (and a valid number)
+</p>
+
+<pre class="code">
+  // Returns progress as a percentage in the [0..1] range
+  var progressPercent = job.getProgress();
+</pre>
+
+
+<h1>Job Result</h1>
+<p>
+  Typically, a client would call the getStatus method every few seconds to get updates on the progress. When a job is finished and successfull,
+  one can get the result using the <b>getResult</b> function
+</p>
+
+<pre class="code">
+  var result = await job.getResult();
+</pre>

--- a/src/client.js
+++ b/src/client.js
@@ -1486,7 +1486,7 @@ class Client {
             throw CampaignException.SOAP_UNKNOWN_METHOD(schemaId, methodName, `Method '${methodName}' of schema '${schemaId}' not found`);
 
         // Compute the SOAP URN. Again, specically handle xtk:jobInterface as it's not a real schema. The actual entity schema
-        // would be available as the entitySchemaId proprtey of the callContext
+        // would be available as the entitySchemaId property of the callContext
         var urn = schemaId !== 'xtk:jobInterface'
             ? that._methodCache.getSoapUrn(schemaId, methodName)
             : `xtk:jobInterface|${entitySchemaId}`;

--- a/src/client.js
+++ b/src/client.js
@@ -1496,10 +1496,8 @@ class Client {
 
         // Compute the SOAP URN. Again, specically handle xtk:jobInterface as it's not a real schema. The actual entity schema
         // would be available as the entitySchemaId property of the callContext
-        var urn = schemaId !== 'xtk:jobInterface'
-            ? that._methodCache.getSoapUrn(schemaId, methodName)
+        var urn = schemaId !== 'xtk:jobInterface' ? that._methodCache.getSoapUrn(schemaId, methodName)
             : `xtk:jobInterface|${entitySchemaId}`;
-
 
         var soapCall = that._prepareSoapCall(urn, methodName, false, callContext.headers, callContext.pushDownOptions);
 

--- a/src/client.js
+++ b/src/client.js
@@ -1829,7 +1829,7 @@ class Client {
     }
 
     /**
-     * Creates a Job object which can be used to submit jobs, retreive status, logs and progress, etc.
+     * Creates a Job object which can be used to submit jobs, retrieve status, logs and progress, etc.
      * @param {Campaign.XtkSoapCallSpec} soapCallSpec the definition of the SOAP call
      * @returns {Campaign.XtkJobInterface} a job
      */

--- a/src/client.js
+++ b/src/client.js
@@ -36,6 +36,7 @@ const request = require('./transport.js').request;
 const Application = require('./application.js').Application;
 const EntityAccessor = require('./entityAccessor.js').EntityAccessor;
 const { Util } = require('./util.js');
+const { XtkJobInterface } = require('./xtkJob.js');
 
 /**
  * @namespace Campaign
@@ -169,16 +170,7 @@ const clientHandler = (representation, headers, pushDownOptions) => {
                         return callContext;
 
                     // get Schema id from namespace (find first upper case letter)
-                    var schemaId = "";
-                    for (var i=0; i<namespace.length; i++) {
-                        const c = namespace[i];
-                        if (c >='A' && c<='Z') {
-                            schemaId = schemaId + ":" + c.toLowerCase() + namespace.substr(i+1);
-                            break;
-                        }
-                        schemaId = schemaId + c;
-                    }
-                    callContext.schemaId = schemaId;
+                    callContext.schemaId = Util.schemaIdFromNamespace(namespace);
 
                     const caller = function(thisArg, argumentsList) {
                         const callContext = thisArg["."];
@@ -1471,20 +1463,35 @@ class Client {
         const result = [];
         const schemaId = callContext.schemaId;
 
-        var schema = await that.getSchema(schemaId, "xml", true);
+        var entitySchemaId = schemaId;
+        if (schemaId === 'xtk:jobInterface')
+            entitySchemaId = callContext.entitySchemaId;
+
+        // Get the schema which contains the method call. Methods of the xtk:jobInterface interface are handled specificaaly
+        // because xtk:jobInterface is not actually a schema, but just an interface. In practice, it's used as an xtk template
+        // rather that an xtk inheritance mechanism
+        const methodSchemaId = schemaId === 'xtk:jobInterface' ? 'xtk:job' : schemaId;
+        var schema = await that.getSchema(methodSchemaId, "xml", true);
         if (!schema)
             throw CampaignException.SOAP_UNKNOWN_METHOD(schemaId, methodName, `Schema '${schemaId}' not found`);
         var schemaName = schema.getAttribute("name");
-        var method = that._methodCache.get(schemaId, methodName);
+
+        // Lookup the method to call
+        var method = that._methodCache.get(methodSchemaId, methodName);
         if (!method) {
             this._methodCache.put(schema);
-            method = that._methodCache.get(schemaId, methodName);
+            method = that._methodCache.get(methodSchemaId, methodName);
         }
         if (!method)
             throw CampaignException.SOAP_UNKNOWN_METHOD(schemaId, methodName, `Method '${methodName}' of schema '${schemaId}' not found`);
-        // console.log(method.toXMLString());
 
-        var urn = that._methodCache.getSoapUrn(schemaId, methodName);
+        // Compute the SOAP URN. Again, specically handle xtk:jobInterface as it's not a real schema. The actual entity schema
+        // would be available as the entitySchemaId proprtey of the callContext
+        var urn = schemaId !== 'xtk:jobInterface'
+            ? that._methodCache.getSoapUrn(schemaId, methodName)
+            : `xtk:jobInterface|${entitySchemaId}`;
+
+
         var soapCall = that._prepareSoapCall(urn, methodName, false, callContext.headers, callContext.pushDownOptions);
 
         // If method is called with one parameter which is a function, then we assume it's a hook: the function will return
@@ -1501,13 +1508,13 @@ class Client {
             if (!object)
                 throw CampaignException.SOAP_UNKNOWN_METHOD(schemaId, methodName, `Cannot call non-static method '${methodName}' of schema '${schemaId}' : no object was specified`);
 
-            const rootName = schemaId.substr(schemaId.indexOf(':') + 1);
+            const rootName = entitySchemaId.substr(entitySchemaId.indexOf(':') + 1);
             object = that._fromRepresentation(rootName, object, callContext.representation);
             // The xtk:persist#NewInstance requires a xtkschema attribute which we can compute here
             // Actually, we're always adding it, for all non-static methods
             const xmlRoot = object.nodeType === 9 ? object.documentElement : object;
             if (!xmlRoot.hasAttribute("xtkschema"))
-                xmlRoot.setAttribute("xtkschema", schemaId);
+                xmlRoot.setAttribute("xtkschema", entitySchemaId);
             soapCall.writeDocument("document", object);
         }
         const parametersIsArray = (typeof parameters == "object") && parameters.length;
@@ -1516,7 +1523,7 @@ class Client {
             var param = DomUtil.getFirstChildElement(params, "param");
             var paramIndex = 0;
             while (param) {
-                   const inout = DomUtil.getAttributeAsString(param, "inout");
+                const inout = DomUtil.getAttributeAsString(param, "inout");
                 if (!inout || inout=="in") {
                     const type = DomUtil.getAttributeAsString(param, "type");
                     const paramName = DomUtil.getAttributeAsString(param, "name");
@@ -1559,9 +1566,9 @@ class Client {
                             // Hack for workflow API. The C++ code checks that the name of the XML element is <variables>. When
                             // using xml representation at the SDK level, it's ok since the SDK caller will set that. But this does
                             // not work when using "BadgerFish" representation where we do not know the root element name.
-                            if (schemaId == "xtk:workflow" && methodName == "StartWithParameters" && paramName == "parameters")
+                            if (entitySchemaId == "xtk:workflow" && methodName == "StartWithParameters" && paramName == "parameters")
                                 docName = "variables";
-                            if (schemaId == "nms:rtEvent" && methodName == "PushEvent")
+                            if (entitySchemaId == "nms:rtEvent" && methodName == "PushEvent")
                                 docName = "rtEvent";
                             // Try to guess the document name. This is usually available in the xtkschema attribute
                             var xtkschema = EntityAccessor.getAttributeAsString(paramValue, "xtkschema");
@@ -1625,7 +1632,7 @@ class Client {
                         else if (type == "DOMDocument") {
                             returnValue = soapCall.getNextDocument();
                             returnValue = that._toRepresentation(returnValue, callContext.representation);
-                            if (schemaId === "xtk:queryDef" && methodName === "ExecuteQuery" && paramName === "output") {
+                            if (entitySchemaId === "xtk:queryDef" && methodName === "ExecuteQuery" && paramName === "output") {
                                 // https://github.com/adobe/acc-js-sdk/issues/3
                                 // Check if query operation is "getIfExists". The "object" variable at this point
                                 // is always an XML, regardless of the xml/json representation
@@ -1819,6 +1826,15 @@ class Client {
         if (threshold !== undefined && rtCount.trim() != "") root.setAttribute("eventQueueMaxSize", threshold);
         const result = this._toRepresentation(doc);
         return result;
+    }
+
+    /**
+     * Creates a Job object which can be used to submit jobs, retreive status, logs and progress, etc.
+     * @param {Campaign.XtkSoapCallSpec} soapCallSpec the definition of the SOAP call
+     * @returns {Campaign.XtkJobInterface} a job
+     */
+    jobInterface(soapCallSpec) {
+        return new XtkJobInterface(this, soapCallSpec);
     }
 }
 

--- a/src/util.js
+++ b/src/util.js
@@ -133,6 +133,24 @@ class Util {
     }
     return obj;
   }
+
+  /**
+   * Get Schema id from namespace (find first upper case letter)
+   * @param {string} namespace a SDK namespace, i.e. xtkWorkflow, nmsDelivery, etc.
+   * @return {string} the corresponding schema id, i.e. xtk:workflow, nms:delivery, etc.
+   */
+  static schemaIdFromNamespace(namespace) {
+    var schemaId = "";
+    for (var i=0; i<namespace.length; i++) {
+        const c = namespace[i];
+        if (c >='A' && c<='Z') {
+            schemaId = schemaId + ":" + c.toLowerCase() + namespace.substr(i+1);
+            break;
+        }
+        schemaId = schemaId + c;
+    }
+    return schemaId;
+  }
 }
 
 /**

--- a/src/xtkJob.js
+++ b/src/xtkJob.js
@@ -184,7 +184,7 @@ class XtkJobInterface {
 
     /**
      * Poll the status of a job previous sumbitted with Execute, Submit, or SubmitSoapCall. The status is made of 3 objects: the status code,
-     * logs, and job properties. Job Properties are arbitrary key value pairs set by the job, but also contains progress informtion.
+     * logs, and job properties. Job Properties are arbitrary key value pairs set by the job, but also contains progress information.
      * This call will fetch the most recent status and logs and aggregate it with previously fetched statuses
      * @param {number|undefined} lastLogId the log id fetch logs from. If unspecified, this function will return the next batch of logs. If set to 0, will return logs from the beginning
      * @param {number|undefined} maxLogCount the max number of logs to fetch. Defaults to 100

--- a/src/xtkJob.js
+++ b/src/xtkJob.js
@@ -264,7 +264,7 @@ class XtkJobInterface {
             rawLog.iRc = XtkCaster.asLong(rawLog.iRc);
             rawLog.logDate = XtkCaster.asDatetime(rawLog.logDate);
             rawLog.logType = XtkCaster.asLong(rawLog.logType);
-            rawLog.message = message
+            rawLog.message = message;
             rawLog.object = XtkCaster.asString(rawLog.object);
             rawLog.errorCode = errorCode;
             logs.push(rawLog);

--- a/src/xtkJob.js
+++ b/src/xtkJob.js
@@ -183,7 +183,7 @@ class XtkJobInterface {
     }
 
     /**
-     * Poll the status of a job previous sumbitted with Execute, Submit, or SubmitSoapCall. The status is made of 3 objects: the status code,
+     * Poll the status of a job previously submitted with Execute, Submit, or SubmitSoapCall. The status is made of 3 objects: the status code,
      * logs, and job properties. Job Properties are arbitrary key value pairs set by the job, but also contains progress information.
      * This call will fetch the most recent status and logs and aggregate it with previously fetched statuses
      * @param {number|undefined} lastLogId the log id fetch logs from. If unspecified, this function will return the next batch of logs. If set to 0, will return logs from the beginning

--- a/src/xtkJob.js
+++ b/src/xtkJob.js
@@ -1,7 +1,3 @@
-const { CampaignException } = require("./campaign");
-const { DomUtil } = require("./domUtil");
-const { XtkCaster } = require("./xtkCaster");
-
 /*
 Copyright 2022 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
@@ -16,6 +12,9 @@ governing permissions and limitations under the License.
 (function() {
 "use strict";
 
+const { CampaignException } = require("./campaign.js");
+const { DomUtil } = require("./domUtil.js");
+const { XtkCaster } = require("./xtkCaster.js");
 
 /**
  * @namespace Campaign
@@ -173,7 +172,7 @@ class XtkJobInterface {
         var jobId = await callContext.client._callMethod("SubmitSoapCall", callContext, [ {
             name: this._soapCall.method,
             service: this._soapCall.xtkschema,
-            param: [
+            param: [
                 { name:"this", type:"DOMDocument", value: this._soapCall.object },
                 { name:"bStart", type:"boolean", value:"false" },
             ]

--- a/src/xtkJob.js
+++ b/src/xtkJob.js
@@ -1,0 +1,338 @@
+const { CampaignException } = require("./campaign");
+const { DomUtil } = require("./domUtil");
+const { XtkCaster } = require("./xtkCaster");
+
+/*
+Copyright 2022 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+(function() {
+"use strict";
+
+
+/**
+ * @namespace Campaign
+ * 
+ * @typedef {DOMElement} SoapMethodDefinition
+ * @memberof Campaign
+ */
+
+
+
+/**
+ * The complete Triforce, or one or more components of the Triforce.
+ * @typedef {Object} XtkSoapCallSpec
+ * @property {string} method - the Soap method name (without any schema information)
+ * @property {string} xtkschema - the method schema id. It can be ommited if the object has a xtkschema property
+ * @property {any} object - the object ("this") to call the method with, possibly null for static methods. Should implement the xtk:job interface
+ * @property {Array} args - the list of arguments to the SOAP call
+ * @memberOf Campaign
+ */
+
+/**
+ * @typedef {Object} XtkJobLog
+ * @property {number} id - the job log id, which can be used for subsequent calls to getStatus
+ * @property {number} iRc - the job return code (0 = ok)
+ * @property {Date} logDate - the timestamp of the log
+ * @property {number} logType - the level of the log message according
+ * @property {string} message - the log message
+ * @property {string} object - the log object
+ * @property {string} errorCode - the log error code if any
+ * @memberOf Campaign
+ */
+
+
+/**
+ * @typedef {Object} XtkJobStatus
+ * @property {number} status - the job status code, as defined in the xtk:job:jobStatus enumeration
+ * @property {XtkJobLog[]} logs - the job log messages
+ * @property {{key: string, value: string}} properties - job properties
+ * @memberOf Campaign
+ */
+
+/**********************************************************************************
+ *
+ * Job Interface
+ * Wraps the xtk:jobInterface interface into convenient JavaScript class
+ *
+ *********************************************************************************/
+/**
+ * @private
+ * @class
+ * @constructor
+ * @memberof Campaign
+ */
+class XtkJobInterface {
+
+    /**
+     * Create a job interface from a client and a SOAP call definition. This method is not meant to be called directly, 
+     * use client.jobInterface instead
+     * @param {Campaign.Client} client the Client object to call Campaign API
+     * @param {Campaign.XtkSoapCallSpec} soapCallSpec the definition of the SOAP call
+     */
+    constructor(client, soapCallSpec) {
+        this._client = client;
+        this._soapCall = soapCallSpec;
+        this._maxLogCount = 100; // default fetch size
+        this._reset();
+    }
+
+    // Reset state before executing or submitting a job
+    _reset() {
+        this.jobId = undefined;
+        this.status = undefined;
+        this.result = undefined;
+        this.lastLogId = 0;
+        this.iRc = 0;
+        this.lastErrorCode = undefined;
+        this.firstErrorCode = undefined;
+    }
+
+    /**
+     * Execute job synchronously (xtk:jobInterface#Execute). Expects the job to have been built with an object implementing the xtk:job interface,
+     * for instance a delivery, and with the method to call (for instance "Prepare")
+     * Static methods are not supported
+     * @returns {string} a job id
+     */
+    async execute() {
+        this._reset();
+        const methodName = this._soapCall.method;
+        const entitySchemaId = this._soapCall.xtkschema ? this._soapCall.xtkschema : (this._soapCall.object ? this._soapCall.object.xtkschema : undefined);
+        if (!entitySchemaId)
+            throw CampaignException.SOAP_UNKNOWN_METHOD(entitySchemaId, methodName, `No schema was provided in soap call or object`);
+        const callContext = {
+            client: this._client,
+            object: this._soapCall.object,
+            schemaId: 'xtk:jobInterface',
+            entitySchemaId: entitySchemaId
+        };
+        var jobId = await callContext.client._callMethod("Execute", callContext, [ methodName ]);
+        this.jobId = jobId;
+        return jobId;
+    }
+
+    /**
+     * Execute job asynchronously (xtk:jobInterface#Execute). Expects the job to have been built with an object implementing the xtk:job interface,
+     * for instance a delivery, and with the method to call (for instance "Prepare")
+     * Static methods are not supported
+     * @returns {string} a job id
+     */
+     async submit() {
+        this._reset();
+        const methodName = this._soapCall.method;
+        const entitySchemaId = this._soapCall.xtkschema ? this._soapCall.xtkschema : (this._soapCall.object ? this._soapCall.object.xtkschema : undefined);
+        if (!entitySchemaId)
+            throw CampaignException.SOAP_UNKNOWN_METHOD(entitySchemaId, methodName, `No schema was provided in soap call or object`);
+        const callContext = {
+            client: this._client,
+            object: this._soapCall.object,
+            schemaId: 'xtk:jobInterface',
+            entitySchemaId: entitySchemaId
+        };
+        var jobId = await callContext.client._callMethod("Submit", callContext, [ this._soapCall.method ]);
+        this.jobId = jobId;
+        return jobId;
+    }
+
+    /**
+     * Execute a SOAP call asynchronously (xtk:jobInterface#Execute). Expects the job to have been built with an object implementing the xtk:job interface,
+     * for instance a delivery, and with the method to call (for instance "Prepare"). Can optionally pass parameters to the job.
+     * Static methods are not supported
+     * @returns {string} a job id
+     */
+     async submitSoapCall() {
+        this._reset();
+        const entitySchemaId = this._soapCall.xtkschema ? this._soapCall.xtkschema : (this._soapCall.object ? this._soapCall.object.xtkschema : undefined);
+        const callContext = {
+            client: this._client,
+            object: this._soapCall.object,
+            schemaId: 'xtk:jobInterface',
+            entitySchemaId: entitySchemaId,
+        };
+
+        const methodName = this._soapCall.method;
+        var schema = await this._client.getSchema(entitySchemaId, "xml", true);
+        if (!schema)
+            throw CampaignException.SOAP_UNKNOWN_METHOD(entitySchemaId, methodName, `Schema '${entitySchemaId}' not found`);
+        var method = this._client._methodCache.get(entitySchemaId, methodName);
+        if (!method)
+            throw CampaignException.SOAP_UNKNOWN_METHOD(entitySchemaId, methodName, `Method '${methodName}' of schema '${entitySchemaId}' not found`);
+        // SubmitSoapCall does not support 
+        const isStatic = DomUtil.getAttributeAsBoolean(method, "static");
+        if (isStatic) 
+            throw CampaignException.SOAP_UNKNOWN_METHOD(entitySchemaId, methodName, `Method '${methodName}' of schema '${entitySchemaId}' is static`);
+
+
+        var jobId = await callContext.client._callMethod("SubmitSoapCall", callContext, [ {
+            name: this._soapCall.method,
+            service: this._soapCall.xtkschema,
+            param: [
+                { name:"this", type:"DOMDocument", value: this._soapCall.object },
+                { name:"bStart", type:"boolean", value:"false" },
+            ]
+        } ]);
+        this.jobId = jobId;
+        return jobId;
+    }
+
+    /**
+     * Poll the status of a job previous sumbitted with Execute, Submit, or SubmitSoapCall. The status is made of 3 objects: the status code,
+     * logs, and job properties. Job Properties are arbitrary key value pairs set by the job, but also contains progress informtion.
+     * This call will fetch the most recent status and logs and aggregate it with previously fetched statuses
+     * @param {number|undefined} lastLogId the log id fetch logs from. If unspecified, this function will return the next batch of logs. If set to 0, will return logs from the beginning
+     * @param {number|undefined} maxLogCount the max number of logs to fetch. Defaults to 100
+     * @returns {Campaign.XtkJobStatus} an object containing the job status, all logs fetched so for, and job properties
+     */
+    async getStatus(lastLogId, maxLogCount) {
+        if (lastLogId === undefined) lastLogId = this.lastLogId;
+        if (maxLogCount === null || maxLogCount === undefined) maxLogCount = this._maxLogCount;
+        var status = await this._client.NLWS.xtkJob.getStatus(this.jobId, lastLogId, maxLogCount);
+        if (this._client._representation === "xml") {
+            status[1] = this._client._toRepresentation(status[1], "SimpleJson");
+            status[2] = this._client._toRepresentation(status[2], "SimpleJson");
+        }
+        status = this._makeJobStatus(status);
+        this._updateStatus(status);
+        return status;
+    }
+
+    // Aggregate new status with previously fetched status
+    _updateStatus(status) {
+        for (var i=0; i<status.logs.length; i++) {
+            if (status.logs[i].id > this.lastLogId)
+                this.lastLogId = status.logs[i].id;
+        }
+        if (this.status === undefined) {
+            this.status = status;
+        }
+        else {
+            const oldLogs = this.status.logs;
+            this.status = status;
+            this.status.logs = oldLogs.concat(this.status.logs);
+        }
+    }
+
+    /**
+     * Returns current progress of the job as a percentage (value between 0 and 1). This requires getStatus to have been called before
+     * @returns {number} the current job progress as a percentage value
+     */
+    getProgress() {
+        if (!this.status || !this.status.properties || !this.status.properties.progress) return 0;
+        if (!this.status.properties.progress.max) return 0;
+        return this.status.properties.progress.current / this.status.properties.progress.max;
+    }
+
+    /**
+     * Get the result of a job, i.e. the value returned by the underlying SOAP call if it had been called directlty. 
+     * Assumes that the job is successful. If not, this call will throw an exception
+     * @returns {*} the job result
+     */
+    async getResult() {
+        var result = await this._client.NLWS.xtkJob.getResult(this.jobId);
+        result = this._makeJobResult(result);
+        this.result = result;
+        return result;
+    }
+
+    // Convert the job result into a typed object
+    _makeJobResult(rawResult) {
+        return rawResult;
+    }
+
+    // Convert job logs into a type object
+    _makeLogs(rawLogs) {
+        const logs = [];
+        rawLogs = rawLogs || {};
+        rawLogs = XtkCaster.asArray(rawLogs.log);
+        for (var i=0; i<rawLogs.length; i++) {
+            const rawLog = rawLogs[i];
+            var message = XtkCaster.asString(rawLog.message);
+            const match = message.match(/(\w{3}-\d{6})(.*)/);
+            var errorCode = undefined;
+            if (match && match.length >= 2) {
+                errorCode = match[1];
+                message = match[2] || "";
+                message = message.trim();
+            }
+            rawLog.id = XtkCaster.asLong(rawLog.id);
+            rawLog.iRc = XtkCaster.asLong(rawLog.iRc);
+            rawLog.logDate = XtkCaster.asDatetime(rawLog.logDate);
+            rawLog.logType = XtkCaster.asLong(rawLog.logType);
+            rawLog.message = message
+            rawLog.object = XtkCaster.asString(rawLog.object);
+            rawLog.errorCode = errorCode;
+            logs.push(rawLog);
+
+            if (errorCode) 
+                this.lastErrorCode = errorCode;
+            if (errorCode && !this.firstErrorCode)
+                this.firstErrorCode = errorCode;
+            if (rawLog.iRc != 0)
+                this.iRc = rawLog.iRc;
+        }
+        return logs;
+    }
+
+    // Convert job properties into a typed object
+    _makeProperties(rawProperties) {
+        rawProperties = rawProperties || {};
+        rawProperties.warning = XtkCaster.asBoolean(rawProperties.warning);
+        if (!rawProperties.progress) rawProperties.progress = {};
+        rawProperties.progress.current = XtkCaster.asLong(rawProperties.progress.current);
+        rawProperties.progress.max = XtkCaster.asLong(rawProperties.progress.max);
+        return rawProperties;
+    }
+
+    // Parse the result of GetStatus API. The result is an array of 3 object. The first is the status code,
+    // followed by the the logs, and finally the properties
+    _makeJobStatus(rawStatus) {
+        if (!rawStatus) rawStatus = [];
+        return {
+            status: XtkCaster.asLong(rawStatus[0]),
+            logs: this._makeLogs(rawStatus[1]),
+            properties: this._makeProperties(rawStatus[2])
+        };
+    }
+
+    /**
+     * Cancel a preciously submitted job
+     */
+     async cancel() {
+        await this._client.NLWS.xtkJob.cancel(this.jobId);
+    }
+
+    /**
+     * Pause a preciously submitted job
+     */
+    async   pause() {
+        await this._client.NLWS.xtkJob.pause(this.jobId);
+    }
+    
+    /**
+     * Waits until a job is actually cancelled
+     * @param {number} timeoutSeconds in seconds
+     */
+     async waitJobCancelled(timeoutSeconds) {
+        await this._client.NLWS.xtkJob.waitJobCancelled(this.jobId, timeoutSeconds);
+    }
+
+    /**
+     * Queries if warnings or errors have been generated for this job
+     * @return {boolean} Returns 'true' if there has been at least one warning or error message
+     */
+     async hasWarning() {
+        return XtkCaster.asBoolean(await this._client.NLWS.xtkJob.hasWarning(this.jobId));
+    }
+}
+
+// Public exports
+exports.XtkJobInterface = XtkJobInterface;
+
+})();

--- a/test/mock.js
+++ b/test/mock.js
@@ -247,7 +247,114 @@ const GET_XTK_SESSION_SCHEMA_RESPONSE = Promise.resolve(`<?xml version='1.0'?>
             </pdomDoc>
         </GetEntityIfMoreRecentResponse>
     </SOAP-ENV:Body>
-    </SOAP-ENV:Envelope>`)
+    </SOAP-ENV:Envelope>`);
+
+const GET_XTK_JOB_SCHEMA_RESPONSE = Promise.resolve(`<?xml version='1.0'?>
+<SOAP-ENV:Envelope xmlns:xsd='http://www.w3.org/2001/XMLSchema' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xmlns:ns='urn:wpp:default' xmlns:SOAP-ENV='http://schemas.xmlsoap.org/soap/envelope/'>
+<SOAP-ENV:Body>
+    <GetEntityIfMoreRecentResponse xmlns='urn:wpp:default' SOAP-ENV:encodingStyle='http://schemas.xmlsoap.org/soap/encoding/'>
+        <pdomDoc xsi:type='ns:Element' SOAP-ENV:encodingStyle='http://xml.apache.org/xml-soap/literalxml'>
+            <schema implements="xtk:jobInterface"  name="job" namespace="xtk" xtkschema="xtk:schema">
+            <interface async="true" label="Job interface" name="jobInterface">
+                <method const="true" name="Execute">
+                <parameters>
+                    <param inout="in" name="methodName" type="string"/>
+                    <param  inout="out" name="id" type="string"/>
+                </parameters>
+                </method>
+                <method const="true" name="Submit">
+                <parameters>
+                    <param inout="in" name="methodName" type="string"/>
+                    <param inout="out" name="id" type="string"/>
+                </parameters>
+                </method>
+                <method const="true" name="SubmitSoapCall">
+                <parameters>
+                    <param inout="in" name="soapCall" type="DOMElement"/>
+                    <param inout="out" name="id" type="string"/>
+                </parameters>
+                </method>
+                <method name="SubmitFromModel" static="true">
+                <parameters>
+                    <param inout="in" name="schema" type="string"/>
+                    <param inout="in" name="where" type="string"/>
+                    <param inout="in" name="methodName" type="string"/>
+                    <param inout="in" name="diff" type="DOMElement"/>
+                    <param inout="in" name="async" type="boolean"/>
+                    <param inout="out" name="jobId" type="long"/>
+                </parameters>
+                </method>
+                <method name="Cancel" static="true">
+                <parameters>
+                    <param inout="in" name="id" type="string"/>
+                </parameters>
+                </method>
+                <method name="WaitJobCancelled" static="true">
+                <parameters>
+                    <param inout="in" name="id" type="string"/>
+                    <param desc="Maximum wait (in seconds)" inout="in" name="timeout" type="long"/>
+                </parameters>
+                </method>
+                <method name="Pause" static="true">
+                <parameters>
+                    <param inout="in" name="id" type="string"/>
+                </parameters>
+                </method>
+                <method name="CheckIfJobInProcess" static="true">
+                <parameters>
+                    <param inout="in" name="pid" type="long"/>
+                    <param name="hostName" type="string"/>
+                    <param inout="out" name="result" type="boolean"/>
+                </parameters>
+                </method>
+                <method name="GetJobsInProcess" static="true">
+                <parameters>
+                    <param desc="Returned document" inout="out" name="jobInfo" type="DOMDocument"/>
+                </parameters>
+                </method>
+                <method name="GetStatus" static="true">
+                <parameters>
+                    <param inout="in" name="id" type="string"/>
+                    <param inout="in" name="lastLogId" type="long"/>
+                    <param inout="in" name="maxLogCount" type="long"/>
+                    <param enum="xtk:jobLog:logType" inout="out" name="status" type="short"/>
+                    <param inout="out" name="returnLogs" type="DOMElement"/>
+                    <param inout="out" name="properties" type="DOMElement"/>
+                </parameters>
+                </method>
+                <method name="GetResult" static="true">
+                <parameters>
+                    <param inout="in" name="id" type="string"/>
+                    <param inout="out" name="response" type="string"/>
+                </parameters>
+                </method>
+                <method name="HasWarning" static="true">
+                <parameters>
+                    <param inout="in" name="id" type="string"/>
+                    <param inout="out" name="hasWarning" type="boolean"/>
+                </parameters>
+                </method>
+                <method name="FilesExist" static="true">
+                <parameters>
+                    <param inout="in" name="files" type="DOMDocument"/>
+                    <param inout="out" name="exist" type="DOMDocument"/>
+                </parameters>
+                </method>
+                <method name="GetServerDiskSpace" static="true">
+                <parameters>
+                    <param inout="out" name="serverDiskSpace" type="int64"/>
+                </parameters>
+                </method>
+            </interface>
+
+            <element autopk="true" name="job">
+                <attribute name="id" sqlname="iJobId" type="long"/>
+            </element>
+        </schema>
+    </pdomDoc>
+    </GetEntityIfMoreRecentResponse>
+</SOAP-ENV:Body>
+</SOAP-ENV:Envelope>`);
 
 const GET_DATABASEID_RESPONSE = Promise.resolve(`<?xml version='1.0'?>
     <SOAP-ENV:Envelope xmlns:xsd='http://www.w3.org/2001/XMLSchema' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xmlns:ns='urn:xtk:session' xmlns:SOAP-ENV='http://schemas.xmlsoap.org/soap/envelope/'>
@@ -834,6 +941,7 @@ exports.Mock = {
   LOGON_RESPONSE_NO_SECURITYTOKEN: LOGON_RESPONSE_NO_SECURITYTOKEN,
   LOGOFF_RESPONSE: LOGOFF_RESPONSE,
   GET_XTK_SESSION_SCHEMA_RESPONSE: GET_XTK_SESSION_SCHEMA_RESPONSE,
+  GET_XTK_JOB_SCHEMA_RESPONSE: GET_XTK_JOB_SCHEMA_RESPONSE,
   GET_DATABASEID_RESPONSE: GET_DATABASEID_RESPONSE,
   GET_OPTION_NOTFOUND_RESPONSE: GET_OPTION_NOTFOUND_RESPONSE,
   GET_OPTION_MISSING_DATA_RESPONSE: GET_OPTION_MISSING_DATA_RESPONSE,

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -17,8 +17,8 @@ governing permissions and limitations under the License.
  * 
  *********************************************************************************/
 
- const { Util, ArrayMap } = require('../src/util.js');
- const { SafeStorage, Cache } = require('../src/cache.js');
+const { Util, ArrayMap } = require('../src/util.js');
+const { SafeStorage, Cache } = require('../src/cache.js');
 
 
 describe('Util', function() {
@@ -35,6 +35,15 @@ describe('Util', function() {
 
         expect(Util.isArray([])).toBe(true);
         expect(Util.isArray([ 1 ])).toBe(true);
+    });
+
+    describe("util.schemaIdFromNamespace", () => {
+        it("Should should extract schema id for simple namespaces", () => {
+            expect(Util.schemaIdFromNamespace("")).toBe("");
+            expect(Util.schemaIdFromNamespace("nmsRecipient")).toBe("nms:recipient");
+            expect(Util.schemaIdFromNamespace("000Recipient")).toBe("000:recipient");
+            expect(Util.schemaIdFromNamespace("Recipient")).toBe(":recipient");
+        });
     });
 
     describe("Util.trim", () => {

--- a/test/xtkJob.test.js
+++ b/test/xtkJob.test.js
@@ -1,0 +1,713 @@
+/*
+Copyright 2022 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+
+/**********************************************************************************
+ *
+ * Unit tests for the ACC client
+ *
+ *********************************************************************************/
+
+const DomUtil = require('../src/domUtil.js').DomUtil;
+const Mock = require('./mock.js').Mock;
+const { XtkJobInterface } = require('../src/xtkJob.js');
+
+
+const MOCK_SUBMIT_JOB_RESPONSE = (jobId) => Promise.resolve(`<?xml version='1.0'?>
+<SOAP-ENV:Envelope xmlns:xsd='http://www.w3.org/2001/XMLSchema'
+  xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
+  xmlns:ns='urn:nms:delivery'
+  xmlns:SOAP-ENV='http://schemas.xmlsoap.org/soap/envelope/'>
+  <SOAP-ENV:Body>
+    <SubmitResponse xmlns='urn:nms:delivery' SOAP-ENV:encodingStyle='http://schemas.xmlsoap.org/soap/encoding/'>
+      <pstrId xsi:type='xsd:string'>${jobId}</pstrId>
+    </SubmitResponse>
+  </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>`);
+
+const MOCK_GETSTATUS1_RESPONSE = (status, current, max, warning, logs) => Promise.resolve(`<?xml version='1.0'?>
+<SOAP-ENV:Envelope xmlns:xsd='http://www.w3.org/2001/XMLSchema'
+  xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
+  xmlns:ns='urn:xtk:job'
+  xmlns:SOAP-ENV='http://schemas.xmlsoap.org/soap/envelope/'>
+  <SOAP-ENV:Body>
+    <GetStatusResponse xmlns='urn:xtk:job' SOAP-ENV:encodingStyle='http://schemas.xmlsoap.org/soap/encoding/'>
+      <psStatus xsi:type='xsd:short'>${status}</psStatus>
+      <pelemReturnLogs xsi:type='ns:Element' SOAP-ENV:encodingStyle='http://xml.apache.org/xml-soap/literalxml'>
+        ${logs ? "<elemReturnLogs>" + logs + "</elemReturnLogs>" : "<elemReturnLogs/>"}
+      </pelemReturnLogs>
+      <pelemProperties xsi:type='ns:Element' SOAP-ENV:encodingStyle='http://xml.apache.org/xml-soap/literalxml'>
+        <elemProperties warning="${warning ? 1 : 0}">
+          <progress current="${current}" max="${max}"/>
+        </elemProperties>
+      </pelemProperties>
+    </GetStatusResponse>
+  </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>`);
+
+
+describe('XRK Jobs', function () {
+
+    describe("Job parsing", () => {
+        it("Should parse job status", () => {
+            expect(new XtkJobInterface()._makeJobStatus()).toEqual({ status:0, logs:[], properties: { warning:false, progress: { current:0, max:0} } }); 
+            expect(new XtkJobInterface()._makeJobStatus({ })).toEqual({ status:0, logs:[], properties: { warning:false, progress: { current:0, max:0} } }); 
+            expect(new XtkJobInterface()._makeJobStatus([ 3 ])).toEqual({ status:3, logs:[], properties: { warning:false, progress: { current:0, max:0} } }); 
+        });
+
+        it("Should parse logs", () => {
+            expect(new XtkJobInterface()._makeJobStatus([ 1, { log: null } ])).toEqual({ status:1, logs:[], properties: { warning:false, progress: { current:0, max:0} } }); 
+            expect(new XtkJobInterface()._makeJobStatus([ 1, { log: [] } ])).toEqual({ status:1, logs:[], properties: { warning:false, progress: { current:0, max:0} } }); 
+            expect(new XtkJobInterface()._makeJobStatus([ 1, { log: { iRc: "3"} } ])).toEqual({ status:1, logs:[ { iRc:3, id:0, logDate:null, logType:0, message:"", object:"" } ], properties: { warning:false, progress: { current:0, max:0} } }); 
+            expect(new XtkJobInterface()._makeJobStatus([ 1, { log: { id:"1234", iRc:"3", logType:"2", message:"Hello", object:"test" } } ])).toEqual({ status:1, logs:[ { iRc:3, id:1234, logDate:null, logType:2, message:"Hello", object:"test" } ], properties: { warning:false, progress: { current:0, max:0} } }); 
+            expect(new XtkJobInterface()._makeJobStatus([ 1, { log: [{ id:"1234", iRc:"3", logType:"2", message:"Hello", object:"test" }] } ])).toEqual({ status:1, logs:[ { iRc:3, id:1234, logDate:null, logType:2, message:"Hello", object:"test" } ], properties: { warning:false, progress: { current:0, max:0} } }); 
+            expect(new XtkJobInterface()._makeJobStatus([ 1, { log: [{ id:"1234", iRc:"3", logType:"2", message:"Hello", object:"test" }, { id:"1244", iRc:"-53", logType:"2", message:"World" }] } ])).toEqual(
+                { status:1, 
+                  logs:[ { iRc:3, id:1234, logDate:null, logType:2, message:"Hello", object:"test" },
+                         { iRc:-53, id:1244, logDate:null, logType:2, message:"World", object:"" } ], 
+                  properties: { warning:false, progress: { current:0, max:0} } 
+                }); 
+        });
+
+        it("Should extract error code", () => {
+            expect(new XtkJobInterface()._makeJobStatus([ 1, { log: { id:"1234", iRc:"3", logType:"2", message:"DLV-490009 Hello", object:"test" } } ])).toEqual({ status:1, logs:[ { iRc:3, id:1234, logDate:null, logType:2, errorCode:"DLV-490009", message:"Hello", object:"test" } ], properties: { warning:false, progress: { current:0, max:0} } }); 
+            expect(new XtkJobInterface()._makeJobStatus([ 1, { log: { id:"1234", iRc:"3", logType:"2", message:"DLV-49000 Hello", object:"test" } } ])).toEqual({ status:1, logs:[ { iRc:3, id:1234, logDate:null, logType:2, message:"DLV-49000 Hello", object:"test" } ], properties: { warning:false, progress: { current:0, max:0} } }); 
+            expect(new XtkJobInterface()._makeJobStatus([ 1, { log: { id:"1234", iRc:"3", logType:"2", message:"DLV-490009", object:"test" } } ])).toEqual({ status:1, logs:[ { iRc:3, id:1234, logDate:null, logType:2, errorCode:"DLV-490009", message:"", object:"test" } ], properties: { warning:false, progress: { current:0, max:0} } }); 
+        });
+
+        it("Should parse log date", () => {
+            expect(new XtkJobInterface()._makeJobStatus([ 1, { log: { logDate:"" } } ])).toEqual({ status:1, logs:[  { iRc:0, id:0, logDate:null, logType:0, message:"", object:"" } ], properties: { warning:false, progress: { current:0, max:0} } }); 
+            expect(new XtkJobInterface()._makeJobStatus([ 1, { log: { logDate:"2022-11-19 16:30:19.140Z" } } ])).toEqual({ status:1, logs:[  { iRc:0, id:0, logDate:new Date(1668875419140), logType:0, message:"", object:"" } ], properties: { warning:false, progress: { current:0, max:0} } }); 
+        });
+
+        it("Should parse progress", () => {
+            expect(new XtkJobInterface()._makeJobStatus([ 1, undefined, {} ])).toEqual({ status:1, logs:[], properties: { warning:false, progress: { current:0, max:0} } }); 
+            expect(new XtkJobInterface()._makeJobStatus([ 1, undefined, { progress:{} } ])).toEqual({ status:1, logs:[], properties: { warning:false, progress: { current:0, max:0} } }); 
+            expect(new XtkJobInterface()._makeJobStatus([ 1, undefined, { progress:{ current:10 } } ])).toEqual({ status:1, logs:[], properties: { warning:false, progress: { current:10, max:0} } }); 
+            expect(new XtkJobInterface()._makeJobStatus([ 1, undefined, { progress:{ current:10, max:100 } } ])).toEqual({ status:1, logs:[], properties: { warning:false, progress: { current:10, max:100} } }); 
+        });
+
+        it("Should return progress as a percentage", () => {
+            const progress = (getStatusResponse) => {
+                const job = new XtkJobInterface();
+                const status = job._makeJobStatus(getStatusResponse);
+                job._updateStatus(status);
+                return job.getProgress();
+            };
+            expect(progress([ 1 ])).toBe(0); 
+            expect(progress([ 1, undefined, {} ])).toBe(0); 
+            expect(progress([ 1, undefined, { progress:{} } ])).toBe(0); 
+            expect(progress([ 1, undefined, { progress:{ current:10 } } ])).toBe(0); 
+            expect(progress([ 1, undefined, { progress:{ current:10, max:100 } } ])).toBe(0.1); 
+        });
+
+        it("Should return progress as a percentage (edge cases)", () => {
+            const job = new XtkJobInterface();
+            expect(job.getProgress()).toBe(0); 
+        });
+    });
+
+    describe("Result parsing", () => {
+        it("Should parse job result", () => {
+            expect(new XtkJobInterface()._makeJobResult()).toEqual(undefined); 
+            expect(new XtkJobInterface()._makeJobResult("Hello")).toEqual("Hello"); 
+            expect(new XtkJobInterface()._makeJobResult({ hello: 'world' })).toEqual({ hello: 'world' }); 
+        });
+    });
+
+    describe("Job update", () => {
+        it("Should set empty status", () => {
+            const job = new XtkJobInterface();
+            expect(job.status).toBeUndefined();
+            job._updateStatus(job._makeJobStatus());
+            expect(job.status).toEqual({ status: 0, properties: { progress: { current:0, max: 0 }, warning:false }, logs: [] });
+        });
+
+        it("Should set initial status", () => {
+            const job = new XtkJobInterface();
+            expect(job.status).toBeUndefined();
+            job._updateStatus(job._makeJobStatus([ 1, { log: [{ id:"1234", iRc:"3", logType:"2", message:"Hello", object:"test" }, { id:"1244", iRc:"-53", logType:"2", message:"World" }] } ]) );
+            expect(job.status).toEqual({ status:1, 
+                logs:[ { iRc:3, id:1234, logDate:null, logType:2, message:"Hello", object:"test" },
+                       { iRc:-53, id:1244, logDate:null, logType:2, message:"World", object:"" } ], 
+                properties: { warning:false, progress: { current:0, max:0} } 
+            }); 
+        });
+
+        it("Should update status", () => {
+            const job = new XtkJobInterface();
+            expect(job.status).toBeUndefined();
+            expect(job.lastLogId).toBe(0);
+            job._updateStatus(job._makeJobStatus([ 1, { log: [{ id:"1234", iRc:"3", logType:"2", message:"Hello", object:"test" }, { id:"1244", iRc:"-53", logType:"2", message:"World" }] } ]) );
+            expect(job.status).toEqual({ status:1, 
+                logs:[ { iRc:3, id:1234, logDate:null, logType:2, message:"Hello", object:"test" },
+                       { iRc:-53, id:1244, logDate:null, logType:2, message:"World", object:"" } ], 
+                properties: { warning:false, progress: { current:0, max:0} } 
+            }); 
+            expect(job.lastLogId).toBe(1244);
+            job._updateStatus(job._makeJobStatus([ 1, { log: [{ id:"1245", iRc:"3", logType:"2", message:"Hello World" }] } ]) );
+            expect(job.status).toEqual({ status:1, 
+                logs:[ { iRc:3, id:1234, logDate:null, logType:2, message:"Hello", object:"test" },
+                       { iRc:-53, id:1244, logDate:null, logType:2, message:"World", object:"" } ,
+                       { iRc:3, id:1245, logDate:null, logType:2, message:"Hello World", object:"" } ], 
+                properties: { warning:false, progress: { current:0, max:0} } 
+            }); 
+            expect(job.lastLogId).toBe(1245);
+        });
+
+        it("Should ignore old logs when computing lastLogId", () => {
+            const job = new XtkJobInterface();
+            job._updateStatus(job._makeJobStatus([ 1, { log: [{ id:"1234", iRc:"3", logType:"2", message:"Hello", object:"test" }, { id:"1244", iRc:"-53", logType:"2", message:"World" }] } ]) );
+            expect(job.lastLogId).toBe(1244);
+            job._updateStatus(job._makeJobStatus([ 1, { log: [{ id:"1200", iRc:"3", logType:"2", message:"Hello World" }] } ]) ); // 1200 < 1234
+            expect(job.lastLogId).toBe(1244);
+        });
+    });
+
+
+    describe("Execute", () => {
+        it("Execute with success", async () => {
+            const client = { _callMethod: jest.fn() };
+            const job = new XtkJobInterface(client, { xtkschema: "nms:delivery", object: "Hello World", method: "Prepare" });
+            client._callMethod.mockReturnValueOnce(Promise.resolve("9876"));
+            const jobId = await job.execute();
+            expect(jobId).toBe("9876");
+            expect(client._callMethod.mock.calls.length).toBe(1);
+            expect(client._callMethod.mock.calls[0][0]).toBe("Execute");
+            expect(client._callMethod.mock.calls[0][1]).toMatchObject({
+                entitySchemaId: "nms:delivery",
+                schemaId: "xtk:jobInterface",
+                object: "Hello World"
+            });
+            expect(client._callMethod.mock.calls[0][2]).toEqual([ "Prepare" ]);
+        });
+
+        it("Infer schema from objects", async () => {
+            const client = { _callMethod: jest.fn() };
+            const job = new XtkJobInterface(client, { object: { xtkschema: "nms:delivery", name: "Hello World" }, method: "Prepare" });
+            client._callMethod.mockReturnValueOnce(Promise.resolve("9876"));
+            const jobId = await job.execute();
+            expect(jobId).toBe("9876");
+            expect(client._callMethod.mock.calls.length).toBe(1);
+            expect(client._callMethod.mock.calls[0][0]).toBe("Execute");
+            expect(client._callMethod.mock.calls[0][1]).toMatchObject({
+                entitySchemaId: "nms:delivery",
+                schemaId: "xtk:jobInterface",
+                object: { xtkschema: "nms:delivery", name: "Hello World" }
+            });
+            expect(client._callMethod.mock.calls[0][2]).toEqual([ "Prepare" ]);
+        });
+
+        it("Should fail if missing entity schema (with object)", async () => {
+            const client = { _callMethod: jest.fn() };
+            const job = new XtkJobInterface(client, { object: { name: "Hello World" }, method: "Prepare" });
+            await expect(job.execute()).rejects.toMatchObject({
+                "detail": "No schema was provided in soap call or object",
+                "errorCode": "SDK-000009",
+                "faultCode": 16384,
+                "faultString": "Unknown method 'Prepare' of schema 'undefined'",
+                "message": "400 - Error 16384: SDK-000009 Unknown method 'Prepare' of schema 'undefined'. No schema was provided in soap call or object",
+                "name": "CampaignException",
+                "statusCode": 400,
+            });
+        });
+
+        it("Should fail if missing entity schema (without object)", async () => {
+            const client = { _callMethod: jest.fn() };
+            const job = new XtkJobInterface(client, { method: "Prepare" });
+            await expect(job.execute()).rejects.toMatchObject({
+                "detail": "No schema was provided in soap call or object",
+                "errorCode": "SDK-000009",
+                "faultCode": 16384,
+                "faultString": "Unknown method 'Prepare' of schema 'undefined'",
+                "message": "400 - Error 16384: SDK-000009 Unknown method 'Prepare' of schema 'undefined'. No schema was provided in soap call or object",
+                "name": "CampaignException",
+                "statusCode": 400,
+            });
+        });
+    });
+
+    describe("Submit", () => {
+        it("Submit with success", async () => {
+            const client = { _callMethod: jest.fn() };
+            const job = new XtkJobInterface(client, { xtkschema: "nms:delivery", object: "Hello World", method: "Prepare" });
+            client._callMethod.mockReturnValueOnce(Promise.resolve("9876"));
+            const jobId = await job.submit();
+            expect(jobId).toBe("9876");
+            expect(client._callMethod.mock.calls.length).toBe(1);
+            expect(client._callMethod.mock.calls[0][0]).toBe("Submit");
+            expect(client._callMethod.mock.calls[0][1]).toMatchObject({
+                entitySchemaId: "nms:delivery",
+                schemaId: "xtk:jobInterface",
+                object: "Hello World"
+            });
+            expect(client._callMethod.mock.calls[0][2]).toEqual([ "Prepare" ]);
+        });
+
+        it("Infer schema from objects", async () => {
+            const client = { _callMethod: jest.fn() };
+            const job = new XtkJobInterface(client, { object: { xtkschema: "nms:delivery", name: "Hello World" }, method: "Prepare" });
+            client._callMethod.mockReturnValueOnce(Promise.resolve("9876"));
+            const jobId = await job.submit();
+            expect(jobId).toBe("9876");
+            expect(client._callMethod.mock.calls.length).toBe(1);
+            expect(client._callMethod.mock.calls[0][0]).toBe("Submit");
+            expect(client._callMethod.mock.calls[0][1]).toMatchObject({
+                entitySchemaId: "nms:delivery",
+                schemaId: "xtk:jobInterface",
+                object: { xtkschema: "nms:delivery", name: "Hello World" }
+            });
+            expect(client._callMethod.mock.calls[0][2]).toEqual([ "Prepare" ]);
+        });
+
+
+        it("Should fail if missing entity schema (with object)", async () => {
+            const client = { _callMethod: jest.fn() };
+            const job = new XtkJobInterface(client, { object: { name: "Hello World" }, method: "Prepare" });
+            await expect(job.submit()).rejects.toMatchObject({
+                "detail": "No schema was provided in soap call or object",
+                "errorCode": "SDK-000009",
+                "faultCode": 16384,
+                "faultString": "Unknown method 'Prepare' of schema 'undefined'",
+                "message": "400 - Error 16384: SDK-000009 Unknown method 'Prepare' of schema 'undefined'. No schema was provided in soap call or object",
+                "name": "CampaignException",
+                "statusCode": 400,
+            });
+        });
+
+        it("Should fail if missing entity schema (without object)", async () => {
+            const client = { _callMethod: jest.fn() };
+            const job = new XtkJobInterface(client, { method: "Prepare" });
+            await expect(job.submit()).rejects.toMatchObject({
+                "detail": "No schema was provided in soap call or object",
+                "errorCode": "SDK-000009",
+                "faultCode": 16384,
+                "faultString": "Unknown method 'Prepare' of schema 'undefined'",
+                "message": "400 - Error 16384: SDK-000009 Unknown method 'Prepare' of schema 'undefined'. No schema was provided in soap call or object",
+                "name": "CampaignException",
+                "statusCode": 400,
+            });
+        });
+    });
+
+    describe("SubmitSoapCall", () => {
+        it("SubmitSoapCall with success", async () => {
+            const client = { _callMethod: jest.fn(), getSchema: jest.fn(), _methodCache: { get: jest.fn()} };
+            const job = new XtkJobInterface(client, { xtkschema: "nms:delivery", object: "Hello World", method: "Prepare" });
+            client._callMethod.mockReturnValueOnce(Promise.resolve("9876"));
+            client.getSchema.mockReturnValueOnce(Promise.resolve(true));
+            client._methodCache.get.mockReturnValueOnce(DomUtil.parse("<method></method>").documentElement);
+            const jobId = await job.submitSoapCall();
+            expect(jobId).toBe("9876");
+            expect(client._callMethod.mock.calls.length).toBe(1);
+            expect(client._callMethod.mock.calls[0][0]).toBe("SubmitSoapCall");
+            expect(client._callMethod.mock.calls[0][1]).toMatchObject({
+                entitySchemaId: "nms:delivery",
+                schemaId: "xtk:jobInterface",
+                object: "Hello World",
+            });
+            expect(client._callMethod.mock.calls[0][2]).toEqual([ {
+                name: "Prepare",
+                service: "nms:delivery",
+                param: [
+                    { name:"this", type:"DOMDocument", value: "Hello World", },
+                    { name:"bStart", type:"boolean", value:"false" },
+                ]
+            } ]);
+        });
+
+        it("Infer schema from objects", async () => {
+            const client = { _callMethod: jest.fn(), getSchema: jest.fn(), _methodCache: { get: jest.fn()} };
+            const job = new XtkJobInterface(client, { object: { xtkschema: "nms:delivery", name: "Hello World" }, method: "Prepare" });
+            client._callMethod.mockReturnValueOnce(Promise.resolve("9876"));
+            client.getSchema.mockReturnValueOnce(Promise.resolve(true));
+            client._methodCache.get.mockReturnValueOnce(DomUtil.parse("<method></method>").documentElement);
+            const jobId = await job.submitSoapCall();
+            expect(jobId).toBe("9876");
+            expect(client._callMethod.mock.calls[0][1]).toMatchObject({
+                entitySchemaId: "nms:delivery",
+                schemaId: "xtk:jobInterface",
+                object: { xtkschema: "nms:delivery", name: "Hello World" }
+            });
+        });
+
+        it("Should fail on missing schema", async () => {
+            const client = { _callMethod: jest.fn(), getSchema: jest.fn(), _methodCache: { get: jest.fn()} };
+            const job = new XtkJobInterface(client, { method: "Prepare" });
+            client._callMethod.mockReturnValueOnce(Promise.resolve("9876"));
+            client.getSchema.mockReturnValueOnce(Promise.resolve(false));
+            client._methodCache.get.mockReturnValueOnce(DomUtil.parse("<method></method>").documentElement);
+            await expect(job.submitSoapCall()).rejects.toMatchObject({
+                "detail": "Schema 'undefined' not found",
+                "errorCode": "SDK-000009",
+                "faultCode": 16384,
+                "faultString": "Unknown method 'Prepare' of schema 'undefined'",
+                "message": "400 - Error 16384: SDK-000009 Unknown method 'Prepare' of schema 'undefined'. Schema 'undefined' not found",
+                "name": "CampaignException",
+                "statusCode": 400,
+            });
+        });
+
+        it("Should fail on invalid schema", async () => {
+            const client = { _callMethod: jest.fn(), getSchema: jest.fn(), _methodCache: { get: jest.fn()} };
+            const job = new XtkJobInterface(client, { object: { xtkschema: "nms:notFound", name: "Hello World" }, method: "Prepare" });
+            client._callMethod.mockReturnValueOnce(Promise.resolve("9876"));
+            client.getSchema.mockReturnValueOnce(Promise.resolve(false));
+            client._methodCache.get.mockReturnValueOnce(DomUtil.parse("<method></method>").documentElement);
+            await expect(job.submitSoapCall()).rejects.toMatchObject({
+                "detail": "Schema 'nms:notFound' not found",
+                "errorCode": "SDK-000009",
+                "faultCode": 16384,
+                "faultString": "Unknown method 'Prepare' of schema 'nms:notFound'",
+                "message": "400 - Error 16384: SDK-000009 Unknown method 'Prepare' of schema 'nms:notFound'. Schema 'nms:notFound' not found",
+                "name": "CampaignException",
+                "statusCode": 400,
+            });
+        });
+
+        it("Should fail on method not found", async () => {
+            const client = { _callMethod: jest.fn(), getSchema: jest.fn(), _methodCache: { get: jest.fn()} };
+            const job = new XtkJobInterface(client, { object: { xtkschema: "nms:delivery", name: "Hello World" }, method: "NotFound" });
+            client._callMethod.mockReturnValueOnce(Promise.resolve("9876"));
+            client.getSchema.mockReturnValueOnce(Promise.resolve(true));
+            client._methodCache.get.mockReturnValueOnce(undefined);
+            await expect(job.submitSoapCall()).rejects.toMatchObject({
+                "detail": "Method 'NotFound' of schema 'nms:delivery' not found",
+                "errorCode": "SDK-000009",
+                "faultCode": 16384,
+                "faultString": "Unknown method 'NotFound' of schema 'nms:delivery'",
+                "message": "400 - Error 16384: SDK-000009 Unknown method 'NotFound' of schema 'nms:delivery'. Method 'NotFound' of schema 'nms:delivery' not found",
+                "name": "CampaignException",
+                "statusCode": 400,
+            });
+        });
+
+        it("Should fail on static methods", async () => {
+            const client = { _callMethod: jest.fn(), getSchema: jest.fn(), _methodCache: { get: jest.fn()} };
+            const job = new XtkJobInterface(client, { object: { xtkschema: "nms:delivery", name: "Hello World" }, method: "StaticMethod" });
+            client._callMethod.mockReturnValueOnce(Promise.resolve("9876"));
+            client.getSchema.mockReturnValueOnce(Promise.resolve(true));
+            client._methodCache.get.mockReturnValueOnce(DomUtil.parse('<method static="true"></method>').documentElement);
+            await expect(job.submitSoapCall()).rejects.toMatchObject({
+                "detail": "Method 'StaticMethod' of schema 'nms:delivery' is static",
+                "errorCode": "SDK-000009",
+                "faultCode": 16384,
+                "faultString": "Unknown method 'StaticMethod' of schema 'nms:delivery'",
+                "message": "400 - Error 16384: SDK-000009 Unknown method 'StaticMethod' of schema 'nms:delivery'. Method 'StaticMethod' of schema 'nms:delivery' is static",
+                "name": "CampaignException",
+                "statusCode": 400,
+            });
+        });
+    });
+
+    describe("Get Status", () => {
+        it("Should get status", async () => {
+            const client = { NLWS: { xtkJob: { getStatus: jest.fn() } }  };
+            const job = new XtkJobInterface(client);
+            job.jobId = "ABC";
+            client.NLWS.xtkJob.getStatus.mockReturnValueOnce(Promise.resolve({ }));
+            const status = await job.getStatus();
+            expect(status).toEqual({ status:0, logs:[], properties: { warning:false, progress: { current:0, max:0} } });
+            expect(job.status).toEqual({ status:0, logs:[], properties: { warning:false, progress: { current:0, max:0} } });
+            expect(client.NLWS.xtkJob.getStatus.mock.calls.length).toBe(1);
+            expect(client.NLWS.xtkJob.getStatus.mock.calls[0]).toEqual(["ABC", 0, 100]);
+        });
+
+        it("Should get next logs", async() => {
+            const client = { NLWS: { xtkJob: { getStatus: jest.fn() } }  };
+            const job = new XtkJobInterface(client);
+            job.jobId = "ABC";
+            client.NLWS.xtkJob.getStatus.mockReturnValueOnce(Promise.resolve([ 1, { log: [ { id: 1 } ] } ]));
+            var status = await job.getStatus();
+            expect(status).toEqual({ status:1, logs:[
+                    { iRc:0, id:1, logDate:null, logType:0, message:"", object:"" }
+                ], properties: { warning:false, progress: { current:0, max:0} } });
+            expect(job.status).toEqual({ status:1, logs:[
+                    { iRc:0, id:1, logDate:null, logType:0, message:"", object:"" }
+                ], properties: { warning:false, progress: { current:0, max:0} } });
+            expect(client.NLWS.xtkJob.getStatus.mock.calls.length).toBe(1);
+            expect(client.NLWS.xtkJob.getStatus.mock.calls[0]).toEqual(["ABC", 0, 100]);
+
+            client.NLWS.xtkJob.getStatus.mockReturnValueOnce(Promise.resolve([ 1, { log: [ { id: 2 }, { id: 3 } ] } ]));
+            status = await job.getStatus();
+            expect(status).toEqual({ status:1, logs:[
+                    { iRc:0, id:1, logDate:null, logType:0, message:"", object:"" },
+                    { iRc:0, id:2, logDate:null, logType:0, message:"", object:"" },
+                    { iRc:0, id:3, logDate:null, logType:0, message:"", object:"" }
+                ], properties: { warning:false, progress: { current:0, max:0} } });
+            expect(job.status).toEqual({ status:1, logs:[
+                    { iRc:0, id:1, logDate:null, logType:0, message:"", object:"" },
+                    { iRc:0, id:2, logDate:null, logType:0, message:"", object:"" },
+                    { iRc:0, id:3, logDate:null, logType:0, message:"", object:"" }
+                ], properties: { warning:false, progress: { current:0, max:0} } });
+            expect(client.NLWS.xtkJob.getStatus.mock.calls.length).toBe(2);
+            expect(client.NLWS.xtkJob.getStatus.mock.calls[1]).toEqual(["ABC", 1, 100]);
+        });
+
+        it("Should get status from id", async () => {
+            const client = { NLWS: { xtkJob: { getStatus: jest.fn() } }  };
+            const job = new XtkJobInterface(client);
+            job.jobId = "ABC";
+            client.NLWS.xtkJob.getStatus.mockReturnValueOnce(Promise.resolve({ }));
+            const status = await job.getStatus(12, 500);
+            expect(client.NLWS.xtkJob.getStatus.mock.calls.length).toBe(1);
+            expect(client.NLWS.xtkJob.getStatus.mock.calls[0]).toEqual(["ABC", 12, 500]);
+        });
+    });
+
+    describe("Get Result", () => {
+        it("Should get result", async () => {
+            const client = { NLWS: { xtkJob: { getResult: jest.fn() } }  };
+            const job = new XtkJobInterface(client);
+            job.jobId = "ABC";
+            client.NLWS.xtkJob.getResult.mockReturnValueOnce(Promise.resolve("Hello"));
+            const result = await job.getResult();
+            expect(result).toEqual("Hello");
+            expect(client.NLWS.xtkJob.getResult.mock.calls.length).toBe(1);
+            expect(client.NLWS.xtkJob.getResult.mock.calls[0][0]).toBe("ABC");
+        });
+    });
+
+    describe("Asynchronous jobs", () => {
+
+        it("Should submit an delivery preparation", async () => {
+            const client = await Mock.makeClient();
+            client._transport.mockReturnValueOnce(Mock.LOGON_RESPONSE);
+            await client.NLWS.xtkSession.logon();
+            const job = client.jobInterface({
+                xtkschema: 'nms:delivery',
+                method: 'Prepare',
+                object: { },    // In reality should be an actual delivery object. Not passed here to simplify the test
+            });
+
+            client._transport.mockReturnValueOnce(Mock.GET_XTK_JOB_SCHEMA_RESPONSE);
+            client._transport.mockReturnValueOnce(MOCK_SUBMIT_JOB_RESPONSE("4210/nms:delivery@@B/C1boHl4jx1AEnDTI4nI137QkcFiiIZf4v++eFsPdM="));
+            var jobId = await job.submit();
+            expect(client._transport).toHaveBeenCalledTimes(3); // Logon, GetSchema(xtk:job), Submit
+            expect(client._transport.mock.calls[1][0].data).toContain('<pk xsi:type="xsd:string">xtk:schema|xtk:job</pk><md5 xsi:type="xsd:string"/><mustExist xsi:type="xsd:boolean">false</mustExist></m:GetEntityIfMoreRecent>');
+            expect(client._transport.mock.calls[2][0].data).toContain('<m:Submit xmlns:m="urn:xtk:jobInterface|nms:delivery"');
+            expect(client._transport.mock.calls[2][0].data).toContain('<delivery xtkschema="nms:delivery"/></document><methodName xsi:type="xsd:string">Prepare</methodName>');
+            expect(jobId).toBe("4210/nms:delivery@@B/C1boHl4jx1AEnDTI4nI137QkcFiiIZf4v++eFsPdM=");
+
+            client._transport.mockReturnValueOnce(Mock.LOGOFF_RESPONSE);
+            await client.NLWS.xtkSession.logoff();
+        });
+
+        it("Should submit an delivery preparation and get status", async () => {
+            const client = await Mock.makeClient();
+            client._transport.mockReturnValueOnce(Mock.LOGON_RESPONSE);
+            await client.NLWS.xtkSession.logon();
+            const job = client.jobInterface({
+                xtkschema: 'nms:delivery',
+                method: 'Prepare',
+                object: { },    // In reality should be an actual delivery object. Not passed here to simplify the test
+            });
+            client._transport.mockReturnValueOnce(Mock.GET_XTK_JOB_SCHEMA_RESPONSE);
+            client._transport.mockReturnValueOnce(MOCK_SUBMIT_JOB_RESPONSE("4210/nms:delivery@@B/C1boHl4jx1AEnDTI4nI137QkcFiiIZf4v++eFsPdM="));
+            jobId = await job.submit();
+
+            // First call to get status returns the status and a no logs
+            client._transport.mockReturnValueOnce(MOCK_GETSTATUS1_RESPONSE(2, 0, 0, true));
+            var status = await job.getStatus();
+            expect(client._transport).toHaveBeenCalledTimes(4); // Logon, GetSchema(xtk:job), Submit, GetStatus
+            expect(client._transport.mock.calls[3][0].data).toContain('<id xsi:type=\"xsd:string\">4210/nms:delivery@@B/C1boHl4jx1AEnDTI4nI137QkcFiiIZf4v++eFsPdM=</id><lastLogId xsi:type=\"xsd:int\">0</lastLogId><maxLogCount xsi:type=\"xsd:int\">100</maxLogCount></m:GetStatus>');
+            expect(job).toMatchObject({
+                jobId: "4210/nms:delivery@@B/C1boHl4jx1AEnDTI4nI137QkcFiiIZf4v++eFsPdM=",
+                lastLogId: 0,
+                iRc: 0
+            })
+            expect(status).toMatchObject({
+                status: 2,
+                logs: [],
+                properties: { warning: true, progress: { current: 0, max: 0 } }
+            });
+
+            // Call GetStatus again, adding some logs and making some progress
+            client._transport.mockReturnValueOnce(MOCK_GETSTATUS1_RESPONSE(2, 50, 231, true, '<log iRc="0" id="1511" logDate="2022-11-19 16:30:19.140Z" logType="2" message="Target preparation in progress..." object=""/>'));
+            var status = await job.getStatus();
+            expect(client._transport).toHaveBeenCalledTimes(5); // Logon, GetSchema(xtk:job), Submit, GetStatus, GetStatus
+            expect(client._transport.mock.calls[4][0].data).toContain('<id xsi:type=\"xsd:string\">4210/nms:delivery@@B/C1boHl4jx1AEnDTI4nI137QkcFiiIZf4v++eFsPdM=</id><lastLogId xsi:type=\"xsd:int\">0</lastLogId><maxLogCount xsi:type=\"xsd:int\">100</maxLogCount></m:GetStatus>');
+            expect(job).toMatchObject({
+                jobId: "4210/nms:delivery@@B/C1boHl4jx1AEnDTI4nI137QkcFiiIZf4v++eFsPdM=",
+                lastLogId: 1511,
+                iRc: 0
+            })
+            expect(status).toMatchObject({
+                status: 2,
+                logs: [
+                    { iRc: 0, id: 1511, logDate: new Date(1668875419140), logType: 2, message: "Target preparation in progress...", object: "" }
+                ],
+                properties: { warning: true, progress: { current: 50, max: 231 } }
+            });
+
+            // Call GetStatus again, adding some logs and making some progress and change status
+            client._transport.mockReturnValueOnce(MOCK_GETSTATUS1_RESPONSE(3, 231, 231, true, '<log iRc="16384" id="1513" logDate="2022-11-19 16:30:19.820Z" logType="0" message="DLV-490009 You have not defined the target population of the delivery action." object="test"/>'));
+            var status = await job.getStatus();
+            expect(client._transport).toHaveBeenCalledTimes(6); // Logon, GetSchema(xtk:job), Submit, GetStatus, GetStatus
+            expect(client._transport.mock.calls[5][0].data).toContain('<id xsi:type=\"xsd:string\">4210/nms:delivery@@B/C1boHl4jx1AEnDTI4nI137QkcFiiIZf4v++eFsPdM=</id><lastLogId xsi:type=\"xsd:int\">1511</lastLogId><maxLogCount xsi:type=\"xsd:int\">100</maxLogCount></m:GetStatus>');
+            expect(job).toMatchObject({
+                jobId: "4210/nms:delivery@@B/C1boHl4jx1AEnDTI4nI137QkcFiiIZf4v++eFsPdM=",
+                lastLogId: 1513,
+                iRc: 16384,
+                lastErrorCode: "DLV-490009",
+                firstErrorCode: "DLV-490009"
+            })
+            expect(status).toMatchObject({
+                status: 3,
+                logs: [
+                    { iRc: 0, id: 1511, logDate: new Date(1668875419140), logType: 2, message: "Target preparation in progress...", object: "" },
+                    { iRc: 16384, id: 1513, logDate: new Date(1668875419820), logType: 0, errorCode: "DLV-490009", message: "You have not defined the target population of the delivery action.", object: "test" },
+                ],
+                properties: { warning: true, progress: { current: 231, max: 231 } }
+            });
+            expect(job.status).toMatchObject({
+                status: 3,
+                logs: [
+                    { iRc: 0, id: 1511, logDate: new Date(1668875419140), logType: 2, message: "Target preparation in progress...", object: "" },
+                    { iRc: 16384, id: 1513, logDate: new Date(1668875419820), logType: 0, errorCode: "DLV-490009", message: "You have not defined the target population of the delivery action.", object: "test" },
+                ],
+                properties: { warning: true, progress: { current: 231, max: 231 } }
+            });
+
+            client._transport.mockReturnValueOnce(Mock.LOGOFF_RESPONSE);
+            await client.NLWS.xtkSession.logoff();
+
+        });
+
+    });
+
+    describe("Pausing anc Cancelling", () => {
+        it("Should pause job", async () => {
+            const client = { NLWS: { xtkJob: { pause: jest.fn() } }  };
+            const job = new XtkJobInterface(client);
+            job.jobId = "ABC";
+            await job.pause();
+            expect(client.NLWS.xtkJob.pause.mock.calls.length).toBe(1);
+            expect(client.NLWS.xtkJob.pause.mock.calls[0]).toEqual(["ABC"]);
+        });
+
+        it("Should cancel job", async () => {
+            const client = { NLWS: { xtkJob: { cancel: jest.fn() } }  };
+            const job = new XtkJobInterface(client);
+            job.jobId = "ABC";
+            await job.cancel();
+            expect(client.NLWS.xtkJob.cancel.mock.calls.length).toBe(1);
+            expect(client.NLWS.xtkJob.cancel.mock.calls[0]).toEqual(["ABC"]);
+        });
+
+        it("Should waitJobCancelled job", async () => {
+            const client = { NLWS: { xtkJob: { waitJobCancelled: jest.fn() } }  };
+            const job = new XtkJobInterface(client);
+            job.jobId = "ABC";
+            await job.waitJobCancelled(7);
+            expect(client.NLWS.xtkJob.waitJobCancelled.mock.calls.length).toBe(1);
+            expect(client.NLWS.xtkJob.waitJobCancelled.mock.calls[0]).toEqual(["ABC", 7]);
+        });
+
+        it("Should test if job has warnings", async () => {
+            const client = { NLWS: { xtkJob: { hasWarning: jest.fn() } }  };
+            const job = new XtkJobInterface(client);
+            job.jobId = "ABC";
+            client.NLWS.xtkJob.hasWarning.mockReturnValueOnce(1);
+            const hasWarning = await job.hasWarning();
+            expect(hasWarning).toBe(true);
+            expect(client.NLWS.xtkJob.hasWarning.mock.calls.length).toBe(1);
+            expect(client.NLWS.xtkJob.hasWarning.mock.calls[0]).toEqual(["ABC"]);
+        });
+    });
+
+
+    describe("XML Representation", () => {
+        it("Should submit an delivery preparation and get status", async () => {
+            const client = await Mock.makeClient({ representation: "xml" });
+            client._transport.mockReturnValueOnce(Mock.LOGON_RESPONSE);
+            await client.NLWS.xtkSession.logon();
+            const job = client.jobInterface({
+                xtkschema: 'nms:delivery',
+                method: 'Prepare',
+                object: DomUtil.parse('<delivery></delivery>'),    // In reality should be an actual delivery object. Not passed here to simplify the test
+            });
+            client._transport.mockReturnValueOnce(Mock.GET_XTK_JOB_SCHEMA_RESPONSE);
+            client._transport.mockReturnValueOnce(MOCK_SUBMIT_JOB_RESPONSE("4210/nms:delivery@@B/C1boHl4jx1AEnDTI4nI137QkcFiiIZf4v++eFsPdM="));
+            jobId = await job.submit();
+
+            // First call to get status returns the status and a no logs
+            client._transport.mockReturnValueOnce(MOCK_GETSTATUS1_RESPONSE(2, 0, 0, true));
+            var status = await job.getStatus();
+            expect(client._transport).toHaveBeenCalledTimes(4); // Logon, GetSchema(xtk:job), Submit, GetStatus
+            expect(client._transport.mock.calls[3][0].data).toContain('<id xsi:type=\"xsd:string\">4210/nms:delivery@@B/C1boHl4jx1AEnDTI4nI137QkcFiiIZf4v++eFsPdM=</id><lastLogId xsi:type=\"xsd:int\">0</lastLogId><maxLogCount xsi:type=\"xsd:int\">100</maxLogCount></m:GetStatus>');
+            expect(job).toMatchObject({
+                jobId: "4210/nms:delivery@@B/C1boHl4jx1AEnDTI4nI137QkcFiiIZf4v++eFsPdM=",
+                lastLogId: 0,
+                iRc: 0
+            })
+            expect(status).toMatchObject({
+                status: 2,
+                logs: [],
+                properties: { warning: true, progress: { current: 0, max: 0 } }
+            });
+
+            // Call GetStatus again, adding some logs and making some progress
+            client._transport.mockReturnValueOnce(MOCK_GETSTATUS1_RESPONSE(2, 50, 231, true, '<log iRc="0" id="1511" logDate="2022-11-19 16:30:19.140Z" logType="2" message="Target preparation in progress..." object=""/>'));
+            var status = await job.getStatus();
+            expect(client._transport).toHaveBeenCalledTimes(5); // Logon, GetSchema(xtk:job), Submit, GetStatus, GetStatus
+            expect(client._transport.mock.calls[4][0].data).toContain('<id xsi:type=\"xsd:string\">4210/nms:delivery@@B/C1boHl4jx1AEnDTI4nI137QkcFiiIZf4v++eFsPdM=</id><lastLogId xsi:type=\"xsd:int\">0</lastLogId><maxLogCount xsi:type=\"xsd:int\">100</maxLogCount></m:GetStatus>');
+            expect(job).toMatchObject({
+                jobId: "4210/nms:delivery@@B/C1boHl4jx1AEnDTI4nI137QkcFiiIZf4v++eFsPdM=",
+                lastLogId: 1511,
+                iRc: 0
+            })
+            expect(status).toMatchObject({
+                status: 2,
+                logs: [
+                    { iRc: 0, id: 1511, logDate: new Date(1668875419140), logType: 2, message: "Target preparation in progress...", object: "" }
+                ],
+                properties: { warning: true, progress: { current: 50, max: 231 } }
+            });
+
+            // Call GetStatus again, adding some logs and making some progress and change status
+            client._transport.mockReturnValueOnce(MOCK_GETSTATUS1_RESPONSE(3, 231, 231, true, '<log iRc="16384" id="1513" logDate="2022-11-19 16:30:19.820Z" logType="0" message="DLV-490009 You have not defined the target population of the delivery action." object="test"/>'));
+            var status = await job.getStatus();
+            expect(client._transport).toHaveBeenCalledTimes(6); // Logon, GetSchema(xtk:job), Submit, GetStatus, GetStatus
+            expect(client._transport.mock.calls[5][0].data).toContain('<id xsi:type=\"xsd:string\">4210/nms:delivery@@B/C1boHl4jx1AEnDTI4nI137QkcFiiIZf4v++eFsPdM=</id><lastLogId xsi:type=\"xsd:int\">1511</lastLogId><maxLogCount xsi:type=\"xsd:int\">100</maxLogCount></m:GetStatus>');
+            expect(job).toMatchObject({
+                jobId: "4210/nms:delivery@@B/C1boHl4jx1AEnDTI4nI137QkcFiiIZf4v++eFsPdM=",
+                lastLogId: 1513,
+                iRc: 16384,
+                lastErrorCode: "DLV-490009",
+                firstErrorCode: "DLV-490009"
+            })
+            expect(status).toMatchObject({
+                status: 3,
+                logs: [
+                    { iRc: 0, id: 1511, logDate: new Date(1668875419140), logType: 2, message: "Target preparation in progress...", object: "" },
+                    { iRc: 16384, id: 1513, logDate: new Date(1668875419820), logType: 0, errorCode: "DLV-490009", message: "You have not defined the target population of the delivery action.", object: "test" },
+                ],
+                properties: { warning: true, progress: { current: 231, max: 231 } }
+            });
+            expect(job.status).toMatchObject({
+                status: 3,
+                logs: [
+                    { iRc: 0, id: 1511, logDate: new Date(1668875419140), logType: 2, message: "Target preparation in progress...", object: "" },
+                    { iRc: 16384, id: 1513, logDate: new Date(1668875419820), logType: 0, errorCode: "DLV-490009", message: "You have not defined the target population of the delivery action.", object: "test" },
+                ],
+                properties: { warning: true, progress: { current: 231, max: 231 } }
+            });
+
+            client._transport.mockReturnValueOnce(Mock.LOGOFF_RESPONSE);
+            await client.NLWS.xtkSession.logoff();
+
+        });
+    });
+
+    
+});


### PR DESCRIPTION
## Description

The xtk:jobInterface is not currently supported by the SDK. The reason is that job entities do not implement xtk:jobInterface (they implement xtk:job) and job interface methods are therefore not visible to the SDK.

The SDK now provides the client.jobInterface function which returns an object which can be used to submit jobs, retreive their status, progress, logs, etc. See the documentation of the SDK for more details.


## Motivation and Context

Long running jobs such as nms:delivery#Prepare must be run as jobs

## How Has This Been Tested?

* New unit test for all new code
* Actually tested on local instance


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
