### PR TITLE
Added public function client.newSchema to create a new XtkSchema object from an XML document or element…

### DIFF
--- a/src/application.js
+++ b/src/application.js
@@ -35,11 +35,14 @@ const PACKAGE_STATUS = { "never": 0, "always": 1, "default": 2, "preCreate": 3 }
 // ========================================================================================
 
 /**
-  * Creates a schema object from an XML representation
-  * This function is not intended to be used publicly.
+  * Creates a schema object from an XML representation.
+  * The returned XtkSchema object will not be added to the application schema cache.
+  * If you do not pass an application object, it will not be possible to follow
+  * references or get enumeration values from the returned XtkSchema
   * 
   * @private
   * @param {DOMElement|DOMDocument} xml the XML document or element representing the schema
+  * @param {Campaign.Application|undefined} the application object which will be used to follow links and references
   * @returns {XtkSchema} a schema object
   * @see {@link XtkSchema}
   * @memberof Campaign
@@ -1094,6 +1097,7 @@ class XtkEnumeration {
  * @private
  * @class
  * @constructor
+ * @param {Campaign.Application|undefined} the application object which will be used to follow links and references
  * @augments Campaign.XtkSchemaNode
  * @param {XML.XtkObject} xml the schema definition
  * @memberof Campaign

--- a/src/client.js
+++ b/src/client.js
@@ -33,7 +33,7 @@ const MethodCache = require('./methodCache.js').MethodCache;
 const OptionCache = require('./optionCache.js').OptionCache;
 const CacheRefresher = require('./cacheRefresher.js').CacheRefresher;
 const request = require('./transport.js').request;
-const Application = require('./application.js').Application;
+const { Application, newSchema } = require('./application.js');
 const EntityAccessor = require('./entityAccessor.js').EntityAccessor;
 const { Util } = require('./util.js');
 const { XtkJobInterface } = require('./xtkJob.js');
@@ -1627,6 +1627,20 @@ class Client {
         ];
         await this._makeInterceptableSoapCall("xtk:session", undefined, soapCall, inputParams, outputParams, representation);
         return outputParams[0].value;
+    }
+
+    /**
+     * Creates a schema object from an XML representation.
+     * The returned XtkSchema object will not be added to the application schema cache.
+     * If you do not pass an application object, it will not be possible to follow
+     * references or get enumeration values from the returned XtkSchema
+     * 
+     * @param {DOMElement|DOMDocument} xml the XML document or element representing the schema
+     * @returns {Campaign.XtkSchema} a schema object
+     * @see {@link Campaign.XtkSchema}
+     */
+    newSchema(xml) {
+        return newSchema(xml, this.application);
     }
 
     /**


### PR DESCRIPTION
## Description

Working with workflow temp schemas in XML form can be tedious and this PR is about being able to create a XtkSchema object from any XML representation of a schema, including workflow temporary schemas. 
The newSchema free function exists but is private. It is now publicly exposed as client.newSchema


## How Has This Been Tested?

New unit tests have been written.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
