### PR TITLE
Fix a bug calling the nms:seedMember#getAsModel method. 

### DIFF
--- a/docs/changeLog.html
+++ b/docs/changeLog.html
@@ -2,6 +2,12 @@
 layout: page
 title: Change Log
 ---
+<section class="changelog"><h1>Version 1.1.14</h1>
+  <h2>In progress</h2>
+  
+  <li>Fix a bug calling the nms:seedMember#getAsModel method. This method starts with a lower case letter (unlike other methods which start with an upper case) which was not propertly handled by the SDK</li>
+</section>
+
 <section class="changelog"><h1>Version 1.1.13</h1>
   <h2>2022/11/24</h2>
   

--- a/src/client.js
+++ b/src/client.js
@@ -1481,6 +1481,13 @@ class Client {
         var schemaName = schema.getAttribute("name");
         var method = that._methodCache.get(schemaId, methodName);
         if (!method) {
+            // first char of the method name may be lower case (ex: nms:seedMember.getAsModel) but the methodName 
+            // variable has been capitalized. Make an attempt to lookup method name without capitalisation
+            const methodNameLC = methodName.substring(0, 1).toLowerCase() + methodName.substring(1);
+            method = that._methodCache.get(schemaId, methodNameLC);
+            if (method) methodName = methodNameLC;
+        }
+        if (!method) {
             this._methodCache.put(schema);
             method = that._methodCache.get(schemaId, methodName);
         }

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -848,6 +848,28 @@ describe('ACC Client', function () {
             await client.NLWS.xtkSession.logon();
 
             client._transport.mockReturnValueOnce(Mock.GET_XTK_SESSION_SCHEMA_RESPONSE);
+            client._transport.mockReturnValueOnce(Promise.resolve(`<?xml version='1.0'?>
+                <SOAP-ENV:Envelope xmlns:xsd='http://www.w3.org/2001/XMLSchema' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xmlns:ns='urn:xtk:session' xmlns:SOAP-ENV='http://schemas.xmlsoap.org/soap/envelope/'>
+                <SOAP-ENV:Body>
+                    <startsWithLowerCaseResponse xmlns='urn:xtk:session' SOAP-ENV:encodingStyle='http://schemas.xmlsoap.org/soap/encoding/'>
+                        <presult xsi:type='xsd:int'>44</presult>
+                    </startsWithLowerCaseResponse>
+                </SOAP-ENV:Body>
+                </SOAP-ENV:Envelope>`));
+
+            const response = await client.NLWS.xtkSession.startsWithLowerCase()
+            expect(response).toBe(44);
+
+            client._transport.mockReturnValueOnce(Mock.LOGOFF_RESPONSE);
+            await client.NLWS.xtkSession.logoff();
+        });
+
+        it("Should support methods starting with a lower case letter", async () => {
+            const client = await Mock.makeClient();
+            client._transport.mockReturnValueOnce(Mock.LOGON_RESPONSE);
+            await client.NLWS.xtkSession.logon();
+
+            client._transport.mockReturnValueOnce(Mock.GET_XTK_SESSION_SCHEMA_RESPONSE);
             await expect(client.NLWS.xtkSession.nonStatic()).rejects.toMatchObject({ errorCode: "SDK-000009" });
 
             client._transport.mockReturnValueOnce(Mock.LOGOFF_RESPONSE);

--- a/test/mock.js
+++ b/test/mock.js
@@ -275,6 +275,11 @@ const GET_XTK_SESSION_SCHEMA_RESPONSE = Promise.resolve(`<?xml version='1.0'?>
                             <param name="name" type="string"/>
                         </parameters>
                     </method>
+                    <method name="startsWithLowerCase" static="true">
+                        <parameters>
+                            <param name="result" type="long" inout="out"/>
+                        </parameters>
+                    </method>
                 </methods>
             </schema>
             </pdomDoc>


### PR DESCRIPTION

## Description

This method starts with a lower case letter (unlike other methods which start with an upper case) which was not propertly handled by the SDK

Calling
`client.NLWS.nmsSeedMember.getAsModel('', 'XX', selection, {}))``

was failing with error SDK-000009 Unknown method 

## How Has This Been Tested?

New unit test

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
