### PR TITLE
Authenticate using 'X-Session-Token' header for file upload and reports

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -546,16 +546,14 @@ const fileUploader = (client) => {
                     }
                     const data = new FormData();
                     data.append('file_noMd5', file);
-                    //TODO: Needs to be refactored after cookie issue get resolved.
                     client._makeHttpCall({
                         url: `${client._connectionParameters._endpoint}/nl/jsp/uploadFile.jsp`,
                         processData: false,
-                        credentials: 'include',
                         method: 'POST',
                         data: data,
                         headers: {
-                            'x-security-token': client._securityToken,
-                            'Cookie': '__sessiontoken=' + client._sessionToken,
+                            'X-Security-Token': client._securityToken,
+                            'X-Session-Token': client._sessionToken,
                         }
                     }).then((okay) => {
                         if (!okay.startsWith('Ok')) {
@@ -1787,11 +1785,10 @@ class Client {
                 url: `${this._connectionParameters._endpoint}/report/${callContext.reportName}?${encodeURI(`_noRender=true&_schema=${callContext.schema}&_context=${callContext.context}&_selection=${callContext.selection}`)}&_selectionCount=${selectionCount}`,
                 headers: {
                     'X-Security-Token': this._securityToken,
-                    'Cookie': '__sessiontoken=' + this._sessionToken, 
+                    'X-Session-Token': this._sessionToken,
                     'Content-Type': 'application/x-www-form-urlencoded'
                 },
                 method: 'POST',
-                credentials: 'include',
                 data : qsStringify(callContext.formData)
             };
             

--- a/src/transport.js
+++ b/src/transport.js
@@ -114,7 +114,6 @@ if (!Util.isBrowser()) {
         method: options.method,
         headers: headers,
         body: options.data,
-        credentials: options.credentials || 'same-origin'
     });
 
     const p = fetch(r).then(async (response) => {

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -3230,8 +3230,10 @@ describe('ACC Client', function () {
                     url: expect.any(String),
                     method: 'POST',
                     processData: false,
-                    credentials: 'include',
-                    headers: expect.anything(),
+                    headers: expect.objectContaining({
+                        'X-Security-Token': expect.any(String),
+                        'X-Session-Token': expect.any(String),
+                    }),
                 })
             );
 
@@ -3492,6 +3494,18 @@ describe('ACC Client', function () {
                 schema: "nms:delivery",
                 formData: {ctx: {}}
             });
+            expect(client._transport).toHaveBeenLastCalledWith(
+                expect.objectContaining({
+                    data: expect.anything(),
+                    url: expect.any(String),
+                    method: 'POST',
+                    headers: expect.objectContaining({
+                        'X-Security-Token': expect.any(String),
+                        'X-Session-Token': expect.any(String),
+                        "Content-Type": "application/x-www-form-urlencoded",
+                    }),
+                })
+            );
             expect(report._reportContext).toBe("throughput");
             expect(report._selection).toBe("12133");
             expect(report.vars.$period).toBe("604800");


### PR DESCRIPTION
Authenticate using 'X-Session-Token' header for file upload and reports

## Description

Currently, file upload and reports API use cookies for authentication. Migrating to custom headers as it will allow to integrate the acc-js-sdk in a browser as third-party cookies will not be readable.

 * This feature is experimental. Longer term, the requests will support Adobe IMS access tokens.
 * Remove `__sessiontoken` cookie hack.
 * Credentials needn't be passed in CORS requests.
 * Modify unit tests accordingly.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

- Modified unit tests to test additional capability.
- Manual tests (using `curl` requests)

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
