### PR TITLE
Fallback mechanism: reset TTL to 5 min when stop auto refresh of cache

### DIFF
--- a/src/cache.js
+++ b/src/cache.js
@@ -306,6 +306,14 @@ class Cache {
       delete this._cache[key];
       await this._remove(key);
   }
+
+  /**
+   * Change TTL for objects in the cache in ms. Defaults to 5 mins
+   * @param {any} ttl
+   */
+  setTTL(ttl) {
+    this._ttl = ttl || 1000 * 300;
+  }
 }
 
 // Public expots

--- a/src/cacheRefresher.js
+++ b/src/cacheRefresher.js
@@ -259,6 +259,8 @@ governing permissions and limitations under the License.
             }
             clearInterval(this._intervalId);
             this._intervalId = null;
+            this._cache.setTTL(1000 * 300);
+            this._cache.clear();
         }
     }
 

--- a/test/cacheRefresher.test.js
+++ b/test/cacheRefresher.test.js
@@ -146,7 +146,9 @@ describe("CacheRefresher cache", function () {
         client._transport.mockReturnValueOnce(Mock.LOGON_RESPONSE);
 
         await client.NLWS.xtkSession.logon();
-        const cache = new Cache();
+        const cache = new Cache(undefined, undefined, 1000 * 600); 
+        await cache.put("Hello", "World");
+        await expect(cache.get("Hello")).resolves.toBe("World");
         const cacheRefresher = new CacheRefresher(cache, client, "xtk:schema", "rootkey");
 
         cacheRefresher.startAutoRefresh();
@@ -156,6 +158,8 @@ describe("CacheRefresher cache", function () {
         await expect(cacheRefresher._refresherStateCache.get("buildNumber")).resolves.toBeUndefined();
         await expect(cacheRefresher._refresherStateCache.get("time")).resolves.toBeUndefined();
         expect(cacheRefresher._intervalId).toBeNull();
+        await expect(cache.get("Hello")).resolves.toBeUndefined();
+        expect(cache._ttl).toBe(1000 * 300); // reset to default TTL of 5 minutes
 
         client._transport.mockReturnValueOnce(Mock.LOGOFF_RESPONSE);
         await client.NLWS.xtkSession.logoff();

--- a/test/caches.test.js
+++ b/test/caches.test.js
@@ -42,6 +42,25 @@ describe('Caches', function() {
             expect(cache._stats).toMatchObject({ reads: 1, writes: 1, memoryHits: 0, storageHits: 0 });
         })
 
+        it("When changes TTL cache value should use new ttl", async () => {
+          const cache = new Cache(undefined, undefined, 1000 * 300); // 5 min TTL
+          cache.setTTL(-1);
+          expect(cache._ttl).toBe(-1);
+          await cache.put("Hello", "World");
+          await expect(cache.get("Hello")).resolves.toBeUndefined();
+          expect(cache._stats).toMatchObject({ reads: 1, writes: 1, memoryHits: 0, storageHits: 0 });
+        })
+
+        it("When TTL value is empty , default value should be used", async () => {
+          const cache = new Cache(undefined, undefined, -1);
+          expect(cache._ttl).toBe(-1);
+          cache.setTTL();
+          expect(cache._ttl).toBe(1000 * 300);
+          await cache.put("Hello", "World");
+          await expect(cache.get("Hello")).resolves.toBe("World");
+          expect(cache._stats).toMatchObject({ reads: 1, writes: 1, memoryHits: 1, storageHits: 0 });
+        })
+
         it("Should support custom key function", async () => {
             const cache = new Cache(undefined, undefined, 300000, ((a, b) => a + "||" + b));
             await cache.put("key-part-1", "key-part-2", "value");


### PR DESCRIPTION

## Description

When auto refresh is stopped the cache content is refreshed only after end of TTL set in cache constructor.
The TTL can be big , 24 hours for web ui client.
So by default the TLL is reset to 5 minutes when auto refresh is stopped.

## Related Issue

https://jira.corp.adobe.com/browse/NEO-52668
When web ui is pointing on an acc server that does support auto refresh we need to fallback on default refresh mechanism  :
Having a TTL of 5 minutes.

## Motivation and Context



## How Has This Been Tested?

Use web ui on an old acc server which does not have GetModifiedEntities method exposed.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
