### PR TITLE
New optional action parameter for upload function

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -535,11 +535,15 @@ const fileUploader = (client) => {
          * This is the exposed/public method for fileUploader instance which will do all the processing related to the upload process internally and returns the promise containing all the required data.
          * @ignore
          * @param file, where file is an instance of [File](https://developer.mozilla.org/en-US/docs/Web/API/File)
+         * @parma {"publishIfNeeded"|"none"|undefined} the post-processing action to execute. Defaults to "publishIfNeeded"
          * @returns {Promise<{name: string, md5: string, type: string, size: string, url: string}>}
          */
-        upload: (file) => {
+        upload: (file, action) => {
             console.log(`fileuploader.upload is an experimental feature and is not currently fully functional. It is work in progress and will change in the future.`);
+            if (!action) action = "publishIfNeeded";
             return new Promise((resolve, reject) => {
+                if (action !== "publishIfNeeded" && action !== "none")
+                    reject(CampaignException.BAD_PARAMETER("action", action, "The 'action' parameter of the upload API should be 'publishIfNeeded' or 'none'"));
                 try {
                     if (!Util.isBrowser()) {
                         throw 'File uploading is only supported in browser based calls.';
@@ -569,28 +573,31 @@ const fileUploader = (client) => {
                                     // https://git.corp.adobe.com/Campaign/ac/blob/v6-master/wpp/xtk/web/dce/uploader.js
                                     return reject(CampaignException.FILE_UPLOAD_FAILED(file.name, 'Malformed data:' + data.toString()));
                                 }
-                                const counter = await client.NLWS.xtkCounter.increaseValue({name: 'xtkResource'});
-                                const fileRes= {
-                                    internalName: 'RES' + counter,
-                                    md5: data[0].md5,
-                                    label: data[0].fileName,
-                                    fileName: data[0].fileName,
-                                    originalName: data[0].fileName,
-                                    useMd5AsFilename: '1',
-                                    storageType: 5,
-                                    xtkschema: 'xtk:fileRes'
-
-                                };
-                                await client.NLWS.xtkSession.write(fileRes);
-                                await client.NLWS.xtkFileRes.create(fileRes).publishIfNeeded();
-                                const url = await client.NLWS.xtkFileRes.create(fileRes).getURL();
-                                resolve({
+                                const result = {
                                     name: data[0].fileName,
                                     md5: data[0].md5,
                                     type: file.type,
                                     size: file.size,
-                                    url: url
-                                });
+                                };
+                                if (action === "publishIfNeeded") {
+                                    const counter = await client.NLWS.xtkCounter.increaseValue({name: 'xtkResource'});
+                                    const fileRes= {
+                                        internalName: 'RES' + counter,
+                                        md5: data[0].md5,
+                                        label: data[0].fileName,
+                                        fileName: data[0].fileName,
+                                        originalName: data[0].fileName,
+                                        useMd5AsFilename: '1',
+                                        storageType: 5,
+                                        xtkschema: 'xtk:fileRes'
+
+                                    };
+                                    await client.NLWS.xtkSession.write(fileRes);
+                                    await client.NLWS.xtkFileRes.create(fileRes).publishIfNeeded();
+                                    const url = await client.NLWS.xtkFileRes.create(fileRes).getURL();
+                                    result.url = url;
+                                }
+                                resolve(result);
                             }
                         };
                         const html = `<body>${okay}</body>`;

--- a/src/client.js
+++ b/src/client.js
@@ -521,6 +521,13 @@ class ConnectionParameters {
 // ========================================================================================
 
 /**
+ * @typedef {Object} FileUploadOptions
+ * @property {"publishIfNeeded"|"none"|undefined} the post-processing action to execute. Defaults to "publishIfNeeded"
+ * @memberOf Campaign
+ */
+
+
+/**
  * File Uploader API for JS SDK(Currently available only in browsers)
  * @private
  * @ignore
@@ -535,13 +542,13 @@ const fileUploader = (client) => {
          * This is the exposed/public method for fileUploader instance which will do all the processing related to the upload process internally and returns the promise containing all the required data.
          * @ignore
          * @param file, where file is an instance of [File](https://developer.mozilla.org/en-US/docs/Web/API/File)
-         * @parma {"publishIfNeeded"|"none"|undefined} the post-processing action to execute. Defaults to "publishIfNeeded"
+         * @param {FileUploadOptions|undefined} options
          * @returns {Promise<{name: string, md5: string, type: string, size: string, url: string}>}
          */
-        upload: (file, action) => {
+        upload: (file, options) => {
             console.log(`fileuploader.upload is an experimental feature and is not currently fully functional. It is work in progress and will change in the future.`);
-            if (!action) action = "publishIfNeeded";
             return new Promise((resolve, reject) => {
+                const action = (options && options.action) ? options.action : "publishIfNeeded";
                 if (action !== "publishIfNeeded" && action !== "none")
                     reject(CampaignException.BAD_PARAMETER("action", action, "The 'action' parameter of the upload API should be 'publishIfNeeded' or 'none'"));
                 try {

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -3549,7 +3549,7 @@ describe('ACC Client', function () {
             const result = await client.fileUploader.upload({
                 type: 'text/html',
                 size: 12345
-            }, "publishIfNeeded");
+            }, { action: "publishIfNeeded" });
 
             expect(result).toMatchObject({
                 md5: "d8e8fca2dc0f896fd7cb4cb0031ba249",
@@ -3581,7 +3581,7 @@ describe('ACC Client', function () {
             const result = await client.fileUploader.upload({
                 type: 'text/html',
                 size: 12345
-            }, "none");
+            }, { action: "none" });
 
             expect(result).toMatchObject({
                 md5: "d8e8fca2dc0f896fd7cb4cb0031ba249",
@@ -3613,7 +3613,7 @@ describe('ACC Client', function () {
             await expect(client.fileUploader.upload({
                 type: 'text/html',
                 size: 12345
-            }, "invalid")).rejects.toMatchObject({
+            }, { action: "invalid" })).rejects.toMatchObject({
                 errorCode: "SDK-000006", 
                 "faultCode": 16384, 
                 "faultString": "Bad parameter 'action' with value 'invalid'", 

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -3511,8 +3511,115 @@ describe('ACC Client', function () {
             }).catch((ex) => {
                 expect(ex.message).toMatch('500 - Error 16384: SDK-000013 "Failed to upload file abcd.txt. Malformed data:');
             })
+        });
 
-        })
+        it("Should support 'publishIfNeeded' action", async () => {
+            // Create a mock client and logon
+            const client = await Mock.makeClient();
+            client._transport.mockReturnValueOnce(Mock.LOGON_RESPONSE);
+            await client.NLWS.xtkSession.logon();
+
+            // Mock the upload protocol
+            // - the upload.jsp (which returns the content of an iframe and JS to eval)
+            // - call to xtk:counter#IncreaseValue (first, retrieve the schema xtk:counter then call the function)
+            // - call to xtk:session#Write
+            // - call to xtk:fileRes#PublishIfNeeded
+            // - call to xtk:fileRes#GetURL
+
+            client._transport.mockReturnValueOnce(Promise.resolve(`Ok 
+        <html xmlns="http://www.w3.org/1999/xhtml">
+            <head>
+              <script type="text/javascript">if(window.parent&&window.parent.document.controller&&"function"==typeof window.parent.document.controller.uploadFileCallBack){var aFilesInfo=new Array;aFilesInfo.push({paramName:"file",fileName:"test.txt",newFileName:"d8e8fca2dc0f896fd7cb4cb0031ba249.txt",md5:"d8e8fca2dc0f896fd7cb4cb0031ba249"}),window.parent.document.controller.uploadFileCallBack(aFilesInfo)}</script>
+            </head>
+        <body></body>
+        </html>`)); // upload.jsp
+
+            client._transport.mockReturnValueOnce(Promise.resolve(Mock.GET_XTK_COUNTER_RESPONSE)); // GetEntityIfMoreRecentResponse - counter
+            client._transport.mockReturnValueOnce(Mock.INCREASE_VALUE_RESPONSE); // xtk:counter#IncreaseValue
+
+            client._transport.mockReturnValueOnce(Mock.GET_XTK_SESSION_SCHEMA_RESPONSE); // GetEntityIfMoreRecentResponse - session
+            client._transport.mockReturnValueOnce(Mock.FILE_RES_WRITE_RESPONSE); // xtk:session#Write
+
+            client._transport.mockReturnValueOnce(Promise.resolve(Mock.GET_FILERES_QUERY_SCHEMA_RESPONSE)); // GetEntityIfMoreRecentResponse - fileRes
+            client._transport.mockReturnValueOnce(Promise.resolve(Mock.PUBLISH_IF_NEEDED_RESPONSE)); // xtk:fileRes#PublishIfNeeded
+
+            client._transport.mockReturnValueOnce(Promise.resolve(Mock.GET_URL_RESPONSE)); // xtk:fileRes#GetURL
+
+            // Call upload
+            const result = await client.fileUploader.upload({
+                type: 'text/html',
+                size: 12345
+            }, "publishIfNeeded");
+
+            expect(result).toMatchObject({
+                md5: "d8e8fca2dc0f896fd7cb4cb0031ba249",
+                name: "test.txt",
+                size: 12345,
+                type: "text/html",
+                url: "http://hello.com"
+            });
+        });
+
+        it("Should support 'none' action", async () => {
+            // Create a mock client and logon
+            const client = await Mock.makeClient();
+            client._transport.mockReturnValueOnce(Mock.LOGON_RESPONSE);
+            await client.NLWS.xtkSession.logon();
+
+            // Mock the upload protocol
+            // With the "none" action, we skip the counter & publication
+            // - the upload.jsp (which returns the content of an iframe and JS to eval)
+            client._transport.mockReturnValueOnce(Promise.resolve(`Ok 
+        <html xmlns="http://www.w3.org/1999/xhtml">
+            <head>
+              <script type="text/javascript">if(window.parent&&window.parent.document.controller&&"function"==typeof window.parent.document.controller.uploadFileCallBack){var aFilesInfo=new Array;aFilesInfo.push({paramName:"file",fileName:"test.txt",newFileName:"d8e8fca2dc0f896fd7cb4cb0031ba249.txt",md5:"d8e8fca2dc0f896fd7cb4cb0031ba249"}),window.parent.document.controller.uploadFileCallBack(aFilesInfo)}</script>
+            </head>
+        <body></body>
+        </html>`)); // upload.jsp
+
+            // Call upload
+            const result = await client.fileUploader.upload({
+                type: 'text/html',
+                size: 12345
+            }, "none");
+
+            expect(result).toMatchObject({
+                md5: "d8e8fca2dc0f896fd7cb4cb0031ba249",
+                name: "test.txt",
+                size: 12345,
+                type: "text/html",
+            });
+            expect(result.url).toBeUndefined();
+        });
+
+        it("Should failed with invalid action", async () => {
+            // Create a mock client and logon
+            const client = await Mock.makeClient();
+            client._transport.mockReturnValueOnce(Mock.LOGON_RESPONSE);
+            await client.NLWS.xtkSession.logon();
+
+            // Mock the upload protocol
+            // With the "none" action, we skip the counter & publication
+            // - the upload.jsp (which returns the content of an iframe and JS to eval)
+            client._transport.mockReturnValueOnce(Promise.resolve(`Ok 
+        <html xmlns="http://www.w3.org/1999/xhtml">
+            <head>
+              <script type="text/javascript">if(window.parent&&window.parent.document.controller&&"function"==typeof window.parent.document.controller.uploadFileCallBack){var aFilesInfo=new Array;aFilesInfo.push({paramName:"file",fileName:"test.txt",newFileName:"d8e8fca2dc0f896fd7cb4cb0031ba249.txt",md5:"d8e8fca2dc0f896fd7cb4cb0031ba249"}),window.parent.document.controller.uploadFileCallBack(aFilesInfo)}</script>
+            </head>
+        <body></body>
+        </html>`)); // upload.jsp
+
+            // Call upload
+            await expect(client.fileUploader.upload({
+                type: 'text/html',
+                size: 12345
+            }, "invalid")).rejects.toMatchObject({
+                errorCode: "SDK-000006", 
+                "faultCode": 16384, 
+                "faultString": "Bad parameter 'action' with value 'invalid'", 
+                "statusCode": 400
+            });
+        });
     });
 
     describe("Setting the xtkschema attribute", () => {


### PR DESCRIPTION
New optional action parameter for upload function. This parameter can be used to set the post-processing action to execute after upload. Defaults to 'publishIfNeeded'. Also supports 'none' which will execute no action

## Related Issue

Current implementation of upload function will automaticaly publish the uploaded resource as a public resource in Campaign. This is correct for attachments, or public resources used in email, but is not correct for other type of resoures, for instance an uploaded audience.
The default value (i.e. no action given) defaults to a pubish action for backwards compatibility

## Motivation and Context

Work in progress to support upload functionality.

## How Has This Been Tested?

Unit tests 

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
