### PR TITLE
NEO-49613: Added dbEnum to XtkSchemaNode

### DIFF
--- a/docs/application.html
+++ b/docs/application.html
@@ -228,13 +228,14 @@ const root = await node.linkTarget();
   <tbody>
     <tr><td><b>children</b></td><td>A array/map of children of the node. See note on the ArrayMap structure below</td></tr>
     <tr><td><b>dataPolicy</b></td><td>Returns a string of characters which provides the data policy of the current node.</td></tr>
+    <tr><td><b>dbEnum</b></td><td>Returns a string of characters which provides the db enum of the current node.</td></tr>
     <tr><td><b>description</b></td><td>A long, human readable, description of the node</td></tr>
     <tr><td><b>descriptionLocalizationId</b></td><td>The translation id of the description of the node.</td></tr>
     <tr><td><b>editType</b></td><td>Returns a string of characters which specifies the editing type of the current node.
     <tr><td><b>enum</b></td><td>The name of the enumeration for the node, or an empty string if the node does node have an enumeration. See <b>enumeration()</b> method to get the corresponding <b>XtkSchemaNode</b></td></tr>
     <tr><td><b>enumerationImage</b></td><td>Returns the name of the image of the current node in the form of a string of characters.</td></tr>
     <tr><td><b>folderModel</b></td><td>Only on the root node, returns a string which contains the folder template(s). On the other nodes, it returns undefined.
-    <tr><td><b>image** </td><td>Returns the name of the image in the form of a string of characters.
+    <tr><td><b>image**</b></td><td>Returns the name of the image in the form of a string of characters.
     <tr><td><b>img</b></td><td>Returns the name of the image in the form of a string of characters. (alias to <b>image</b> property)</td></tr>
     <tr><td><b>integrity</b></td><td>Returns the link integrity type.</td></tr>
     <tr><td><b>keys</b></td><td>A array/map of keys in this node, indexed by key name. Map values are of type <b>XtkSchemaKey</b></td></tr>
@@ -271,7 +272,7 @@ const root = await node.linkTarget();
     <tr><td><b>label</b></td><td>The label (i.e. human readable, localised) name of the node.</td></tr>
     <tr><td><b>labelLocalizationId</b></td><td>The translation id of the label of the node.</td></tr>
     <tr><td><b>name</b></td><td>The name of the node (internal name)</td></tr>
-    <tr><td><b>nodePath** </td><td>The xpath of the node
+    <tr><td><b>nodePath**</b></td><td>The xpath of the node
     <tr><td><b>parent</b></td><td>The parent node (a <b>XtkSchemaNode</b> object). Will be null for schema nodes</td></tr>
     <tr><td><b>PKSequence</b></td><td>Returns a character string that provides the name of the sequence to use for the primary key.</td></tr>
     <tr><td><b>packageStatus</b></td><td>Returns a number that gives the package status.</td></tr>

--- a/src/application.js
+++ b/src/application.js
@@ -252,6 +252,12 @@ class XtkSchemaNode {
          this.dataPolicy = EntityAccessor.getAttributeAsString(xml, "dataPolicy");
 
         /**
+         * Returns a string of characters which provides the db enum of the current node.
+         * @type {string}
+         */
+        this.dbEnum = EntityAccessor.getAttributeAsString(xml, "dbEnum");
+
+        /**
          * Returns a string of characters which specifies the editing type of the current node.
          * @type {string}
          */

--- a/src/cacheRefresher.js
+++ b/src/cacheRefresher.js
@@ -214,7 +214,7 @@ governing permissions and limitations under the License.
                 } else {
                     throw ex;
                 }
-            };
+            }
         }
 
         // Refresh Cache : remove entities modified recently listed in xmlDoc

--- a/test/application.test.js
+++ b/test/application.test.js
@@ -141,6 +141,25 @@ describe('Application', () => {
             });
         });
 
+        describe('dbEnum', () => {
+            it("Should find dbEnum attribute", () => {
+                var xml = DomUtil.parse(`<schema namespace='nms' name='recipient'>
+                                            <element name='recipient' label='Recipients'>
+                                                <attribute dbEnum="operationNature" desc="Nature of the campaign" label="Nature"
+               length="64" name="nature" type="string"/>
+                                            </element>
+                                        </schema>`);
+                var schema = newSchema(xml);
+                var root = schema.root;
+                expect(!!root.children.get("@nature")).toBe(true);
+                var attribute = root.children["@nature"];
+                expect(attribute).not.toBeNull();
+                expect(attribute.dbEnum).toBe("operationNature");
+                expect(attribute.type).toBe("string");
+                expect(attribute.length).toBe(64);
+            });
+        });
+
         describe("Children", () => {
             it("Should browse root children", () => {
                 var xml = DomUtil.parse(`<schema namespace='nms' name='recipient'>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Extended XtkSchemaNode class with additional dbEnum property

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Adde dbENum property to XtkSchemaNode since it was missing


## How Has This Been Tested?

New Unit test 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
