### PR TITLE
Add the X-Session-Token custom header to all SOAP and API calls

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -1881,6 +1881,7 @@ class Client {
             url: `${this._connectionParameters._endpoint}/nl/jsp/ping.jsp`,
             headers: {
                 'X-Security-Token': this._securityToken,
+                'X-Session-Token': this._sessionToken,
                 'Cookie': '__sessiontoken=' + this._sessionToken
             }
         };
@@ -1951,6 +1952,7 @@ class Client {
             url: `${this._connectionParameters._endpoint}/nl/jsp/mcPing.jsp`,
             headers: {
                 'X-Security-Token': this._securityToken,
+                'X-Session-Token': this._sessionToken,
                 'Cookie': '__sessiontoken=' + this._sessionToken
             }
         };

--- a/src/soap.js
+++ b/src/soap.js
@@ -538,7 +538,8 @@ class SoapMethodCall {
         const headers = {
             'Content-type': `application/soap+xml${this._charset ? ";charset=" + this._charset : ""}`,
             'SoapAction': `${this.urn}#${this.methodName}`,
-            'X-Security-Token': this._securityToken
+            'X-Security-Token': this._securityToken,
+            'X-Session-Token': this._sessionToken,
         };
 
         // Add HTTP headers specific to the SOAP call for better tracing/troubleshooting

--- a/src/util.js
+++ b/src/util.js
@@ -98,7 +98,8 @@ class Util {
     }
     if (typeof obj == "object") {
       for (const p in obj) {
-        if (p.toLowerCase() === "x-security-token")
+        const lowerP = p.toLowerCase();
+        if (lowerP === "x-security-token" || lowerP === "x-session-token")
           obj[p] = "***";
         else if (p === "Cookie") {
           var index = obj[p].toLowerCase().indexOf("__sessiontoken");
@@ -126,6 +127,7 @@ class Util {
       // Hide session tokens
       obj = this._removeBetween(obj, "<Cookie>__sessiontoken=", "</Cookie>");
       obj = this._removeBetween(obj, "<X-Security-Token>", "</X-Security-Token>");
+      obj = this._removeBetween(obj, "<X-Session-Token>", "</X-Session-Token>");
       obj = this._removeBetween(obj, '<sessiontoken xsi:type="xsd:string">', '</sessiontoken>');
       obj = this._removeBetween(obj, "<pstrSessionToken xsi:type='xsd:string'>", "</pstrSessionToken>");
       obj = this._removeBetween(obj, "<pstrSecurityToken xsi:type='xsd:string'>", "</pstrSecurityToken>");

--- a/test/soap.test.js
+++ b/test/soap.test.js
@@ -163,6 +163,7 @@ describe('SOAP', function() {
             const call = makeSoapMethodCall(undefined, "xtk:session", "Empty", "$session$", "$security$");
             const [ request ] = call._createHTTPRequest(URL);
             assert.equal(request.headers["X-Security-Token"], "$security$", "Security token matches");
+            assert.equal(request.headers["X-Session-Token"], "$session$", "Session token matches");
             assert.equal(request.headers["Cookie"], "__sessiontoken=$session$", "Session token matches");
             const env = DomUtil.parse(request.data).documentElement;
             const header = hasChildElement(env, "SOAP-ENV:Header");

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -86,6 +86,10 @@ describe('Util', function() {
             expect(Util.trim({hello:"Lead<X-Security-Token>Stuff</X-Security-Token>Trail"})).toStrictEqual({hello:"Lead<X-Security-Token>***</X-Security-Token>Trail"});
         })
 
+        it("Should remove session token headers", () => {
+            expect(Util.trim({hello:"Lead<X-Session-Token>Stuff</X-Session-Token>Trail"})).toStrictEqual({hello:"Lead<X-Session-Token>***</X-Session-Token>Trail"});
+        })
+
         it("Should remove session tokens", () => {
             expect(Util.trim({hello:'Lead<sessiontoken xsi:type="xsd:string">Stuff</sessiontoken>Trail'})).toStrictEqual({hello:'Lead<sessiontoken xsi:type="xsd:string">***</sessiontoken>Trail'});
         })


### PR DESCRIPTION
## Description

Make sure all SOAP API calls set the custom X-Session-Token header. This change is necessary to ensure consistent and secure authentication when the SDK is used in the context of a browser (where cookies can be blocked) with future server-side changes.

## Related Issue

Third-party Cookies are blocked by the browsers, which means SOAP call authentication relies on the session token passed in the SOAP payload. Unfortunately this requires an ACC security zone with sessionTokenOnly flag set which is not a secure configuration. Instead, we pass the session token as an HTTP header and future builds of the server will be able to handle it in secure security zones.

## Motivation and Context

Ensure secure access by default

## How Has This Been Tested?

Unit tests

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
