### PR TITLE
Make the caches asynchronous

### DIFF
--- a/docs/caches.html
+++ b/docs/caches.html
@@ -43,9 +43,34 @@ client.clearAllCaches();
 <p>It's possible to disable persistent caches using the <b>noStorage</b> connection option.</p>
 
 <p>It is also possible to setup one's own persistent cache, by passing a <b>storage</b> object as a connection option.
-  This object should implement 3 methods: <b>getItem</b>, <b>setItem</b>, and <b>removeItem</b> (synchronous)</p>
+   See the "Custom Storage" section below for more details.</p>
 
 <p>Additionally, since version 1.1.18, the <b>storage</b> object should also support the for...in operator to iterate through its keys</p>
+
+
+<h1>Cache root key</h1>
+
+<p>
+  By default, the SDK will prefix all cache entity by a root key, which is made of the SDK version and the instance URL. 
+  It is possible to change this using the `cacheRootKey` connection parameter.
+</p>
+<ul>
+  <li>* `default` or undefined: default prefix</li>
+  <li>* `none`: no prefix</li>
+</ul>
+
+<h1>Custom storage</h1>
+
+A custom storage is a JavaScript object with the following functions:
+* `getItem` is given a cache key and should return the corresponding value
+* `setItem` is given a cache key and value and should cache the corresponding key/value pair
+
+Optionally, the storage object can contain the following
+* `removeItem` is given a cache key and should remove the corresponding key/value pair from the cache
+* The storage object should also be iterable using the for..in construct
+
+The get/set/remove item function can be either synchronous or asynchronous, i.e. can optionally return a promise.
+
 
 <h1>Auto-refresh caches</h1>
 

--- a/docs/changeLog.html
+++ b/docs/changeLog.html
@@ -3,6 +3,22 @@ layout: page
 title: Change Log
 ---
 
+<section class="changelog"><h1>Version 1.1.20</h1>
+  <h2>2023/01/03</h2>
+  
+  <li>
+    Add support for asynchronous caches. The signature of cache objects (Cache, MethodCache,
+    OptionCache, XtkEntityCache, SafeStorage) have changed to asynchronous functions.
+    However, the delegate object used to configure custom caches now support either synchronous
+    or async results. See the <a href="https://opensource.adobe.com/acc-js-sdk/cacehs.html">Cache documentation for more details</a>
+  </li>
+  <li>
+    Ability to configure the prefix to use for the cached objects. Default to a string containing
+    the SDK version and instance domain.
+  </li>
+</section>
+
+
 <section class="changelog"><h1>Version 1.1.19</h1>
   <h2>2022/12/21</h2>
   

--- a/docs/changeLog.html
+++ b/docs/changeLog.html
@@ -10,7 +10,7 @@ title: Change Log
     Add support for asynchronous caches. The signature of cache objects (Cache, MethodCache,
     OptionCache, XtkEntityCache, SafeStorage) have changed to asynchronous functions.
     However, the delegate object used to configure custom caches now support either synchronous
-    or async results. See the <a href="https://opensource.adobe.com/acc-js-sdk/cacehs.html">Cache documentation for more details</a>
+    or async results. See the <a href="https://opensource.adobe.com/acc-js-sdk/caches.html">Cache documentation for more details</a>
   </li>
   <li>
     Ability to configure the prefix to use for the cached objects. Default to a string containing

--- a/src/client.js
+++ b/src/client.js
@@ -647,7 +647,9 @@ class Client {
         if (instanceKey.startsWith("http://")) instanceKey = instanceKey.substr(7);
         if (instanceKey.startsWith("https://")) instanceKey = instanceKey.substr(8);
 
-        // Determine the cache root key. By default, it's ade of the 
+        // Determine the cache root key. There are 3 possible values:
+        // * no value or "default" is the default behavior, i.e. all cache keys are prefixed with "acc.js.sdk.${sdk.getSDKVersion().version}.${instanceKey}.cache."
+        // * "none" (or actually anything else for now), where cache keys are not prefixed by anything
         const rootKeyType = connectionParameters._options.cacheRootKey;
         let rootKey = "";
         if (!rootKeyType || rootKeyType === "default")

--- a/src/methodCache.js
+++ b/src/methodCache.js
@@ -75,8 +75,8 @@ class MethodCache extends Cache {
      * @deprecated
      * @param {Element} schema DOM document node represening the schema 
      */
-    cache(schema) {
-        return this.put(schema);
+    async cache(schema) {
+        return await this.put(schema);
     }
     
     /**
@@ -84,7 +84,7 @@ class MethodCache extends Cache {
      * 
      * @param {Element} schema DOM document node represening the schema 
      */
-    put(schema) {
+    async put(schema) {
         var namespace = DomUtil.getAttributeAsString(schema, "namespace");
         var name = DomUtil.getAttributeAsString(schema, "name");
         var impls = DomUtil.getAttributeAsString(schema, "implements");
@@ -103,7 +103,7 @@ class MethodCache extends Cache {
                 while (child) {
                     const methodName = DomUtil.getAttributeAsString(child, "name");
                     const cached = { method: child, urn: schemaId };
-                    super.put(schemaId, methodName, cached);
+                    await super.put(schemaId, methodName, cached);
                     child = DomUtil.getNextSiblingElement(child, "method");
                 }
             }
@@ -124,7 +124,7 @@ class MethodCache extends Cache {
                     let cached = this._cache[key].value;
                     cached = { method: cached.method, urn: urn };
                     const methodName = DomUtil.getAttributeAsString(cached.method, "name");
-                    super.put(schemaId, methodName, cached);
+                    await super.put(schemaId, methodName, cached);
                 }
             }
         }
@@ -137,8 +137,8 @@ class MethodCache extends Cache {
      * @param {string} methodName the method name
      * @returns {Campaign.SoapMethodDefinition} the method definition, or undefined if the schema or the method is not found
      */
-    get(schemaId, methodName) {
-        const cached = super.get(schemaId, methodName);
+    async get(schemaId, methodName) {
+        const cached = await super.get(schemaId, methodName);
         return cached ? cached.method : undefined;
     }
 
@@ -149,8 +149,8 @@ class MethodCache extends Cache {
      * @param {string} methodName the method name
      * @returns {string} the URN (or Soap action header), or undefined if the schema or the method is not found
      */
-    getSoapUrn(schemaId, methodName) {
-        const cached = super.get(schemaId, methodName);
+    async getSoapUrn(schemaId, methodName) {
+        const cached = await super.get(schemaId, methodName);
         return cached ? cached.urn : undefined;
     }
 }

--- a/src/optionCache.js
+++ b/src/optionCache.js
@@ -65,7 +65,7 @@ class OptionCache extends Cache {
      * @param {Array} rawValueAndtype a 2 elements array, whose first element is the raw option value (text serialized) and the second element 
      * is the data type of the option. Such an array is returned by the xtk:session#GetOption method
      */
-     cache(schemaId, methodName) {
+    async cache(schemaId, methodName) {
         return this.put(schemaId, methodName);
     }
 
@@ -76,7 +76,7 @@ class OptionCache extends Cache {
      * @param {Array} rawValueAndtype a 2 elements array, whose first element is the raw option value (text serialized) and the second element 
      * is the data type of the option. Such an array is returned by the xtk:session#GetOption method
      */
-    put(name, rawValueAndtype) {
+    async put(name, rawValueAndtype) {
         var value = null;
         var type = 0;
         var rawValue;
@@ -85,7 +85,7 @@ class OptionCache extends Cache {
             type = rawValueAndtype[1];
             value = XtkCaster.as(rawValue, type);
         }
-        super.put(name, { value:value, type:type, rawValue:rawValue });
+        await super.put(name, { value:value, type:type, rawValue:rawValue });
         return value;
     }
 
@@ -95,8 +95,8 @@ class OptionCache extends Cache {
      * @param {string} name the option name
      * @returns {*} the option value
      */
-    get(name) {
-        const option = super.get(name);
+    async get(name) {
+        const option = await super.get(name);
         return option ? option.value : undefined;
     }
 
@@ -106,8 +106,8 @@ class OptionCache extends Cache {
      * @param {string} name the option name
      * @returns {Campaign.XtkOption} the option
      */
-    getOption(name) {
-        return super.get(name);
+    async getOption(name) {
+        return await super.get(name);
     }
 }
 

--- a/src/util.js
+++ b/src/util.js
@@ -153,6 +153,23 @@ class Util {
     }
     return schemaId;
   }
+
+  /**
+   * Test if an object is a promise
+   * @param {*} object the object to test
+   * @returns {boolean} if the object is a promise
+   */
+  static isPromise(object) {
+    if (object === null || object === undefined) return false;
+    if (object.then && (typeof object.then === "function")) return true;
+    return false;
+  }
+
+  static asPromise(object) {
+    if (this.isPromise(object)) 
+      return object;
+    return Promise.resolve(object);
+  }
 }
 
 /**

--- a/src/xtkEntityCache.js
+++ b/src/xtkEntityCache.js
@@ -64,8 +64,8 @@ class XtkEntityCache extends Cache {
      * @param {string} entityFullName is the entity name, such as "nms:recipient"
      * @returns {*} the cached entity, or undefined if not found
      */
-    get(entityType, entityFullName) {
-        return super.get(entityType, entityFullName);
+    async get(entityType, entityFullName) {
+        return await super.get(entityType, entityFullName);
     }
 
     /**
@@ -74,15 +74,15 @@ class XtkEntityCache extends Cache {
      * @param {string} entityFullName is the entity name, such as "nms:recipient"
      * @param {*} entity is the entity
      */
-    put(entityType, entityFullName, entity) {
-        super.put(entityType, entityFullName, entity);
+    async put(entityType, entityFullName, entity) {
+        await super.put(entityType, entityFullName, entity);
         // For schemas, cache interfaces
         if (entityType == "xtk:schema") {
             const namespace = entity.getAttribute("namespace");
             var interfaceElement = DomUtil.getFirstChildElement(entity, "interface");
             while (interfaceElement) {
                 const name = `${namespace}:${interfaceElement.getAttribute("name")}`;
-                super.put(entityType, name, interfaceElement);
+                await super.put(entityType, name, interfaceElement);
                 interfaceElement = DomUtil.getNextSiblingElement(interfaceElement, "interface");
             }
         }

--- a/test/cacheRefresher.test.js
+++ b/test/cacheRefresher.test.js
@@ -36,13 +36,13 @@ describe("CacheRefresher cache", function () {
 
         client._transport.mockReturnValueOnce(Mock.GETMODIFIEDENTITIES_CLEAR_RESPONSE);
         await cacheRefresher._callAndRefresh();
-        expect(cacheRefresher._refresherStateCache.get("buildNumber")).toBe("9469");
-        expect(cacheRefresher._refresherStateCache.get("time")).toBe("2022-07-28T14:38:55.766Z");
+        await expect(cacheRefresher._refresherStateCache.get("buildNumber")).resolves.toBe("9469");
+        await expect(cacheRefresher._refresherStateCache.get("time")).resolves.toBe("2022-07-28T14:38:55.766Z");
 
         client._transport.mockReturnValueOnce(Mock.GETMODIFIEDENTITIES_CLEAR_RESPONSE);
         await cacheRefresher._callAndRefresh();
-        expect(cacheRefresher._refresherStateCache.get("buildNumber")).toBe("9469");
-        expect(cacheRefresher._refresherStateCache.get("time")).toBe("2022-07-28T14:38:55.766Z");
+        await expect(cacheRefresher._refresherStateCache.get("buildNumber")).resolves.toBe("9469");
+        await expect(cacheRefresher._refresherStateCache.get("time")).resolves.toBe("2022-07-28T14:38:55.766Z");
 
         client._transport.mockReturnValueOnce(Mock.LOGOFF_RESPONSE);
         await client.NLWS.xtkSession.logoff();
@@ -61,8 +61,8 @@ describe("CacheRefresher cache", function () {
 
         const cacheRefresher = new CacheRefresher(cache, client, "xtk:schema", "rootkey");
 
-        expect(cacheRefresher._refresherStateCache.get("buildNumber")).toBeUndefined();
-        expect(cacheRefresher._refresherStateCache.get("time")).toBeUndefined();
+        await expect(cacheRefresher._refresherStateCache.get("buildNumber")).resolves.toBeUndefined();
+        await expect(cacheRefresher._refresherStateCache.get("time")).resolves.toBeUndefined();
         client._transport.mockReturnValue(Promise.resolve(Mock.GETMODIFIEDENTITIES_CLEAR_RESPONSE));
         jest.useFakeTimers();
         cacheRefresher.startAutoRefresh(5000);
@@ -72,8 +72,8 @@ describe("CacheRefresher cache", function () {
         // to allow soap call to finish
         await new Promise(process.nextTick);
 
-        expect(cacheRefresher._refresherStateCache.get("buildNumber")).toBe("9469");
-        expect(cacheRefresher._refresherStateCache.get("time")).toBe("2022-07-28T14:38:55.766Z");
+        await expect(cacheRefresher._refresherStateCache.get("buildNumber")).resolves.toBe("9469");
+        await expect(cacheRefresher._refresherStateCache.get("time")).resolves.toBe("2022-07-28T14:38:55.766Z");
 
         cacheRefresher.stopAutoRefresh();
         client._transport.mockReturnValueOnce(Mock.LOGOFF_RESPONSE);
@@ -91,13 +91,13 @@ describe("CacheRefresher cache", function () {
             const cache = new Cache();
 
             const cacheRefresher = new CacheRefresher(cache, client, "xtk:schema", "rootkey");
-            cacheRefresher._refresherStateCache.put("buildNumber", "9469");
-            cacheRefresher._refresherStateCache.put("time", "2022-07-28T14:38:55.766Z");
+            await cacheRefresher._refresherStateCache.put("buildNumber", "9469");
+            await cacheRefresher._refresherStateCache.put("time", "2022-07-28T14:38:55.766Z");
 
             client._transport.mockReturnValueOnce(Mock.GETMODIFIEDENTITIES_CLEAR_RESPONSE);
             await cacheRefresher._callAndRefresh();
-            expect(cacheRefresher._refresherStateCache.get("buildNumber")).toBe("9469");
-            expect(cacheRefresher._refresherStateCache.get("time")).toBe("2022-07-28T14:38:55.766Z");
+            await expect(cacheRefresher._refresherStateCache.get("buildNumber")).resolves.toBe("9469");
+            await expect(cacheRefresher._refresherStateCache.get("time")).resolves.toBe("2022-07-28T14:38:55.766Z");
 
             client._transport.mockReturnValueOnce(Mock.LOGOFF_RESPONSE);
 
@@ -122,20 +122,20 @@ describe("CacheRefresher cache", function () {
         const cache = new Cache();
         const cacheRefresher = new CacheRefresher(cache, client, "xtk:schema", "rootkey");
 
-        cache.put("xtk:schema|nms:recipient", "<content recipient>");
-        cache.put("xtk:schema|nms:replicationStrategy", "<content xtk:schema|nms:replicationStrategy>");
-        cache.put("xtk:schema|nms:operation", "<content xtk:schema|nms:operation>");
-        expect(cache.get("xtk:schema|nms:recipient")).toBe("<content recipient>");
-        expect(cache.get("xtk:schema|nms:replicationStrategy")).toBe("<content xtk:schema|nms:replicationStrategy>");
-        expect(cache.get("xtk:schema|nms:operation")).toBe("<content xtk:schema|nms:operation>");
+        await cache.put("xtk:schema|nms:recipient", "<content recipient>");
+        await cache.put("xtk:schema|nms:replicationStrategy", "<content xtk:schema|nms:replicationStrategy>");
+        await cache.put("xtk:schema|nms:operation", "<content xtk:schema|nms:operation>");
+        await expect(cache.get("xtk:schema|nms:recipient")).resolves.toBe("<content recipient>");
+        await expect(cache.get("xtk:schema|nms:replicationStrategy")).resolves.toBe("<content xtk:schema|nms:replicationStrategy>");
+        await expect(cache.get("xtk:schema|nms:operation")).resolves.toBe("<content xtk:schema|nms:operation>");
 
         client._transport.mockReturnValueOnce(Mock.GETMODIFIEDENTITIES_SCHEMA_RESPONSE);
         await cacheRefresher._callAndRefresh();
-        expect(cacheRefresher._refresherStateCache.get("buildNumber")).toBe("9469");
-        expect(cacheRefresher._refresherStateCache.get("time")).toBe("2022-07-28T15:32:00.785Z");
-        expect(cache.get("xtk:schema|nms:recipient")).toBeUndefined();
-        expect(cache.get("xtk:schema|nms:replicationStrategy")).toBeUndefined();
-        expect(cache.get("xtk:schema|nms:operation")).toBe("<content xtk:schema|nms:operation>");
+        await expect(cacheRefresher._refresherStateCache.get("buildNumber")).resolves.toBe("9469");
+        await expect(cacheRefresher._refresherStateCache.get("time")).resolves.toBe("2022-07-28T15:32:00.785Z");
+        await expect(cache.get("xtk:schema|nms:recipient")).resolves.toBeUndefined();
+        await expect(cache.get("xtk:schema|nms:replicationStrategy")).resolves.toBeUndefined();
+        await expect(cache.get("xtk:schema|nms:operation")).resolves.toBe("<content xtk:schema|nms:operation>");
 
         client._transport.mockReturnValueOnce(Mock.LOGOFF_RESPONSE);
         await client.NLWS.xtkSession.logoff();
@@ -153,8 +153,8 @@ describe("CacheRefresher cache", function () {
 
         client._transport.mockReturnValueOnce(Mock.GETMODIFIEDENTITIES_UNDEFINED_RESPONSE);
         await cacheRefresher._callAndRefresh();
-        expect(cacheRefresher._refresherStateCache.get("buildNumber")).toBeUndefined();
-        expect(cacheRefresher._refresherStateCache.get("time")).toBeUndefined();
+        await expect(cacheRefresher._refresherStateCache.get("buildNumber")).resolves.toBeUndefined();
+        await expect(cacheRefresher._refresherStateCache.get("time")).resolves.toBeUndefined();
         expect(cacheRefresher._intervalId).toBeNull();
 
         client._transport.mockReturnValueOnce(Mock.LOGOFF_RESPONSE);
@@ -178,8 +178,8 @@ describe("CacheRefresher cache", function () {
         } catch (e) {
             expect(e).not.toBeNull();
         }
-        expect(cacheRefresher._refresherStateCache.get("buildNumber")).toBeUndefined();
-        expect(cacheRefresher._refresherStateCache.get("time")).toBeUndefined();
+        await expect(cacheRefresher._refresherStateCache.get("buildNumber")).resolves.toBeUndefined();
+        await expect(cacheRefresher._refresherStateCache.get("time")).resolves.toBeUndefined();
         expect(cacheRefresher._intervalId).not.toBeNull();
 
         cacheRefresher.stopAutoRefresh();
@@ -211,8 +211,8 @@ describe("CacheRefresher cache", function () {
         // to allow soap call to finish
         await new Promise(process.nextTick);
 
-        expect(cacheRefresher._refresherStateCache.get("buildNumber")).toBe("9469");
-        expect(cacheRefresher._refresherStateCache.get("time")).toBe("2022-07-28T14:38:55.766Z");
+        await expect(cacheRefresher._refresherStateCache.get("buildNumber")).resolves.toBe("9469");
+        await expect(cacheRefresher._refresherStateCache.get("time")).resolves.toBe("2022-07-28T14:38:55.766Z");
 
         cacheRefresher.stopAutoRefresh();
         client._transport.mockReturnValueOnce(Mock.LOGOFF_RESPONSE);

--- a/test/caches.test.js
+++ b/test/caches.test.js
@@ -27,75 +27,75 @@ const { DomUtil } = require('../src/domUtil.js');
 describe('Caches', function() {
 
     describe("Generic cache", () => {
-        it("Should cache with default TTL and default key function", () => {
+        it("Should cache with default TTL and default key function", async () => {
             const cache = new Cache();
-            cache.put("Hello", "World");
+            await cache.put("Hello", "World");
             expect(cache._stats).toMatchObject({ reads: 0, writes: 1 });
-            expect(cache.get("Hello")).toBe("World");
+            await expect(cache.get("Hello")).resolves.toBe("World");
             expect(cache._stats).toMatchObject({ reads: 1, writes: 1, memoryHits: 1, storageHits: 0 });
         })
 
-        it("Should expires after TTL", () => {
+        it("Should expires after TTL", async () => {
             const cache = new Cache(undefined, undefined, -1);    // negative TTL => will immediately expire
-            cache.put("Hello", "World");
-            expect(cache.get("Hello")).toBeUndefined();
+            await cache.put("Hello", "World");
+            await expect(cache.get("Hello")).resolves.toBeUndefined();
             expect(cache._stats).toMatchObject({ reads: 1, writes: 1, memoryHits: 0, storageHits: 0 });
         })
 
-        it("Should support custom key function", () => {
+        it("Should support custom key function", async () => {
             const cache = new Cache(undefined, undefined, 300000, ((a, b) => a + "||" + b));
-            cache.put("key-part-1", "key-part-2", "value");
-            expect(cache.get("key-part-1")).toBeUndefined();
-            expect(cache.get("key-part-2")).toBeUndefined();
-            expect(cache.get("key-part-1", "key-part-2")).toBe("value");
+            await cache.put("key-part-1", "key-part-2", "value");
+            await expect(cache.get("key-part-1")).resolves.toBeUndefined();
+            await expect(cache.get("key-part-2")).resolves.toBeUndefined();
+            await expect(cache.get("key-part-1", "key-part-2")).resolves.toBe("value");
         })
 
-        it("Should clear cache", () => {
+        it("Should clear cache", async () => {
             const cache = new Cache();
-            cache.put("Hello", "World");
-            expect(cache.get("Hello")).toBe("World");
-            cache.clear();
-            expect(cache.get("Hello")).toBeUndefined();
+            await cache.put("Hello", "World");
+            await expect(cache.get("Hello")).resolves.toBe("World");
+            await cache.clear();
+            await expect(cache.get("Hello")).resolves.toBeUndefined();
             expect(cache._stats).toMatchObject({ reads: 2, writes: 1, memoryHits: 1, storageHits: 0, clears: 1 });
         })
 
-        it("Should remove key in cache", () => {
+        it("Should remove key in cache", async () => {
             const cache = new Cache();
-            cache.put("Hello", "World");
-            cache.put("Hi", "A");
-            expect(cache.get("Hello")).toBe("World");
-            expect(cache.get("Hi")).toBe("A");
+            await cache.put("Hello", "World");
+            await cache.put("Hi", "A");
+            await expect(cache.get("Hello")).resolves.toBe("World");
+            await expect(cache.get("Hi")).resolves.toBe("A");
             expect(cache._stats).toMatchObject({ reads: 2, writes: 2, memoryHits: 2 });
-            cache.remove("Hello");
-            expect(cache.get("Hello")).toBeUndefined();
-            expect(cache.get("Hi")).toBe("A");
+            await cache.remove("Hello");
+            await expect(cache.get("Hello")).resolves.toBeUndefined();
+            await expect(cache.get("Hi")).resolves.toBe("A");
             expect(cache._stats).toMatchObject({ reads: 4, writes: 2, memoryHits: 3, removals: 1 });
             // should support removing a key which has already been removed
-            cache.remove("Hello");
-            expect(cache.get("Hello")).toBeUndefined();
-            expect(cache.get("Hi")).toBe("A");
+            await cache.remove("Hello");
+            await expect(cache.get("Hello")).resolves.toBeUndefined();
+            await expect(cache.get("Hi")).resolves.toBe("A");
         })
     });
 
     describe("Entity cache", function() {
-        it("Should cache value", function() {
+        it("Should cache value", async () => {
             const cache = new XtkEntityCache();
-            assert.equal(cache.get("xtk:srcSchema", "nms:recipient"), undefined);
-            cache.put("xtk:srcSchema", "nms:recipient", "$$entity$$");
-            assert.equal(cache.get("xtk:srcSchema", "nms:recipient"), "$$entity$$");
+            await expect(cache.get("xtk:srcSchema", "nms:recipient")).resolves.toBeUndefined();
+            await cache.put("xtk:srcSchema", "nms:recipient", "$$entity$$");
+            await expect(cache.get("xtk:srcSchema", "nms:recipient")).resolves.toBe("$$entity$$");
         });
 
-        it("Should cache interfaces", function() {
+        it("Should cache interfaces", async () => {
             const cache = new XtkEntityCache();
             const schema = DomUtil.parse(`<schema namespace="xtk" name="session" implements="xtk:persist">
                     <interface name="persist"/>
                     <element name="session"/>
                 </schema>`);
-            cache.put("xtk:schema", "xtk:session", schema.documentElement);
-            const session = cache.get("xtk:schema", "xtk:session");
+            await cache.put("xtk:schema", "xtk:session", schema.documentElement);
+            const session = await cache.get("xtk:schema", "xtk:session");
             expect(session).not.toBeNull();
             expect(session.getAttribute("name")).toBe("session");
-            const persist = cache.get("xtk:schema", "xtk:persist");
+            const persist = await cache.get("xtk:schema", "xtk:persist");
             expect(persist).not.toBeNull();
             expect(persist.getAttribute("name")).toBe("persist");
         });
@@ -104,124 +104,124 @@ describe('Caches', function() {
 
     describe("Option cache", function() {
 
-        it("Should cache value", function() {
+        it("Should cache value", async () => {
             const cache = new OptionCache();
-            expect(cache.get("hello")).toBeUndefined();
-            cache.put("hello", ["world", 6]);
-            expect(cache.get("hello")).toBe("world");
-            expect(cache.getOption("hello")).toEqual({"rawValue": "world", "type": 6, "value": "world"});
+            await expect(cache.get("hello")).resolves.toBeUndefined();
+            await cache.put("hello", ["world", 6]);
+            await expect(cache.get("hello")).resolves.toBe("world");
+            await expect(cache.getOption("hello")).resolves.toEqual({"rawValue": "world", "type": 6, "value": "world"});
         });
 
-        it("Should cache multiple value", function() {
+        it("Should cache multiple value", async () => {
             const cache = new OptionCache();
-            cache.put("hello", ["world", 6]);
-            cache.put("foo", ["bar", 6]);
-            expect(cache.get("hello")).toBe("world");
-            expect(cache.getOption("hello")).toEqual({"rawValue": "world", "type": 6, "value": "world"});
-            expect(cache.get("foo")).toBe("bar");
-            expect(cache.getOption("foo")).toEqual({"rawValue": "bar", "type": 6, "value": "bar"});
+            await cache.put("hello", ["world", 6]);
+            await cache.put("foo", ["bar", 6]);
+            await expect(cache.get("hello")).resolves.toBe("world");
+            await expect(cache.getOption("hello")).resolves.toEqual({"rawValue": "world", "type": 6, "value": "world"});
+            await expect(cache.get("foo")).resolves.toBe("bar");
+            await expect(cache.getOption("foo")).resolves.toEqual({"rawValue": "bar", "type": 6, "value": "bar"});
         });
 
-        it("Should overwrite cached value", function() {
+        it("Should overwrite cached value", async () => {
             const cache = new OptionCache();
-            cache.put("hello", ["world", 6]);
-            expect(cache.get("hello")).toBe( "world");
-            expect(cache.getOption("hello")).toEqual({"rawValue": "world", "type": 6, "value": "world"});
-            cache.put("hello", ["cruel world", 6]);
-            expect(cache.get("hello")).toBe("cruel world");
-            expect(cache.getOption("hello")).toEqual({"rawValue": "cruel world", "type": 6, "value": "cruel world"});
+            await cache.put("hello", ["world", 6]);
+            await expect(cache.get("hello")).resolves.toBe( "world");
+            await expect(cache.getOption("hello")).resolves.toEqual({"rawValue": "world", "type": 6, "value": "world"});
+            await cache.put("hello", ["cruel world", 6]);
+            await expect(cache.get("hello")).resolves.toBe("cruel world");
+            await expect(cache.getOption("hello")).resolves.toEqual({"rawValue": "cruel world", "type": 6, "value": "cruel world"});
         });
 
-        it("Should clear cache", function() {
+        it("Should clear cache", async () => {
             const cache = new OptionCache();
-            cache.put("hello", ["world", 6]);
-            expect(cache.get("hello")).toBe("world");
-            expect(cache.getOption("hello")).toEqual({"rawValue": "world", "type": 6, "value": "world"});
-            cache.clear();
-            expect(cache.get("hello")).toBeUndefined();
-            expect(cache.getOption("hello")).toBeUndefined();
+            await cache.put("hello", ["world", 6]);
+            await expect(cache.get("hello")).resolves.toBe("world");
+            await expect(cache.getOption("hello")).resolves.toEqual({"rawValue": "world", "type": 6, "value": "world"});
+            await cache.clear();
+            await expect(cache.get("hello")).resolves.toBeUndefined();
+            await expect(cache.getOption("hello")).resolves.toBeUndefined();
         });
 
-        it("Should not find", function() {
+        it("Should not find", async () => {
             const cache = new OptionCache();
-            expect(cache.get("hello")).toBeUndefined();
-            expect(cache.getOption("hello")).toBeUndefined();
+            await expect(cache.get("hello")).resolves.toBeUndefined();
+            await expect(cache.getOption("hello")).resolves.toBeUndefined();
         });
 
-        it("Deprecated cache methods should now replaced with put", () => {
+        it("Deprecated cache methods should now replaced with put", async () => {
             const cache = new OptionCache();
-            cache.cache("hello", ["world", 6]);
-            expect(cache.get("hello")).toBe("world");
-            expect(cache.getOption("hello")).toEqual({"rawValue": "world", "type": 6, "value": "world"});
+            await cache.cache("hello", ["world", 6]);
+            await expect(cache.get("hello")).resolves.toBe("world");
+            await expect(cache.getOption("hello")).resolves.toEqual({"rawValue": "world", "type": 6, "value": "world"});
         });
     });
 
     describe("Method cache", function() {
-        it("Should cache methods", function() {
+        it("Should cache methods", async () => {
             const cache = new MethodCache();
             var schema = DomUtil.parse("<schema namespace='nms' name='recipient'><methods><method name='Delete'/><method name='Create'/></methods></schema>");
-            cache.put(schema.documentElement);
+            await cache.put(schema.documentElement);
 
-            var found = cache.get("nms:recipient", "Delete");
+            var found = await cache.get("nms:recipient", "Delete");
             assert.ok(found !== null && found !== undefined);
             assert.equal(found.nodeName, "method");
             assert.equal(found.getAttribute("name"), "Delete");
 
-            found = cache.get("nms:recipient", "Create");
+            found = await cache.get("nms:recipient", "Create");
             assert.ok(found !== null && found !== undefined);
             assert.equal(found.nodeName, "method");
             assert.equal(found.getAttribute("name"), "Create");
         });
 
-        it("Should cache interface methods", function() {
+        it("Should cache interface methods", async () => {
             const cache = new MethodCache();
             var schema = DomUtil.parse("<schema namespace='nms' name='recipient' implements='nms:i'><interface name='i'><method name='Update'/></interface><element name='recipient'/><methods><method name='Delete'/><method name='Create'/></methods></schema>");
-            cache.put(schema.documentElement);
+            await cache.put(schema.documentElement);
             // interface method should be on schema
-            var found = cache.get("nms:recipient", "Update");
+            var found = await cache.get("nms:recipient", "Update");
             assert.ok(found !== null && found !== undefined);
             // and on interface as well
-            found = cache.get("nms:i", "Update");
+            found = await cache.get("nms:i", "Update");
             assert.ok(found !== null && found !== undefined);
         });
 
-        it("Should clear the cache", function() {
+        it("Should clear the cache", async () => {
             const cache = new MethodCache();
             var schema = DomUtil.parse("<schema namespace='nms' name='recipient'><methods><method name='Delete'/><method name='Create'/></methods></schema>");
-            cache.put(schema.documentElement);
+            await cache.put(schema.documentElement);
 
-            var found = cache.get("nms:recipient", "Delete");
+            var found = await cache.get("nms:recipient", "Delete");
             assert.ok(found !== null && found !== undefined);
 
-            cache.clear();
-            found = cache.get("nms:recipient", "Delete");
+            await cache.clear();
+            found = await cache.get("nms:recipient", "Delete");
             assert.ok(found === undefined);
         });
 
-        it("Should ignore non-method nodes", function() {
+        it("Should ignore non-method nodes", async () => {
             const cache = new MethodCache();
             var schema = DomUtil.parse("<schema namespace='nms' name='recipient'><methods><method name='Delete'/><dummy name='Update'/><method name='Create'/></methods></schema>");
-            cache.put(schema.documentElement);
+            await cache.put(schema.documentElement);
 
-            var found = cache.get("nms:recipient", "Delete");
+            var found = await cache.get("nms:recipient", "Delete");
             assert.ok(found !== null && found !== undefined);
-            found = cache.get("nms:recipient", "Update");
+            found = await cache.get("nms:recipient", "Update");
             assert.ok(found === undefined);
-            found = cache.get("nms:recipient", "Create");
+            found = await cache.get("nms:recipient", "Create");
             assert.ok(found !== null && found !== undefined);
         });
 
-        it("Deprecated cache methods should now replaced with put", () => {
+        it("Deprecated cache methods should now replaced with put", async () => {
             const cache = new MethodCache();
             var schema = DomUtil.parse("<schema namespace='nms' name='recipient'><methods><method name='Delete'/><method name='Create'/></methods></schema>");
-            cache.cache(schema.documentElement);
+            await cache.cache(schema.documentElement);
 
-            var found = cache.get("nms:recipient", "Delete");
+            var found = await cache.get("nms:recipient", "Delete");
             assert.ok(found !== null && found !== undefined);
             assert.equal(found.nodeName, "method");
             assert.equal(found.getAttribute("name"), "Delete");
 
-            found = cache.get("nms:recipient", "Create");
+            found = await cache.get("nms:recipient", "Create");
             assert.ok(found !== null && found !== undefined);
             assert.equal(found.nodeName, "method");
             assert.equal(found.getAttribute("name"), "Create");
@@ -240,71 +240,71 @@ describe('Caches', function() {
     });
 
     describe("Method cache for interfaces", function() {
-        it("Should cache methods", function() {
+        it("Should cache methods", async () => {
             const cache = new MethodCache();
             // Test for fix in verion 0.1.23. The xtk:session schema has a direct method "Logon" but also implements the
             // xtk:persist interface.
             var schema = DomUtil.parse("<schema namespace='xtk' name='session' implements='xtk:persist'><interface name='persist'><method name='Write' static='true'/></interface><methods><method name='Logon'/></methods></schema>");
-            cache.put(schema.documentElement);
+            await cache.put(schema.documentElement);
 
             // Logon method should be found in xtk:session and have the xtk:session URN (for SOAP action)
-            var found = cache.get("xtk:session", "Logon");
-            var urn = cache.getSoapUrn("xtk:session", "Logon");
+            var found = await cache.get("xtk:session", "Logon");
+            var urn = await cache.getSoapUrn("xtk:session", "Logon");
             assert.ok(found !== null && found !== undefined);
             assert.strictEqual(found.nodeName, "method");
             assert.strictEqual(found.getAttribute("name"), "Logon");
             assert.strictEqual(urn, "xtk:session");
 
             // Logon method should not exist on the xtk:persist interface
-            found = cache.get("xtk:persist", "Logon");
-            urn = cache.getSoapUrn("xtk:persist", "Logon");
+            found = await cache.get("xtk:persist", "Logon");
+            urn = await cache.getSoapUrn("xtk:persist", "Logon");
             assert.ok(found === undefined);
             assert.ok(urn === undefined);
 
             // The Write method should also be on xtk:session but use xtk:persist as a URN
-            found = cache.get("xtk:session", "Write");
-            urn = cache.getSoapUrn("xtk:session", "Write");
+            found = await cache.get("xtk:session", "Write");
+            urn = await cache.getSoapUrn("xtk:session", "Write");
             assert.ok(found !== null && found !== undefined);
             assert.strictEqual(found.nodeName, "method");
             assert.strictEqual(found.getAttribute("name"), "Write");
             assert.strictEqual(urn, "xtk:persist|xtk:session");
 
             // For compatibility reasons (SDK versions earlier than 0.1.23), keep the Write method on the interface too
-            found = cache.get("xtk:persist", "Write");
-            urn = cache.getSoapUrn("xtk:persist", "Write");
+            found = await cache.get("xtk:persist", "Write");
+            urn = await cache.getSoapUrn("xtk:persist", "Write");
             assert.ok(found !== null && found !== undefined);
             assert.strictEqual(found.nodeName, "method");
             assert.strictEqual(found.getAttribute("name"), "Write");
             assert.strictEqual(urn, "xtk:persist");
         });
 
-        it("Edge cases for getSoapUrn", () => {
+        it("Edge cases for getSoapUrn", async () => {
             const cache = new MethodCache();
             var schema = DomUtil.parse("<schema namespace='xtk' name='session' implements='xtk:persist'><interface name='persist'><method name='Write' static='true'/></interface><methods><method name='Logon'/></methods></schema>");
-            cache.put(schema.documentElement);
+            await cache.put(schema.documentElement);
 
             // Schema and method exist
-            var urn = cache.getSoapUrn("xtk:session", "Logon");
+            var urn = await cache.getSoapUrn("xtk:session", "Logon");
             expect(urn).toBe("xtk:session");
 
             // Schema exists but method doesn't
-            urn = cache.getSoapUrn("xtk:session", "Dummy");
+            urn = await cache.getSoapUrn("xtk:session", "Dummy");
             expect(urn).toBeUndefined();
 
             // Neither schema nor method exist
-            urn = cache.getSoapUrn("xtk:dummy", "Dummy");
+            urn = await cache.getSoapUrn("xtk:dummy", "Dummy");
             expect(urn).toBeUndefined();
         });
 
-        it("Schema has interfaces that do not match what schema implements", () => {
+        it("Schema has interfaces that do not match what schema implements", async () => {
             const cache = new MethodCache();
             // Schema has xtk:persist interface but does not implement it
             var schema = DomUtil.parse("<schema namespace='xtk' name='session'><interface name='persist'><method name='Write' static='true'/></interface><methods><method name='Logon'/></methods></schema>");
-            cache.put(schema.documentElement);
+            await cache.put(schema.documentElement);
 
             // Logon method should be found in xtk:session and have the xtk:session URN (for SOAP action)
-            var found = cache.get("xtk:session", "Logon");
-            var urn = cache.getSoapUrn("xtk:session", "Logon");
+            var found = await cache.get("xtk:session", "Logon");
+            var urn = await cache.getSoapUrn("xtk:session", "Logon");
             assert.ok(found !== null && found !== undefined);
             assert.strictEqual(found.nodeName, "method");
             assert.strictEqual(found.getAttribute("name"), "Logon");
@@ -316,18 +316,18 @@ describe('Caches', function() {
 
         describe("JSON safe storage", () => {
 
-            it("Should find mock json from the cache", () => {
+            it("Should find mock json from the cache", async () => {
                 const map = {};
                 const delegate = {
                     getItem: jest.fn((key) => map[key]),
                     setItem: jest.fn((key, value) => map[key] = value)
                 }
                 const storage = new SafeStorage(delegate, "");
-                expect(storage.getItem("not_found")).toBeUndefined();
+                await expect(storage.getItem("not_found")).resolves.toBeUndefined();
                 map["k1"] = `{ "hello": "world" }`;
-                expect(storage.getItem("k1")).toMatchObject({ hello: "world" });
+                await expect(storage.getItem("k1")).resolves.toMatchObject({ hello: "world" });
                 map["k2"] = `{ "value": { "hello": "world" } }`;
-                expect(storage.getItem("k2")).toMatchObject({ value: { hello: "world" } });
+                await expect(storage.getItem("k2")).resolves.toMatchObject({ value: { hello: "world" } });
             });
         });
 
@@ -346,32 +346,32 @@ describe('Caches', function() {
                 }
             };
 
-            it("Should find mock xml from the cache", () => {
+            it("Should find mock xml from the cache", async () => {
                 const map = {};
                 const delegate = {
                     getItem: jest.fn((key) => map[key]),
                     setItem: jest.fn((key, value) => map[key] = value)
                 }
                 const storage = new SafeStorage(delegate, "", xmlSerDeser);
-                expect(storage.getItem("not_found")).toBeUndefined();
+                await expect(storage.getItem("not_found")).resolves.toBeUndefined();
                 map["k1"] = `{ "hello": "world" }`;
-                expect(storage.getItem("k1")).toBeUndefined();      // k1 cached object does not have "value" attribute containing serialized XML
+                await expect(storage.getItem("k1")).resolves.toBeUndefined();      // k1 cached object does not have "value" attribute containing serialized XML
                 map["k1"] = `{ "hello": "world", "value": "" }`;
-                expect(storage.getItem("k1")).toBeUndefined();      // k1 cached object does not have "value" attribute containing serialized XML
+                await expect(storage.getItem("k1")).resolves.toBeUndefined();      // k1 cached object does not have "value" attribute containing serialized XML
                 map["k1"] = `{ "value": { "hello": "world" } }`;
-                expect(storage.getItem("k2")).toBeUndefined();      // k1 cached object does not have "value" attribute but it's not valid XML
+                await expect(storage.getItem("k2")).resolves.toBeUndefined();      // k1 cached object does not have "value" attribute but it's not valid XML
                 map["k1"] = `{ "value": "" } }`;
-                expect(storage.getItem("k1")).toBeUndefined();      // k1 cached object does not have "value" attribute but it's not valid XML
+                await expect(storage.getItem("k1")).resolves.toBeUndefined();      // k1 cached object does not have "value" attribute but it's not valid XML
                 map["k1"] = `{ "value": "bad" } }`;
-                expect(storage.getItem("k1")).toBeUndefined();      // k1 cached object does not have "value" attribute but it's not valid XML
+                await expect(storage.getItem("k1")).resolves.toBeUndefined();      // k1 cached object does not have "value" attribute but it's not valid XML
                 map["k2"] = `{ "value": "<hello/>" }`;
-                expect(storage.getItem("k2").value.tagName).toBe("hello");
+                await expect(storage.getItem("k2")).resolves.toMatchObject({ value: {tagName: "hello"}});
             });
         });
     });
 
     describe("Cache seralizers", () => {
-        it("Should serialize json", () => {
+        it("Should serialize json", async () => {
             const cache = new OptionCache();
             const serDeser = cache._storage._serDeser;
             expect(serDeser({ hello: "World" }, true)).toBe('{"hello":"World"}');
@@ -446,5 +446,33 @@ describe('Caches', function() {
             expect(cached.value.x).toBe(3);
             expect(cached.value.method.documentElement.tagName).toBe("hello");
         })
-    })
+    });
+    
+    describe("Sync and Async delegates", () => {
+        it("Should support synchronous delegates", async () => {
+            const map = {};
+            const delegate = {
+                getItem: jest.fn((key) => map[key]),
+                setItem: jest.fn((key, value) => map[key] = value)
+            }
+            const storage = new SafeStorage(delegate, "");
+            await storage.setItem("Hello", { cruel: "World" });
+            await expect(storage.getItem("Hello")).resolves.toMatchObject({ cruel: "World" });
+        });
+        it("Should support asynchronous delegates", async () => {
+            const map = {};
+            const delegate = {
+                getItem: jest.fn(async (key) => Promise.resolve(map[key]) ),
+                setItem: jest.fn(async (key, value) => {
+                    return new Promise((resolve, reject) => {
+                        map[key] = value;
+                        resolve(value);
+                    });
+                })
+            }
+            const storage = new SafeStorage(delegate, "");
+            await storage.setItem("Hello", { cruel: "World" });
+            await expect(storage.getItem("Hello")).resolves.toMatchObject({ cruel: "World" });
+        });
+    });
 });

--- a/test/observability.test.js
+++ b/test/observability.test.js
@@ -336,7 +336,7 @@ describe('ACC Client Observability', function () {
     </SOAP-ENV:Envelope>`);
             };
             client._transport.mockImplementationOnce(getOption);
-            client.clearOptionCache();
+            await client.clearOptionCache();
             var value = await client.getOption("Dummy");
             expect(value).toBe("DummyZZ");
 
@@ -345,7 +345,7 @@ describe('ACC Client Observability', function () {
                 if (inputParameters[0].value === "Dummy") inputParameters[0].value = "XtkDatabaseId";
             });
             client._transport.mockImplementationOnce(getOption);
-            client.clearOptionCache();
+            await client.clearOptionCache();
             var value = await client.getOption("Dummy");
             expect(value).toBe("XtkDatabaseIdZZ");
             


### PR DESCRIPTION
## Description

Make the cache interface asynchronous. See https://opensource.adobe.com/acc-js-sdk/caches.html for more details.
The storage interface is backwards compatible: getItem, setItem, and removeItem can be synchronous functions. They can also be asynchronous, i.e. return promises.

There is however a slight change in the client API concerning the cache clearing APIs which are now returning a promise, i.e. the cache clearing is made asynchronously.
This concerns the functions: clearOptionCache, clearMethodCache, clearEntityCache, and clearAllCaches

## Motivation and Context

Support storages which have an asynchronous interface.

## How Has This Been Tested?

Unit tests

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

The change is largely non breaking, except for the cache clearing functions.

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
