### PR TITLE
Add onBeforeCall / onAfterCall observers

### DIFF
--- a/docs/observability.html
+++ b/docs/observability.html
@@ -6,41 +6,95 @@ title: Observability
 
 <p>The Campaign client implements an observer mechanism that you can use to hook into what's hapenning internally.</p>
 
-<p>An <b>Observer</b>is an object having any of the following methods:</p>
+<p>An <b>Observer</b> is an object which has one or several callback methods which will be called at certain particular points in the SDK</p>
 
-<p>For SOAP calls</p>
+
+<h1>SOAP calls</h1>
+<p>It is possible to observe the SOAP calls that are performed by the SDK. The following callbacks are called whenever a SOAP call is made. They can observe the SOAP calls but are not supposed to modify any of the parameters</p>
+<p></p>
 <ul>
-    <li>onSOAPCall(soapCall, safeCallData)</li>
-    <li>onSOAPCallSuccess(soapCall, safeCallResponse) {}</li>
-    <li>onSOAPCallFailure(soapCall, exception) {}</li>
+    <li><b>onSOAPCall</b> (soapCall, safeCallData)</li>
+    <li><b>onSOAPCallSuccess</b> (soapCall, safeCallResponse) {}</li>
+    <li><b>onSOAPCallFailure</b> (soapCall, exception) {}</li>
 </ul>
 
-<p>For HTTP calls (such as JSP, JSSP...). Note that despite SOAP calls are also HTTP calls, the following callbacks will not be called for SOAP calls.</p>
+<p>The <b>soapCall</b> parameter is the SOAP call which is being observed. In the <b>onSOAPCall</b> callback, the SOAP call has not been executed yet.</p>
 
+<p>The <b>safeCallData</b> and <b>safeCallResponse</b> represent the text XML of the SOAP request and response, but in which all session and security tokens have been replaced with "***" string. Hence the name "safe". You should use those parameters for any logging purpose to avoid leaking credentials.</p>
+
+
+<p>The <b>soapCall</b> parameter is a <b>SoapMethodCall</b> object which describes the SOAP call. It has the following public attributes. </p>
+<p></p>
 <ul>
-    <li>onHTTPCall(request, safeCallData)</li>
-    <li>onHTTPCallSuccess(request, safeCallResponse) {}</li>
-    <li>onHTTPCallFailure(request, exception) {}</li>
+    <li><b>urn</b> is the SOAP URN which corresponds to the Campaign schema id. For instance "xtk:session"</li>
+    <li><b>methodName</b> is the name of the method to call. For instance "Logon"</li>
+    <li><b>internal</b> is true or false, depending if the SOAP call is an internal SOAP call performed by the framework itself, or if it's a SOAP call issued by a SDK user</li>
+    <li><b>request</b> is a literal corresponding to the HTTP request. It's compatible with the <b>transport</b> protocol. It may be undefined if the SOAP call has need been completely built</li>
+    <li><b>response</b> is a string containing the XML result of the SOAP call if the call was successful. It may be undefined if the call was not executed yet or if the call failed</li>
 </ul>
 
-<p>The <b>soapCall</b>parameter is the SOAP call which is being observed. In the <b>onSOAPCall</b>callback, the SOAP call has not been executed yet.</p>
-
-<p>The <b>request</b>parameter is the HTTP request (as defined in the transport protocol above)</p>
-
-<p>The <b>safeCallData</b>and <b>safeCallResponse</b>represent the text XML of the SOAP request and response, but in which all session and security tokens have been replaced with "***" string. Hence the name "safe". You should use those parameters for any logging purpose to avoid leaking credentials.</p>
 
 
-<p>The <b>soapCall</b>parameter is a <b>SoapMethodCall</b>object which describes the SOAP call. It has the following public attributes. </p>
-
+<h1>HTTP calls</h1>
+<p>For HTTP calls (such as JSP, JSSP...). Note that despite SOAP calls are also HTTP calls, the following callbacks will not be called for SOAP calls. These callbacks are not supposed to modify any of the parameters</p>
+<p></p>
 <ul>
-    <li><b>urn</b>is the SOAP URN which corresponds to the Campaign schema id. For instance "xtk:session"</li>
-    <li><b>methodName</b>is the name of the method to call. For instance "Logon"</li>
-    <li><b>internal</b>is true or false, depending if the SOAP call is an internal SOAP call performed by the framework itself, or if it's a SOAP call issued by a SDK user</li>
-    <li><b>request</b>is a literal corresponding to the HTTP request. It's compatible with the <b>transport</b>protocol. It may be undefined if the SOAP call has need been completely built</li>
-    <li><b>response</b>is a string containing the XML result of the SOAP call if the call was successful. It may be undefined if the call was not executed yet or if the call failed</li>
+    <li><b>onHTTPCall</b> (request, safeCallData)</li>
+    <li><b>onHTTPCallSuccess</b> (request, safeCallResponse) {}</li>
+    <li><b>onHTTPCallFailure</b> (request, exception) {}</li>
 </ul>
 
-<p>In version 1.1.7, the observer interface is extended to listen for internal events of the SDK. The <b>event</b>function of the observer, if it exist will be call for each SDK event with 2 parameters: the event itself, and for some events, a parent event. For instance a SOAP response event will have the SOAP request for a parent event.</p>
+
+<p>The <b>request</b> parameter is the HTTP request (as defined in the transport protocol above)</p>
+
+
+<h1>Logging all SOAP calls</h1>
+
+<p>SOAP calls can be logged by setting the <b>traceAPICalls</b> attribute on the client at any time. For security reasons, the security and session tokens values will be replaced by "***" to avoid leaking them</p>
+
+
+<pre class="code">
+client.traceAPICalls(true);
+</pre>
+
+<p>This is an example of the logs</p>
+<pre class="code">
+SOAP//request xtk:session#GetOption &lt;SOAP-ENV:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
+xmlns:ns="http://xml.apache.org/xml-soap">
+&lt;SOAP-ENV:Header>
+&lt;Cookie>__sessiontoken=***&lt;/Cookie>
+&lt;X-Security-Token>***&lt;/X-Security-Token>
+&lt;/SOAP-ENV:Header>
+&lt;SOAP-ENV:Body>
+&lt;m:GetOption xmlns:m="urn:xtk:session" SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+&lt;sessiontoken xsi:type="xsd:string">***&lt;/sessiontoken>
+&lt;name xsi:type="xsd:string">XtkDatabaseId&lt;/name>
+&lt;/m:GetOption>
+&lt;/SOAP-ENV:Body>
+&lt;/SOAP-ENV:Envelope>
+
+SOAP//response xtk:session#GetOption &lt;?xml version='1.0'?>
+&lt;SOAP-ENV:Envelope xmlns:xsd='http://www.w3.org/2001/XMLSchema'
+xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
+xmlns:ns='urn:xtk:session'
+xmlns:SOAP-ENV='http://schemas.xmlsoap.org/soap/envelope/'>
+&lt;SOAP-ENV:Body>
+&lt;GetOptionResponse xmlns='urn:xtk:session' SOAP-ENV:encodingStyle='http://schemas.xmlsoap.org/soap/encoding/'>
+&lt;pstrValue xsi:type='xsd:string'>uFE80000000000000F1FA913DD7CC7C4804BA419F&lt;/pstrValue>
+&lt;pbtType xsi:type='xsd:byte'>6&lt;/pbtType>
+&lt;/GetOptionResponse>
+&lt;/SOAP-ENV:Body>
+&lt;/SOAP-ENV:Envelope>
+</pre>
+
+
+
+
+
+<h1>Observability events</h1>
+<p>In version 1.1.7, the observer interface is extended to listen for internal events of the SDK. The <b>event</b> function of the observer, if it exist will be call for each SDK event with 2 parameters: the event itself, and for some events, a parent event. For instance a SOAP response event will have the SOAP request for a parent event.</p>
 
 <pre class="code">
 client.registerObserver({
@@ -127,43 +181,46 @@ client.registerObserver({
 
 
 
-<h1>Logging all SOAP calls</h1>
+<h1>Method interception</h1>
 
-<p>SOAP calls can be logged by setting the <b>traceAPICalls</b>attribute on the client at any time. For security reasons, the security and session tokens values will be replaced by "***" to avoid leaking them</p>
+<p>
+    In version 1.1.17 of the SDK, it's possible to use the observer mechanism to intercept SOAP calls, modify parameters before the call is made, or modify the response before it's returned to the caller.
+</p>
+<p>
+    Some SOAP calls are not intercepted: internal SOAP calls performed by the SDK itself (for instance to get schemas) are not intercepted. Logon and Logoff methods are not intercepted either.
+</p>
+<p>
+    The <b>beforeSoapCall</b> and <b>afterSoapCall</b> methods can be used. They will be passed the following parameters
+</p>
 
+<table>
+    <thead>
+        <tr>
+            <th>Parameter</th>
+            <th>Comment / Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><b>method</b></td>
+            <td>An object describing the SOAP method. It contains the <b>urn</b>, <b>name</b> and <b>isStatic</b> attributes</td>
+        </tr>
+        <tr>
+            <td><b>object</b></td>
+            <td>The object ("this") on which the method applies (it will be undefined for static methods). The <b>beforeSoapCall</b> callback is free to modify the object as needed.</td>
+        </tr>
+        <tr>
+            <td><b>inputParameters</b></td>
+            <td>Is an array containing the method parameters. The <b>beforeSoapCall</b> callback is free to modify the object as needed. </td>
+        </tr>
+        <tr>
+            <td><b>representation</b></td>
+            <td>The representation (SimpleJson, xml, etc.) used for this method and in which the object and parameters are set</td>
+        </tr>
+        <tr>
+            <td><b>outputParameters</b></td>
+            <td>For the <b>afterSoapCall</b> method, an array containing the return value of the SOAP calls. The <b>afterSoapCall</b> callback is free to modify the object as needed. </td>
+        </tr>
+    </tbody>
+</table>
 
-<pre class="code">
-client.traceAPICalls(true);
-</pre>
-
-<p>This is an example of the logs</p>
-<pre class="code">
-SOAP//request xtk:session#GetOption &lt;SOAP-ENV:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
-xmlns:ns="http://xml.apache.org/xml-soap">
-&lt;SOAP-ENV:Header>
-&lt;Cookie>__sessiontoken=***&lt;/Cookie>
-&lt;X-Security-Token>***&lt;/X-Security-Token>
-&lt;/SOAP-ENV:Header>
-&lt;SOAP-ENV:Body>
-&lt;m:GetOption xmlns:m="urn:xtk:session" SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
-&lt;sessiontoken xsi:type="xsd:string">***&lt;/sessiontoken>
-&lt;name xsi:type="xsd:string">XtkDatabaseId&lt;/name>
-&lt;/m:GetOption>
-&lt;/SOAP-ENV:Body>
-&lt;/SOAP-ENV:Envelope>
-
-SOAP//response xtk:session#GetOption &lt;?xml version='1.0'?>
-&lt;SOAP-ENV:Envelope xmlns:xsd='http://www.w3.org/2001/XMLSchema'
-xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
-xmlns:ns='urn:xtk:session'
-xmlns:SOAP-ENV='http://schemas.xmlsoap.org/soap/envelope/'>
-&lt;SOAP-ENV:Body>
-&lt;GetOptionResponse xmlns='urn:xtk:session' SOAP-ENV:encodingStyle='http://schemas.xmlsoap.org/soap/encoding/'>
-&lt;pstrValue xsi:type='xsd:string'>uFE80000000000000F1FA913DD7CC7C4804BA419F&lt;/pstrValue>
-&lt;pbtType xsi:type='xsd:byte'>6&lt;/pbtType>
-&lt;/GetOptionResponse>
-&lt;/SOAP-ENV:Body>
-&lt;/SOAP-ENV:Envelope>
-</pre>

--- a/src/cacheRefresher.js
+++ b/src/cacheRefresher.js
@@ -146,7 +146,7 @@ governing permissions and limitations under the License.
         // Get last modified entities for the Campaign server and remove from cache last modified entities
         async _callAndRefresh() {
             const that = this;
-            const soapCall = this._client._prepareSoapCall("xtk:session", "GetModifiedEntities", true, this._connectionParameters._options.extraHttpHeaders);
+            const soapCall = this._client._prepareSoapCall("xtk:session", "GetModifiedEntities", true, true, this._connectionParameters._options.extraHttpHeaders);
 
             if (this._lastTime === undefined) {
                 const storedTime = this._refresherStateCache.get("time");
@@ -191,6 +191,7 @@ governing permissions and limitations under the License.
 
             // Do a soap call GetModifiedEntities instead of xtksession.GetModifiedEnties because we don't want to go through methodCache 
             // which might not contain the method GetModifiedEntities just after a build updgrade from a old version of acc 
+            // This is an internal SOAP call that cannot be intercepted by observers onBeforeCall / onAfterCall
             return this._client._makeSoapCall(soapCall)
                 .then(() => {
                     let doc = soapCall.getNextDocument();

--- a/src/campaign.js
+++ b/src/campaign.js
@@ -30,7 +30,7 @@ const { Util } = require("./util.js");
   static CANNOT_GET_CREDENTIALS_PASSWORD(type)            { return new CampaignException(undefined, 400, 16384, `SDK-000002 Cannot get password for Credentials of type '${type}'`); }
   static INVALID_CONNECTION_OPTIONS(options)              { return new CampaignException(undefined, 400, 16384, `SDK-000003 Invalid options parameter (type '${typeof options}'). An object literal is expected`); }
   static INVALID_REPRESENTATION(representation, details)  { return new CampaignException(undefined, 400, 16384, `SDK-000004 Invalid representation '${representation}'.`, details); }
-  static CREDENTIALS_FOR_INVALID_EXT_ACCOUNT(name, type)  { return new CampaignException(undefined, 400, 16384, `SDK-000005 Cannot created connection parameters for external account '${name}': account type ${type} not supported`); }
+  static CREDENTIALS_FOR_INVALID_EXT_ACCOUNT(name, type)  { return new CampaignException(undefined, 400, 16384, `SDK-000005 Cannot create connection parameters for external account '${name}': account type ${type} not supported`); }
   static BAD_PARAMETER(name, value, details)              { return new CampaignException(undefined, 400, 16384, `SDK-000006 Bad parameter '${name}' with value '${value}'`, details); }
   static UNEXPECTED_SOAP_RESPONSE(call, details)          { return new CampaignException(     call, 500,   -53, `SDK-000007 Unexpected response from SOAP call`, details); }
   static BAD_SOAP_PARAMETER(call, name, value, details)   { return new CampaignException(     call, 400, 16384, `SDK-000008 Bad parameter '${name}' with value '${value}'`, details); }

--- a/src/client.js
+++ b/src/client.js
@@ -61,6 +61,13 @@ const qsStringify = require('qs-stringify');
  * @memberOf Campaign
 */
 
+/**
+ * @typedef {Object} XtkMethodParam
+    * @property {string} name - the name of the parameter
+    * @property {string} type - the type of the parameter
+    * @property {*} value - the values of the parameter in the expected representation
+    * @memberOf Campaign
+ */
 
 /**
  * Java Script Proxy handler for an XTK object. An XTK object is one constructed with the following syntax:
@@ -919,17 +926,19 @@ class Client {
      * @private
      * @param {string} urn is the API name space, usually the schema. For instance xtk:session
      * @param {string} method is the method to call, for instance Logon
+     * @param {boolean} isStatic is a boolean indicating if the method is static or not
      * @param {boolean} internal is a boolean indicating whether the SOAP call is performed by the SDK (internal = true) or on behalf of a user
      * @return {SOAP.SoapMethodCall} a SoapMethodCall which have been initialized with security tokens... and to which the method
      * parameters should be set
      */
-    _prepareSoapCall(urn, method, internal, extraHttpHeaders, pushDownOptions) {
+    _prepareSoapCall(urn, method, isStatic, internal, extraHttpHeaders, pushDownOptions) {
         const soapCall = new SoapMethodCall(this._transport, urn, method,
                                             this._sessionToken, this._securityToken,
                                             this._getUserAgentString(),
                                             Object.assign({}, this._connectionParameters._options, pushDownOptions),
                                             extraHttpHeaders);
         soapCall.internal = !!internal;
+        soapCall.isStatic = isStatic;
         return soapCall;
     }
 
@@ -980,6 +989,225 @@ class Client {
     _soapEndPoint() {
         return this._connectionParameters._endpoint + "/nl/jsp/soaprouter.jsp";
     }
+
+    // Serializes parameters for a SOAP call
+    // @param {string} entitySchemaId is the id of the schema of the entity underlying the SOAP call
+    // @param {DOMDocument} schema is the XML schema of the method call
+    // @param {SOAP.SoapMethodCall} soapCall is the SOAP call being performed
+    // @param {Campaign.XtkMethodParam[]} inputParameters is the list of input parameters. The first paramater in the array is the "this" parameter for non-static method calls
+    // @param {string} representation is the representation to use to interpret the input parameters
+    async _writeSoapCallParameters(entitySchemaId, schema, soapCall, inputParameters, representation) {
+        const methodName = soapCall.methodName;
+        var isThisParam = !soapCall.isStatic;
+
+        for (const ip of inputParameters) {
+            const type = ip.type;
+            const paramName = ip.name;
+            var paramValue = ip.value;
+
+            if (type == "string")
+                soapCall.writeString(ip.name, XtkCaster.asString(ip.value));    
+            else if (type == "primarykey")
+                soapCall.writeString(ip.name, XtkCaster.asString(ip.value));
+            else if (type == "boolean")
+                soapCall.writeBoolean(ip.name, XtkCaster.asBoolean(ip.value));
+            else if (type == "byte")
+                soapCall.writeByte(ip.name, XtkCaster.asByte(ip.value));
+            else if (type == "short")
+                soapCall.writeShort(ip.name, XtkCaster.asShort(ip.value));
+            else if (type == "int")
+                soapCall.writeLong(ip.name, XtkCaster.asLong(ip.value));
+            else if (type == "long")
+                soapCall.writeLong(ip.name, XtkCaster.asLong(ip.value));
+            else if (type == "int64")
+                soapCall.writeInt64(ip.name, XtkCaster.asInt64(ip.value));
+            else if (type == "datetime")
+                soapCall.writeTimestamp(ip.name, XtkCaster.asTimestamp(ip.value));
+            else if (type == "date")
+                soapCall.writeDate(ip.name, XtkCaster.asDate(ip.value));
+            else if (type == "DOMDocument" || type == "DOMElement") {
+                var docName = undefined;    
+                let paramRepresentation = representation;
+                if (paramValue.__xtkProxy) {
+                    // A xtk proxy object is passed as a parameter. The call context contains the schema so we
+                    // can use it to determine the XML document root (docName)
+                    const paramValueContext = paramValue["."];
+                    paramValue = paramValueContext.object;
+                    const xtkschema = paramValueContext.schemaId;
+                    const index = xtkschema.indexOf(":");
+                    docName = xtkschema.substring(index+1);
+                    paramRepresentation = paramValueContext.representation; // xtk proxy may have it's own representation
+                }
+                else {
+                    // Hack for workflow API. The C++ code checks that the name of the XML element is <variables>. When
+                    // using xml representation at the SDK level, it's ok since the SDK caller will set that. But this does
+                    // not work when using "BadgerFish" representation where we do not know the root element name.
+                    if (entitySchemaId == "xtk:workflow" && methodName == "StartWithParameters" && paramName == "parameters")
+                        docName = "variables";
+                    if (entitySchemaId == "nms:rtEvent" && methodName == "PushEvent")
+                        docName = "rtEvent";
+                    // Try to guess the document name. This is usually available in the xtkschema attribute
+                    var xtkschema = EntityAccessor.getAttributeAsString(paramValue, "xtkschema");
+                    if (!xtkschema) xtkschema = paramValue["@xtkschema"];
+                    if (xtkschema) {
+                        const index = xtkschema.indexOf(":");
+                        docName = xtkschema.substring(index+1);
+                    }
+                    if (!docName) docName = paramName; // Use te parameter name as the XML root element
+                }
+                var xmlValue = this._fromRepresentation(docName, paramValue, paramRepresentation || representation);
+                if (type == "DOMDocument") {
+                    if (isThisParam) {
+                        isThisParam = false;
+                        // The xtk:persist#NewInstance requires a xtkschema attribute which we can compute here
+                        // Actually, we're always adding it, for all non-static methods
+                        const xmlRoot = xmlValue.nodeType === 9 ? xmlValue.documentElement : xmlValue;
+                        if (!xmlRoot.hasAttribute("xtkschema"))
+                            xmlRoot.setAttribute("xtkschema", entitySchemaId);
+                        soapCall.writeDocument("document", xmlValue);
+                    }
+                    else
+                        soapCall.writeDocument(paramName, xmlValue);
+                }
+                else
+                    soapCall.writeElement(paramName, xmlValue);
+            }
+            else
+                throw CampaignException.BAD_SOAP_PARAMETER(soapCall, paramName, paramValue, `Unsupported parameter type '${type}' for parameter '${paramName}' of method '${methodName}' of schema '${entitySchemaId}`);
+        }
+    }
+
+    // Deserializes results for a SOAP call
+    // @param {string} entitySchemaId is the id of the schema of the entity underlying the SOAP call
+    // @param {DOMDocument} schema is the XML schema of the method call
+    // @param {SOAP.SoapMethodCall} soapCall is the SOAP call being performed
+    // @param {Campaign.XtkMethodParam[]}  outputParameters is the list of output parameters. The first paramater in the array is the "this" parameter for non-static method calls
+    // @param {string} representation is the representation to use to interpret the parameters
+    async _readSoapCallResult(entitySchemaId, schema, soapCall, outputParameters, representation) {
+        const methodName = soapCall.methodName;
+        var isThisParam = !soapCall.isStatic;
+        for (const op of outputParameters) {
+            const type = op.type;
+            const paramName = op.name;
+            var returnValue = op.value;
+
+            if (isThisParam) {
+                isThisParam = false;
+                // Non static methods, such as xtk:query#SelectAll return a element named "entity" which is the object itself on which
+                // the method is called. This is the new version of the object (in XML form)
+                const entity = soapCall.getEntity();
+                if (entity)
+                    returnValue = this._toRepresentation(entity, representation);
+            }
+            else if (type == "string")
+                returnValue = soapCall.getNextString();
+            else if (type == "primarykey")
+                returnValue = soapCall.getNextPrimaryKey();
+            else if (type == "boolean")
+                returnValue = soapCall.getNextBoolean();
+            else if (type == "byte")
+                returnValue = soapCall.getNextByte();
+            else if (type == "short")
+                returnValue = soapCall.getNextShort();
+            else if (type == "long")
+                returnValue = soapCall.getNextLong();
+            else if (type == "int64")
+                // int64 are represented as strings to make sure no precision is lost
+                returnValue = soapCall.getNextInt64();
+            else if (type == "datetime")
+                returnValue = soapCall.getNextDateTime();
+            else if (type == "date")
+                returnValue = soapCall.getNextDate();
+            else if (type == "DOMDocument") {
+                returnValue = soapCall.getNextDocument();
+                returnValue = this._toRepresentation(returnValue, representation);
+            }
+            else if (type == "DOMElement") {
+                returnValue = soapCall.getNextElement();
+                returnValue = this._toRepresentation(returnValue, representation);
+            }
+            else {
+                const schemaName = entitySchemaId.substring(entitySchemaId.indexOf(':') + 1);
+                // type can reference a schema element. The naming convension is that the type name
+                // is {schemaName}{elementNameCamelCase}. For instance, the type "sessionUserInfo"
+                // matches the "userInfo" element of the "xtkSession" schema
+                let element;
+                if (type.substr(0, schemaName.length) == schemaName) {
+                    const shortTypeName = type.substr(schemaName.length, 1).toLowerCase() + type.substr(schemaName.length + 1);
+                    element = DomUtil.getFirstChildElement(schema, "element");
+                    while (element) {
+                        if (element.getAttribute("name") == shortTypeName) {
+                            // Type found in schema: Process as a DOM element
+                            returnValue = soapCall.getNextElement();
+                            returnValue = this._toRepresentation(returnValue, representation);
+                            break;
+                        }
+                        element = DomUtil.getNextSiblingElement(element, "element");
+                    }
+
+                }
+                if (!element)
+                    throw CampaignException.UNEXPECTED_SOAP_RESPONSE(soapCall, `Unsupported return type '${type}' for parameter '${paramName}' of method '${methodName}' of schema '${entitySchemaId}'`);
+            }
+            op.value = returnValue;
+        }
+        soapCall.checkNoMoreArgs();
+    }
+
+    /**
+     * Serialize input parameters, make a SOAP call and deserialize result parameters. Calls observer when necessary.
+     * 
+     * The inputParams and outputParams arrays contain prepopulated parameter lists with the name, type (and value for
+     * input params). This function does not return anything but will populate the outputParams array with the actual result.
+     *
+     * @private
+     * @param {string} entitySchemaId is the id of the schema of the entity underlying the SOAP call
+     * @param {DOMDocument} schema is the XML schema of the method call
+     * @param {SOAP.SoapMethodCall} soapCall is the SOAP call being performed
+     * @param {Campaign.XtkMethodParam[]}  inputParams is the list of input parameters. The first paramater in the array is the "this" parameter for non-static method calls
+     * @param {Campaign.XtkMethodParam[]}  outputParams is the list of output parameters. The first paramater in the array is the "this" parameter for non-static method calls
+     * @param {string} representation is the representation to use to interpret the parameters 
+     */
+    async _makeInterceptableSoapCall(entitySchemaId, schema, soapCall, inputParams, outputParams, representation) {
+        // Call observers and give them a chance to modify the parameters before the call is actually made
+        if (!soapCall.internal) {
+            await this._beforeSoapCall({
+                urn: soapCall.urn,
+                name: soapCall.methodName,
+            }, inputParams, representation);
+        }
+
+        // Make SOAP call
+        await this._writeSoapCallParameters(entitySchemaId, schema, soapCall, inputParams, representation);
+        await this._makeSoapCall(soapCall);
+        await this._readSoapCallResult(entitySchemaId, schema, soapCall, outputParams, representation);
+        
+        // Specific handling of query results
+        // https://github.com/adobe/acc-js-sdk/issues/3 
+        if (entitySchemaId === "xtk:queryDef" && soapCall.methodName === "ExecuteQuery") {
+            const returnValue = outputParams[1].value; // first parameter is the "this", second one (index 1) is the query result
+            const emptyResult = Object.keys(returnValue).length == 0;
+            const object = inputParams[0].value; // first parmater is the "this"
+            const operation = EntityAccessor.getAttributeAsString(object, "operation");
+            if (operation == "getIfExists" && emptyResult)
+                outputParams[1].value = null;
+            else if (operation == "select" && emptyResult) {
+                const querySchemaId = EntityAccessor.getAttributeAsString(object, "schema");
+                const index = querySchemaId.indexOf(':');
+                const querySchemaName = querySchemaId.substr(index + 1);
+                outputParams[1].value[querySchemaName] = [];
+            }
+        }
+
+        // Call observers and give them a chance to modify the results
+        if (!soapCall.internal) {
+            await this._afterSoapCall({
+                urn: soapCall.urn,
+                name: soapCall.methodName
+            }, inputParams, representation, outputParams);
+        }
+    }
+
     /**
      * After a SOAP method call has been prepared with '_prepareSoapCall', and parameters have been added,
      * this function actually executes the SOAP call
@@ -1102,7 +1330,7 @@ class Client {
             return Promise.resolve();
         }
         else if (credentials._type == "UserPassword" || credentials._type == "BearerToken") {
-            const soapCall = that._prepareSoapCall("xtk:session", credentials._type === "UserPassword" ? "Logon" : "BearerTokenLogon", false, this._connectionParameters._options.extraHttpHeaders);
+            const soapCall = that._prepareSoapCall("xtk:session", credentials._type === "UserPassword" ? "Logon" : "BearerTokenLogon", true, false, this._connectionParameters._options.extraHttpHeaders);
             // No retry for logon SOAP methods
             soapCall.retry = false;
             if (credentials._type == "UserPassword") {
@@ -1181,7 +1409,7 @@ class Client {
             this.stopRefreshCaches();
             const credentials = this._connectionParameters._credentials;
             if (credentials._type != "SessionToken" && credentials._type != "AnonymousUser") {
-                var soapCall = that._prepareSoapCall("xtk:session", "Logoff", false, this._connectionParameters._options.extraHttpHeaders);
+                var soapCall = that._prepareSoapCall("xtk:session", "Logoff", true, false, this._connectionParameters._options.extraHttpHeaders);
                 return this._makeSoapCall(soapCall).then(function() {
                     that._sessionToken = "";
                     that._securityToken = "";
@@ -1370,17 +1598,17 @@ class Client {
      * @return {XML.XtkObject} A DOM or JSON representation of the entity, or null if the entity is not found
      */
      async getEntityIfMoreRecent(entityType, fullName, representation, internal) {
-        const that = this;
-        const soapCall = this._prepareSoapCall("xtk:persist", "GetEntityIfMoreRecent", internal, this._connectionParameters._options.extraHttpHeaders);
-        soapCall.writeString("pk", entityType + "|" + fullName);
-        soapCall.writeString("md5", "");
-        soapCall.writeBoolean("mustExist", false);
-        return this._makeSoapCall(soapCall).then(function() {
-            var doc = soapCall.getNextDocument();
-            soapCall.checkNoMoreArgs();
-            doc = that._toRepresentation(doc, representation);
-            return doc;
-        });
+        const soapCall = this._prepareSoapCall("xtk:persist", "GetEntityIfMoreRecent", true, internal, this._connectionParameters._options.extraHttpHeaders);
+        const inputParams = [
+            { name: "pk", type: "string", value: entityType + "|" + fullName },
+            { name: "md5", type: "string", value: "" },
+            { name: "mustExist", type: "boolean", value: false },
+        ];
+        const outputParams = [
+            { name: "doc", type: "DOMDocument" },
+        ];
+        await this._makeInterceptableSoapCall("xtk:session", undefined, soapCall, inputParams, outputParams, representation);
+        return outputParams[0].value;
     }
 
     /**
@@ -1462,7 +1690,6 @@ class Client {
      */
     async _callMethod(methodName, callContext, parameters) {
         const that = this;
-        const result = [];
         const schemaId = callContext.schemaId;
 
         var entitySchemaId = schemaId;
@@ -1476,7 +1703,6 @@ class Client {
         var schema = await that.getSchema(methodSchemaId, "xml", true);
         if (!schema)
             throw CampaignException.SOAP_UNKNOWN_METHOD(schemaId, methodName, `Schema '${schemaId}' not found`);
-        var schemaName = schema.getAttribute("name");
 
         // Lookup the method to call
         var method = that._methodCache.get(methodSchemaId, methodName);
@@ -1499,7 +1725,8 @@ class Client {
         var urn = schemaId !== 'xtk:jobInterface' ? that._methodCache.getSoapUrn(schemaId, methodName)
             : `xtk:jobInterface|${entitySchemaId}`;
 
-        var soapCall = that._prepareSoapCall(urn, methodName, false, callContext.headers, callContext.pushDownOptions);
+        const isStatic = DomUtil.getAttributeAsBoolean(method, "static");
+        var soapCall = that._prepareSoapCall(urn, methodName, isStatic, false, callContext.headers, callContext.pushDownOptions);
 
         // If method is called with one parameter which is a function, then we assume it's a hook: the function will return
         // the actual list of parameters
@@ -1509,21 +1736,28 @@ class Client {
         if (isfunc)
             parameters = parameters[0](method, callContext);
 
-        const isStatic = DomUtil.getAttributeAsBoolean(method, "static");
-        var object = callContext.object;
-        if (!isStatic) {
-            if (!object)
-                throw CampaignException.SOAP_UNKNOWN_METHOD(schemaId, methodName, `Cannot call non-static method '${methodName}' of schema '${schemaId}' : no object was specified`);
+        // Create input and output parameters arrays. Each array will contain elements for the corresponding parameter name, type and value
+        const inputParams = [];
+        const outputParams = [];
 
-            const rootName = entitySchemaId.substr(entitySchemaId.indexOf(':') + 1);
-            object = that._fromRepresentation(rootName, object, callContext.representation);
-            // The xtk:persist#NewInstance requires a xtkschema attribute which we can compute here
-            // Actually, we're always adding it, for all non-static methods
-            const xmlRoot = object.nodeType === 9 ? object.documentElement : object;
-            if (!xmlRoot.hasAttribute("xtkschema"))
-                xmlRoot.setAttribute("xtkschema", entitySchemaId);
-            soapCall.writeDocument("document", object);
+        // For non static methods, the first input and the first output parameters represent the entity itself. The name of the corresponding
+        // parameter is set the the entity schema name.
+        if (!isStatic) {
+            var schemaName = entitySchemaId.substring(entitySchemaId.indexOf(':') + 1);
+            if (!callContext.object)
+                throw CampaignException.SOAP_UNKNOWN_METHOD(schemaId, methodName, `Cannot call non-static method '${methodName}' of schema '${schemaId}' : no object was specified`);
+            inputParams.push({
+                name: schemaName,
+                type: "DOMDocument",
+                value: callContext.object
+            });
+            outputParams.push({
+                name: schemaName,
+                type: "DOMDocument"
+            });
         }
+
+        // Traverse the <parameters> object and create the corresponding parameter objects
         const parametersIsArray = (typeof parameters == "object") && parameters.length;
         const params = DomUtil.getFirstChildElement(method, "parameters");
         if (params) {
@@ -1531,167 +1765,47 @@ class Client {
             var paramIndex = 0;
             while (param) {
                 const inout = DomUtil.getAttributeAsString(param, "inout");
+                const type = DomUtil.getAttributeAsString(param, "type");
+                const paramName = DomUtil.getAttributeAsString(param, "name");
                 if (!inout || inout=="in") {
-                    const type = DomUtil.getAttributeAsString(param, "type");
-                    const paramName = DomUtil.getAttributeAsString(param, "name");
                     let paramValue = parametersIsArray ? parameters[paramIndex] : parameters;
+                    const inputParam = {
+                        name: paramName,
+                        type: type,
+                        value: paramValue
+                    };
+                    inputParams.push(inputParam);
                     paramIndex = paramIndex + 1;
-                    if (type == "string")
-                        soapCall.writeString(paramName, XtkCaster.asString(paramValue));
-                    else if (type == "primarykey")
-                        soapCall.writeString(paramName, XtkCaster.asString(paramValue));
-                    else if (type == "boolean")
-                        soapCall.writeBoolean(paramName, XtkCaster.asBoolean(paramValue));
-                    else if (type == "byte")
-                        soapCall.writeByte(paramName, XtkCaster.asByte(paramValue));
-                    else if (type == "short")
-                        soapCall.writeShort(paramName, XtkCaster.asShort(paramValue));
-                    else if (type == "int")
-                        soapCall.writeLong(paramName, XtkCaster.asLong(paramValue));
-                    else if (type == "long")
-                        soapCall.writeLong(paramName, XtkCaster.asLong(paramValue));
-                    else if (type == "int64")
-                        soapCall.writeInt64(paramName, XtkCaster.asInt64(paramValue));
-                    else if (type == "datetime")
-                        soapCall.writeTimestamp(paramName, XtkCaster.asTimestamp(paramValue));
-                    else if (type == "date")
-                        soapCall.writeDate(paramName, XtkCaster.asDate(paramValue));
-                    else if (type == "DOMDocument" || type == "DOMElement") {
-                        var docName = undefined;
-                        let representation = callContext.representation;
-                        if (paramValue.__xtkProxy) {
-                            // A xtk proxy object is passed as a parameter. The call context contains the schema so we
-                            // can use it to determine the XML document root (docName)
-                            const paramValueContext = paramValue["."];
-                            paramValue = paramValueContext.object;
-                            const xtkschema = paramValueContext.schemaId;
-                            const index = xtkschema.indexOf(":");
-                            docName = xtkschema.substring(index+1);
-                            representation = paramValueContext.representation; // xtk proxy may have it's own representation
-                        }
-                        else {
-                            // Hack for workflow API. The C++ code checks that the name of the XML element is <variables>. When
-                            // using xml representation at the SDK level, it's ok since the SDK caller will set that. But this does
-                            // not work when using "BadgerFish" representation where we do not know the root element name.
-                            if (entitySchemaId == "xtk:workflow" && methodName == "StartWithParameters" && paramName == "parameters")
-                                docName = "variables";
-                            if (entitySchemaId == "nms:rtEvent" && methodName == "PushEvent")
-                                docName = "rtEvent";
-                            // Try to guess the document name. This is usually available in the xtkschema attribute
-                            var xtkschema = EntityAccessor.getAttributeAsString(paramValue, "xtkschema");
-                            if (!xtkschema) xtkschema = paramValue["@xtkschema"];
-                            if (xtkschema) {
-                                const index = xtkschema.indexOf(":");
-                                docName = xtkschema.substring(index+1);
-                            }
-                            if (!docName) docName = paramName; // Use te parameter name as the XML root element
-                        }
-                        var xmlValue = that._fromRepresentation(docName, paramValue, representation);
-                        if (type == "DOMDocument")
-                            soapCall.writeDocument(paramName, xmlValue);
-                        else
-                            soapCall.writeElement(paramName, xmlValue);
-                    }
-                    else
-                        throw CampaignException.BAD_SOAP_PARAMETER(soapCall, paramName, paramValue, `Unsupported parameter type '${type}' for parameter '${paramName}' of method '${methodName}' of schema '${schemaId}`);
+                }
+                else if (inout=="out") {
+                    outputParams.push({
+                        name: paramName,
+                        type: type,
+                    });
+                }
+                else {
+                    throw CampaignException.BAD_PARAMETER("inout", inout, `Parameter '${paramName}' of schema '${entitySchemaId}' is not correctly defined as an input or output parameter`);
                 }
                 param = DomUtil.getNextSiblingElement(param, "param");
             }
         }
 
-        return that._makeSoapCall(soapCall).then(function() {
-            if (!isStatic) {
-                // Non static methods, such as xtk:query#SelectAll return a element named "entity" which is the object itself on which
-                // the method is called. This is the new version of the object (in XML form)
-                const entity = soapCall.getEntity();
-                if (entity) {
-                    callContext.object = that._toRepresentation(entity, callContext.representation);
-                }
-            }
+        // Make the SOAP call
+        await this._makeInterceptableSoapCall(entitySchemaId, schema, soapCall, inputParams, outputParams, callContext.representation);
+        
+        // Simplify the result when there's 0 or 1 return value
+        if (!isStatic) {
+            const newObject = outputParams.shift().value;
+            if (newObject) callContext.object = newObject;
+        }
+        if (outputParams.length == 0) return null;
+        if (outputParams.length == 1) return outputParams[0].value;
+        const result = [];
+        for (var i=0; i<outputParams.length; i++) {
+            result.push(outputParams[i].value);
+        }
+        return result;
 
-            if (params) {
-                var param = DomUtil.getFirstChildElement(params, "param");
-                while (param) {
-                    const inout = DomUtil.getAttributeAsString(param, "inout");
-                    if (inout=="out") {
-                        const type = DomUtil.getAttributeAsString(param, "type");
-                        const paramName = DomUtil.getAttributeAsString(param, "name");
-                        var returnValue;
-                        if (type == "string")
-                            returnValue = soapCall.getNextString();
-                        else if (type == "primarykey")
-                            returnValue = soapCall.getNextPrimaryKey();
-                        else if (type == "boolean")
-                            returnValue = soapCall.getNextBoolean();
-                        else if (type == "byte")
-                            returnValue = soapCall.getNextByte();
-                        else if (type == "short")
-                            returnValue = soapCall.getNextShort();
-                        else if (type == "long")
-                            returnValue = soapCall.getNextLong();
-                        else if (type == "int64")
-                            // int64 are represented as strings to make sure no precision is lost
-                            returnValue = soapCall.getNextInt64();
-                        else if (type == "datetime")
-                            returnValue = soapCall.getNextDateTime();
-                        else if (type == "date")
-                            returnValue = soapCall.getNextDate();
-                        else if (type == "DOMDocument") {
-                            returnValue = soapCall.getNextDocument();
-                            returnValue = that._toRepresentation(returnValue, callContext.representation);
-                            if (entitySchemaId === "xtk:queryDef" && methodName === "ExecuteQuery" && paramName === "output") {
-                                // https://github.com/adobe/acc-js-sdk/issues/3
-                                // Check if query operation is "getIfExists". The "object" variable at this point
-                                // is always an XML, regardless of the xml/json representation
-                                const objectRoot = object.documentElement;
-                                const emptyResult = Object.keys(returnValue).length == 0;
-                                var operation = DomUtil.getAttributeAsString(objectRoot, "operation");
-                                if (operation == "getIfExists" && emptyResult)
-                                    returnValue = null;
-                                if (operation == "select" && emptyResult) {
-                                    const querySchemaId = DomUtil.getAttributeAsString(objectRoot, "schema");
-                                    const index = querySchemaId.indexOf(':');
-                                    const querySchemaName = querySchemaId.substr(index + 1);
-                                    returnValue[querySchemaName] = [];
-                                }
-                            }
-                        }
-                        else if (type == "DOMElement") {
-                            returnValue = soapCall.getNextElement();
-                            returnValue = that._toRepresentation(returnValue, callContext.representation);
-                        }
-                        else {
-                            // type can reference a schema element. The naming convension is that the type name
-                            // is {schemaName}{elementNameCamelCase}. For instance, the type "sessionUserInfo"
-                            // matches the "userInfo" element of the "xtkSession" schema
-                            let element;
-                            if (type.substr(0, schemaName.length) == schemaName) {
-                                const shortTypeName = type.substr(schemaName.length, 1).toLowerCase() + type.substr(schemaName.length + 1);
-                                element = DomUtil.getFirstChildElement(schema, "element");
-                                while (element) {
-                                    if (element.getAttribute("name") == shortTypeName) {
-                                        // Type found in schema: Process as a DOM element
-                                        returnValue = soapCall.getNextElement();
-                                        returnValue = that._toRepresentation(returnValue, callContext.representation);
-                                        break;
-                                    }
-                                    element = DomUtil.getNextSiblingElement(element, "element");
-                                }
-
-                            }
-                            if (!element)
-                                throw CampaignException.UNEXPECTED_SOAP_RESPONSE(soapCall, `Unsupported return type '${type}' for parameter '${paramName}' of method '${methodName}' of schema '${schemaId}'`);
-                        }
-                        result.push(returnValue);
-                    }
-                    param = DomUtil.getNextSiblingElement(param, "param");
-                }
-            }
-            soapCall.checkNoMoreArgs();
-            if (result.length == 0) return null;
-            if (result.length == 1) return result[0];
-            return result;
-        });
     }
 
     async _makeHttpCall(request) {
@@ -1881,6 +1995,47 @@ class Client {
      */
     jobInterface(soapCallSpec) {
         return new XtkJobInterface(this, soapCallSpec);
+    }
+
+    // Calls the beforeSoapCall method on all observers which have this method. Ignore any exception
+    // that may occur in the callbacks. This function does not return anything but may modify the object
+    // or parameters before the SOAP call is performed
+    // @param {*} method is an object decribing the method
+    // @param {Array<*>} inputParameters is an array containing the method parameters
+    // @param {string} representation is the representation (SimpleJson, xml, etc.) used for this method and in which the object and parameters are set
+    async _beforeSoapCall(method, inputParameters, representation) {
+        if (!representation) representation = this._representation;
+        for (const observer of this._observers) {
+            if (observer.beforeSoapCall) {
+                try {
+                    await observer.beforeSoapCall(method, inputParameters, representation);
+                }
+                catch (any) {
+                    // Ignore errors occuring in observers
+                }
+            }
+        }
+    }
+
+    // Calls the afterSoapCall method on all observers which have this method. Ignore any exception
+    // that may occur in the callbacks. This function does not return anything but may modify the return
+    // value of a SOAP call bedore it is returned to the called
+    // @param {*} method is an object decribing the method
+    // @param {Array<*>} inputParameters is an array containing the method parameters
+    // @param {string} representation is the representation (SimpleJson, xml, etc.) used for this method and in which the object and parameters are set
+    // @param {Array<*>} outputParameters an array (possibly) empty of the values returned by the SOAP call
+    async _afterSoapCall(method, inputParameters, representation, outputParameters) {
+        if (!representation) representation = this._representation;
+        for (const observer of this._observers) {
+            if (observer.afterSoapCall) {
+                try {
+                    await observer.afterSoapCall(method, inputParameters, representation, outputParameters);
+                }
+                catch (any) {
+                    // Ignore errors occuring in observers
+                }
+            }
+        }
     }
 }
 

--- a/src/soap.js
+++ b/src/soap.js
@@ -92,6 +92,7 @@ class SoapMethodCall {
         // Current URN and method (for error reporting)
         this.urn = urn;
         this.methodName = methodName;
+        this.isStatic = false;
 
         // Soap calls marked as internal are calls performed by the framework internally
         // (such as GetEntityIfMoreRecent calls needed to lookup schemas)
@@ -341,7 +342,7 @@ class SoapMethodCall {
     getEntity() {
         if (!this.elemCurrent)
             return null;
-            if (this.elemCurrent.getAttribute("xsi:type") != "ns:Element")
+        if (this.elemCurrent.getAttribute("xsi:type") != "ns:Element")
             return null;
         if (this.elemCurrent.tagName != "entity")
             return null;

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -842,6 +842,18 @@ describe('ACC Client', function () {
             await client.NLWS.xtkSession.logoff();
         });
 
+        it("Should fail if method parameter inout attribute is not correct", async () => {
+            const client = await Mock.makeClient();
+            client._transport.mockReturnValueOnce(Mock.LOGON_RESPONSE);
+            await client.NLWS.xtkSession.logon();
+
+            client._transport.mockReturnValueOnce(Mock.GET_XTK_SESSION_SCHEMA_RESPONSE);
+            await expect(client.NLWS.xtkSession.badParam()).rejects.toMatchObject({ errorCode: "SDK-000006" });
+
+            client._transport.mockReturnValueOnce(Mock.LOGOFF_RESPONSE);
+            await client.NLWS.xtkSession.logoff();
+        });
+
         it("Should fail if calling non static function without object", async () => {
             const client = await Mock.makeClient();
             client._transport.mockReturnValueOnce(Mock.LOGON_RESPONSE);

--- a/test/mock.js
+++ b/test/mock.js
@@ -280,6 +280,11 @@ const GET_XTK_SESSION_SCHEMA_RESPONSE = Promise.resolve(`<?xml version='1.0'?>
                             <param name="result" type="long" inout="out"/>
                         </parameters>
                     </method>
+                    <method name="badParam" static="true">
+                        <parameters>
+                            <param name="bad" type="long" inout="zz"/>
+                        </parameters>
+                    </method>
                 </methods>
             </schema>
             </pdomDoc>

--- a/test/soap.test.js
+++ b/test/soap.test.js
@@ -734,7 +734,7 @@ describe('SOAP', function() {
             const client = await sdk.init(connectionParameters);
             client._transport = jest.fn();
             expect(client._connectionParameters._options.charset).toBe('UTF-8');
-            const soapCall = client._prepareSoapCall("xtk:persist", "GetEntityIfMoreRecent", true);
+            const soapCall = client._prepareSoapCall("xtk:persist", "GetEntityIfMoreRecent", true, true);
             expect (soapCall._charset).toBe('UTF-8');
             const [ request ] = soapCall._createHTTPRequest(URL);
             assert.equal(request.headers["Content-type"], "application/soap+xml;charset=UTF-8");
@@ -745,7 +745,7 @@ describe('SOAP', function() {
             const client = await sdk.init(connectionParameters);
             client._transport = jest.fn();
             expect(client._connectionParameters._options.charset).toBe('');
-            const soapCall = client._prepareSoapCall("xtk:persist", "GetEntityIfMoreRecent", true);
+            const soapCall = client._prepareSoapCall("xtk:persist", "GetEntityIfMoreRecent", true, true);
             expect (soapCall._charset).toBe('');
             const [ request ] = soapCall._createHTTPRequest(URL);
             assert.equal(request.headers["Content-type"], "application/soap+xml");
@@ -756,7 +756,7 @@ describe('SOAP', function() {
             const client = await sdk.init(connectionParameters);
             client._transport = jest.fn();
             expect(client._connectionParameters._options.charset).toBe('ISO-8859-1');
-            const soapCall = client._prepareSoapCall("xtk:persist", "GetEntityIfMoreRecent", true);
+            const soapCall = client._prepareSoapCall("xtk:persist", "GetEntityIfMoreRecent", true, true);
             expect (soapCall._charset).toBe('ISO-8859-1');
             const [ request ] = soapCall._createHTTPRequest(URL);
             assert.equal(request.headers["Content-type"], "application/soap+xml;charset=ISO-8859-1");


### PR DESCRIPTION
Add an interception mechanism to make it possible for an observer to modify SOAP call parameters before making the SOAP calls and modify return values before they are returned to the caller

## Description

In order to have a central place to properly intercept call, some refactoring has been done.

The central place to make SOAP calls is the _makeInterceptableSoapCall function.
This function is in charge of calling the beforeSoapCall and afterSoapCall observers, and to serialize and deserialize the XML into the expected representation. This code was inlined in _callMethod before, it's now more structured and split into multiple functions (_writeSoapCallParameters, _makeSoapCall, and _readSoapCallResult). The XtkMethodParam type is also introduced to represent a parameter of a SOAP call.
A side effect of this refactoring is that the SoapMethodCall object now has a isStatic member which indiates if the SOAP call is static or not.

## How Has This Been Tested?

New unit tests

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
