### PR TITLE
Clear storage cache if the sdk versions or the instances are different

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -647,6 +647,15 @@ class Client {
         if (instanceKey.startsWith("https://")) instanceKey = instanceKey.substr(8);
         const rootKey = `acc.js.sdk.${sdk.getSDKVersion().version}.${instanceKey}.cache`;
 
+        // Clear storage cache if the sdk versions or the instances are different
+        if (this._storage && typeof this._storage.removeItem === 'function') {
+          for (let key in this._storage) {
+            if (key.startsWith("acc.js.sdk.") && !key.startsWith(rootKey)) {
+              this._storage.removeItem(key);
+            }
+          }
+        }
+
         this._entityCache = new XtkEntityCache(this._storage, `${rootKey}.XtkEntityCache`, connectionParameters._options.entityCacheTTL);
         this._entityCacheRefresher = new CacheRefresher(this._entityCache, this, "xtk:schema", `${rootKey}.XtkEntityCache`);
         this._methodCache = new MethodCache(this._storage, `${rootKey}.MethodCache`, connectionParameters._options.methodCacheTTL);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When creating a new "Client" object, we check in the storage if there're some irrelevant acc.js.sdk cache items: containing other sdk versions or cache for other instances.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
in the case of using localStorage, whose size is limited to 5Mb, the irrelevant caches take space
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
A unit test has been added
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
