### PR TITLE
Added support for IMS Bearer tokens without require any session and security tokens

### DIFF
--- a/docs/changeLog.html
+++ b/docs/changeLog.html
@@ -2,8 +2,18 @@
 layout: page
 title: Change Log
 ---
+
+<section class="changelog"><h1>Version 1.1.25</h1>
+  <h2>2023/04/11</h2>
+
+  <li>
+    Added support for IMS Bearer tokens without require any session and security tokens. See <a href="https://opensource.adobe.com/acc-js-sdk/connecting.html"> for more details.</a>
+  </li>
+</section>
+
+
 <section class="changelog"><h1>Version 1.1.24</h1>
-  <h2>2023/03/07</h2>
+  <h2>2023/04/07</h2>
 
   <li>
     Added support for abortable requests. See <a href="https://opensource.adobe.com/acc-js-sdk/abortRequest.html"> for more details.</a>

--- a/docs/connecting.html
+++ b/docs/connecting.html
@@ -75,7 +75,22 @@ const connectionParameters = sdk.ConnectionParameters.ofUserAndPassword(
 
 
 <h2>Login with IMS access token</h2>
-<p>The SDK supports IMS access token of an IMS user with the <b>ofBearerToken</b> function. Pass it a bearer token.</p>
+
+<p>In Campaign 8.5 and above, native support for IMS bearer tokens is avaiable and can be used in the SDK as the preferred connection method.</p>
+<pre class="code">
+    const connectionParameters = sdk.ConnectionParameters.ofImsBearerToken(
+                                    "https://myInstance.campaign.adobe.com", 
+                                    "ims_bearer_token");
+</pre>
+
+<p>With this authentication method, an IMS Bearer token is obtained outside of Campaing, for example using Adobe.io and is passed directly to 
+    all Campaign APIs. Campaigns itslef will verify the token and grant the corresponding access.
+</p>
+
+    
+<p>For older versions of Campaign, you can still use IMS tokens with the <b>ofBearerToken</b> function. The difference between ofImsBearerToken and ofBearerToken
+    is that ofBearerToken will internally call "xtk:session#BearerTokenLogon" to exchange the IMS token for Campaign session and security tokens. Subsequent
+    API calls will use Campaign tokens. It's recommended to us <b>ofImsBearerToken</b> logon whenever possible.</p>
 <pre class="code">
 const connectionParameters = sdk.ConnectionParameters.ofBearerToken(
                                 "https://myInstance.campaign.adobe.com", 

--- a/src/client.js
+++ b/src/client.js
@@ -11,7 +11,7 @@ governing permissions and limitations under the License.
 */
 (function() {
 "use strict";
-
+/*jshint sub:true*/
 
 /**********************************************************************************
  *
@@ -244,12 +244,12 @@ class Credentials {
      */
     constructor(type, sessionToken, securityToken) {
         if (type != "UserPassword" && type != "ImsServiceToken" && type != "SessionToken" &&
-            type != "AnonymousUser" && type != "SecurityToken" && type != "BearerToken")
+            type != "AnonymousUser" && type != "SecurityToken" && type != "BearerToken" && type != "ImsBearerToken")
             throw CampaignException.INVALID_CREDENTIALS_TYPE(type);
         this._type = type;
         this._sessionToken = sessionToken || "";
         this._securityToken = securityToken || "";
-        if (type == "BearerToken") {
+        if (type == "BearerToken" || type === "ImsBearerToken") {
             this._bearerToken = sessionToken || "";
             this._sessionToken = "";
         }
@@ -397,8 +397,13 @@ class ConnectionParameters {
     }
 
     /**
-     * Creates connection parameters for a Campaign instance from bearer token
-     *
+     * Creates connection parameters for a Campaign instance from bearer token.
+     * This authentication method uses an IMS Bearer token and calls the xtk:session#BearerTokenLogin method
+     * which will exchange the IMS bearer token with Campaign session and security tokens.
+     * This is a legacy method. Campaign 8.5 will has an authentication method which allows to directly
+     * use the IMS bearer token and which is recommended. 
+     * To avoid an extra call to "BearerTokenLogin", use the "ofImsBearerToken" method.
+     * 
      * @param {string} endpoint The campaign endpoint (URL)
      * @param {string} bearerToken IMS bearer token
      * @param {*} options connection options
@@ -408,6 +413,23 @@ class ConnectionParameters {
         const credentials = new Credentials("BearerToken", bearerToken);
         return new ConnectionParameters(endpoint, credentials, options);
     }
+
+    /**
+     * Creates connection parameters for a Campaign instance from a IMS bearer token.
+     * This authentication method does not require exchange the IMS token with session and security tokens
+     * and only works in ACC 8.5 and above.
+     * For older version of ACC or to use session/seurity tokens, use the "ofBearerToken" method.
+     * 
+     * @param {string} endpoint The campaign endpoint (URL)
+     * @param {string} bearerToken IMS bearer token
+     * @param {*} options connection options
+     * @returns {ConnectionParameters} a ConnectionParameters object which can be used to create a Client
+     */
+    static ofImsBearerToken(endpoint, bearerToken, options) {
+        const credentials = new Credentials("ImsBearerToken", bearerToken);
+        return new ConnectionParameters(endpoint, credentials, options);
+    }
+
     /**
      * Creates connection parameters for a Campaign instance, using an IMS service token and a user name (the user to impersonate)
      *
@@ -546,15 +568,13 @@ const fileUploader = (client) => {
                     }
                     const data = new FormData();
                     data.append('file_noMd5', file);
+                    const headers = client._getAuthHeaders(false);
                     client._makeHttpCall({
                         url: `${client._connectionParameters._endpoint}/nl/jsp/uploadFile.jsp`,
                         processData: false,
                         method: 'POST',
                         data: data,
-                        headers: {
-                            'X-Security-Token': client._securityToken,
-                            'X-Session-Token': client._sessionToken,
-                        }
+                        headers: headers
                     }).then((okay) => {
                         if (!okay.startsWith('Ok')) {
                             throw okay;
@@ -631,13 +651,28 @@ class Client {
      */
     constructor(sdk, connectionParameters) {
         this.sdk = sdk;
+        this.reinit(connectionParameters);
+
+        this._observers = [];
+        this._cacheChangeListeners = [];
+    }
+
+    /**
+     * Re-initialize a client with new connection parameters.
+     * Typically called from the refreshClient callback after a connection expires.
+     * Conserves observers
+     *
+     * @param {Campaign.ConnectionParameters} user user name, for instance admin
+     */
+    reinit(connectionParameters) {
         this._connectionParameters = connectionParameters; // ## TODO security concern (password kept in memory)
         this._representation = connectionParameters._options.representation;
 
         this._sessionInfo = undefined;
         this._sessionToken = undefined;
         this._securityToken = undefined;
-        this._installedPackages = {};     // package set (key and value = package id, ex: "nms:amp")
+        this._bearerToken = undefined;      // set when using Bearer authentication and "ImsBearer" credential type
+        this._installedPackages = {};       // package set (key and value = package id, ex: "nms:amp")
 
         this._secretKeyCipher = undefined;
 
@@ -653,7 +688,7 @@ class Client {
         const rootKeyType = connectionParameters._options.cacheRootKey;
         let rootKey = "";
         if (!rootKeyType || rootKeyType === "default")
-            rootKey = `acc.js.sdk.${sdk.getSDKVersion().version}.${instanceKey}.cache.`;
+            rootKey = `acc.js.sdk.${this.sdk.getSDKVersion().version}.${instanceKey}.cache.`;
 
         // Clear storage cache if the sdk versions or the instances are different
         if (this._storage && typeof this._storage.removeItem === 'function') {
@@ -673,8 +708,6 @@ class Client {
 
         this._transport = connectionParameters._options.transport;
         this._traceAPICalls = connectionParameters._options.traceAPICalls;
-        this._observers = [];
-        this._cacheChangeListeners = [];
         this._refreshClient = connectionParameters._options.refreshClient;
 
         // expose utilities
@@ -733,6 +766,26 @@ class Client {
     _getUserAgentString() {
         const version = this.sdk.getSDKVersion();
         return `${version.name}/${version.version} ${version.description}`;
+    }
+
+    /**
+     * Get HTTP authentication headers
+     * @param
+     * @returns {Object} the headers
+     */
+    _getAuthHeaders(setCookie) {
+        const headers = {};
+        if (this._bearerToken) {
+            headers['Authorization'] = `Bearer ${this._bearerToken}`;
+        }
+        else {
+            headers['X-Security-Token'] = this._securityToken;
+            headers['X-Session-Token'] = this._sessionToken;
+            if (setCookie) {
+                headers['Cookie'] = '__sessiontoken=' + this._sessionToken;
+            }
+        }
+        return headers;
     }
 
     /**
@@ -915,6 +968,9 @@ class Client {
         const credentialsType = this._connectionParameters._credentials._type;
         if (credentialsType == "AnonymousUser")
             return true;
+        else if (credentialsType == "ImsBearerToken") {
+            return !!this._bearerToken;
+        }
 
         // When using bearer token authentication we are considered logged only after
         // the bearer token has been converted into session token and security token
@@ -953,7 +1009,8 @@ class Client {
                                             this._sessionToken, this._securityToken,
                                             this._getUserAgentString(),
                                             Object.assign({}, this._connectionParameters._options, pushDownOptions),
-                                            extraHttpHeaders);
+                                            extraHttpHeaders,
+                                            this._bearerToken);
         soapCall.internal = !!internal;
         soapCall.isStatic = isStatic;
         return soapCall;
@@ -1310,6 +1367,7 @@ class Client {
         this.application = null;
         this._sessionToken = "";
         this._securityToken = "";
+        this._bearerToken = undefined;
         const credentials = this._connectionParameters._credentials;
 
         const sdkVersion = this.sdk.getSDKVersion();
@@ -1335,6 +1393,7 @@ class Client {
             that._installedPackages = {};
             that._sessionToken = credentials._sessionToken;
             that._securityToken = "";
+            that._bearerToken = undefined;
             that._onLogon();
             return Promise.resolve();
         }
@@ -1343,6 +1402,16 @@ class Client {
             that._installedPackages = {};
             that._sessionToken = "";
             that._securityToken = credentials._securityToken;
+            that._bearerToken = undefined;
+            that._onLogon();
+            return Promise.resolve();
+        }
+        else if (credentials._type == "ImsBearerToken") {
+            that._sessionInfo = undefined;
+            that._installedPackages = {};
+            that._sessionToken = "";
+            that._securityToken = "";
+            that._bearerToken = credentials._bearerToken;
             that._onLogon();
             return Promise.resolve();
         }
@@ -1393,6 +1462,7 @@ class Client {
                 // store member variables after all parameters are decode the ensure atomicity
                 that._sessionToken = sessionToken;
                 that._securityToken = securityToken;
+                that._bearerToken = undefined;
 
                 that._onLogon();
             });
@@ -1430,6 +1500,7 @@ class Client {
                 return this._makeSoapCall(soapCall).then(function() {
                     that._sessionToken = "";
                     that._securityToken = "";
+                    that._bearerToken = undefined;
                     that.application = null;
                     soapCall.checkNoMoreArgs();
                 });
@@ -1437,6 +1508,7 @@ class Client {
             else {
                 that._sessionToken = "";
                 that._securityToken = "";
+                that._bearerToken = undefined;
                 that.application = null;
             }
         } finally {
@@ -1900,13 +1972,10 @@ class Client {
      * @returns {Campaign.PingStatus} an object describing the server status
      */
     async ping() {
+        const headers = this._getAuthHeaders(true);
         const request = {
             url: `${this._connectionParameters._endpoint}/nl/jsp/ping.jsp`,
-            headers: {
-                'X-Security-Token': this._securityToken,
-                'X-Session-Token': this._sessionToken,
-                'Cookie': '__sessiontoken=' + this._sessionToken
-            }
+            headers: headers,
         };
         for (let h in this._connectionParameters._options.extraHttpHeaders)
             request.headers[h] = this._connectionParameters._options.extraHttpHeaders[h];
@@ -1939,14 +2008,12 @@ class Client {
                 callContext.formData.ctx = DomUtil.toXMLString(xmlCtx);
             }
             const selectionCount = callContext.selection.split(',').length;
-
+            
+            const headers = this._getAuthHeaders(false);
+            headers['Content-Type'] = 'application/x-www-form-urlencoded';
             const request = {
                 url: `${this._connectionParameters._endpoint}/report/${callContext.reportName}?${encodeURI(`_noRender=true&_schema=${callContext.schema}&_context=${callContext.context}&_selection=${callContext.selection}`)}&_selectionCount=${selectionCount}`,
-                headers: {
-                    'X-Security-Token': this._securityToken,
-                    'X-Session-Token': this._sessionToken,
-                    'Content-Type': 'application/x-www-form-urlencoded'
-                },
+                headers: headers,
                 method: 'POST',
                 data : qsStringify(callContext.formData)
             };
@@ -1971,13 +2038,10 @@ class Client {
      * @returns {Campaign.McPingStatus} an object describing Message Center server status
      */
     async mcPing() {
+        const headers = this._getAuthHeaders(true);
         const request = {
             url: `${this._connectionParameters._endpoint}/nl/jsp/mcPing.jsp`,
-            headers: {
-                'X-Security-Token': this._securityToken,
-                'X-Session-Token': this._sessionToken,
-                'Cookie': '__sessiontoken=' + this._sessionToken
-            }
+            headers: headers
         };
         for (let h in this._connectionParameters._options.extraHttpHeaders)
             request.headers[h] = this._connectionParameters._options.extraHttpHeaders[h];

--- a/test/imBearerToken.test.js
+++ b/test/imBearerToken.test.js
@@ -1,0 +1,174 @@
+/*
+Copyright 2023 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+
+/**********************************************************************************
+ *
+ * Unit tests for IMS Bearer Token authentication
+ *
+ *********************************************************************************/
+const sdk = require('../src/index.js');
+const Mock = require('./mock.js').Mock;
+
+describe('IMS Bearer Toekn', function () {
+
+    async function makeImsClient(options) {
+        const connectionParameters = sdk.ConnectionParameters.ofImsBearerToken("http://acc-sdk:8080", "ey...", options);
+        const client = await sdk.init(connectionParameters);
+        if (!options || !options.transport) // allow tests to explicitely set the transport
+          client._transport = jest.fn();
+        return client;
+      }
+
+    it('Should logon with IMS Bearer Token', async () => {
+        const client = await makeImsClient();
+        // No "Logon" API call is made when using IMS Bearer Token
+        //client._transport.mockReturnValueOnce(Mock.LOGON_RESPONSE);
+        await client.NLWS.xtkSession.logon();
+        expect(client.isLogged()).toBe(true);
+    });
+
+    // TODO: double check what LogOff means for IMS Bearer Token
+    // TODO: check if the Bearer token is passed to the Logoff API call
+    it('Should logoff', async () => {
+        const client = await makeImsClient();
+        await client.NLWS.xtkSession.logon();
+
+        client._transport.mockReturnValueOnce(Mock.LOGOFF_RESPONSE);
+        await client.NLWS.xtkSession.logoff();
+        expect(client.isLogged()).toBe(false);
+
+        expect(client._transport).toBeCalledTimes(1);
+        const calls = client._transport.mock.calls;
+        expect(calls[0][0].headers).toMatchObject({
+            "ACC-SDK-Auth": "ImsBearerToken",
+            "Authorization": "Bearer ey..."
+        });
+        expect(calls[0][0].headers["X-Security-Token"]).toBeUndefined();
+        expect(calls[0][0].headers["X-Session-Token"]).toBeUndefined();
+    });
+
+    it('Should call API with Bearer Token', async () => {
+        const client = await makeImsClient();
+        await client.NLWS.xtkSession.logon();
+
+        // Get Option
+        client._transport.mockReturnValueOnce(Mock.GET_XTK_SESSION_SCHEMA_RESPONSE);
+        client._transport.mockReturnValueOnce(Mock.GET_DATABASEID_RESPONSE);
+        var databaseId = await client.getOption("XtkDatabaseId");
+        expect(databaseId).toBe("uFE80000000000000F1FA913DD7CC7C480041161C");
+
+        // Check that headers were correctly populated for both calls
+        expect(client._transport).toBeCalledTimes(2);
+        const calls = client._transport.mock.calls;
+        expect(calls[0][0].headers).toMatchObject({
+            "ACC-SDK-Auth": "ImsBearerToken",
+            "ACC-SDK-Call-Internal": "1",
+            "Authorization": "Bearer ey..."
+        });
+        expect(calls[0][0].headers["X-Security-Token"]).toBeUndefined();
+        expect(calls[0][0].headers["X-Session-Token"]).toBeUndefined();
+
+        expect(calls[1][0].headers).toMatchObject({
+            "ACC-SDK-Auth": "ImsBearerToken",
+            "Authorization": "Bearer ey..."
+        });
+        expect(calls[1][0].headers["ACC-SDK-Call-Internal"]).toBeUndefined();
+        expect(calls[1][0].headers["X-Security-Token"]).toBeUndefined();
+        expect(calls[1][0].headers["X-Session-Token"]).toBeUndefined();
+    });
+
+    it("Expired session refresh client callback", async () => {
+
+        const refreshClient = async (client) => {
+            const connectionParameters = sdk.ConnectionParameters.ofImsBearerToken("http://acc-sdk:8080", "ey2...", options);
+            client.reinit(connectionParameters);
+            await client.NLWS.xtkSession.logon();
+            return client;
+        };
+
+        const transport = jest.fn();
+        const options = {
+            transport: transport,
+            refreshClient: refreshClient,
+        };
+        const connectionParameters = sdk.ConnectionParameters.ofImsBearerToken("http://acc-sdk:8080", "ey1...", options);
+        const client = await sdk.init(connectionParameters);
+        await client.NLWS.xtkSession.logon();
+
+        client._transport.mockReturnValueOnce(Promise.resolve(`XSV-350008 Session has expired or is invalid. Please reconnect.`));
+        client._transport.mockReturnValueOnce(Mock.GET_XTK_SESSION_SCHEMA_RESPONSE);
+        client._transport.mockReturnValueOnce(Mock.GET_DATABASEID_RESPONSE);
+        var databaseId = await client.getOption("XtkDatabaseId");
+        expect(databaseId).toBe("uFE80000000000000F1FA913DD7CC7C480041161C");
+        const lastCall = client._transport.mock.calls[client._transport.mock.calls.length - 1];
+        expect(lastCall[0].headers).toMatchObject({
+            "ACC-SDK-Auth": "ImsBearerToken",
+            "Authorization": "Bearer ey2..."
+        });
+        expect(lastCall[0].headers["X-Security-Token"]).toBeUndefined();
+        expect(lastCall[0].headers["X-Session-Token"]).toBeUndefined();
+    });
+
+
+    it("Should call ping API", async () => {
+        const client = await makeImsClient();
+        await client.NLWS.xtkSession.logon();
+
+        client._transport.mockReturnValueOnce(Mock.PING);
+        const ping = await client.ping();
+        expect(ping.status).toBe("OK");
+        expect(ping.timestamp).toBe("2021-08-27 15:43:48.862Z");
+
+        const lastCall = client._transport.mock.calls[client._transport.mock.calls.length - 1];
+        expect(lastCall[0].headers).toMatchObject({
+            "ACC-SDK-Auth": "ImsBearerToken",
+            "Authorization": "Bearer ey..."
+        });
+        expect(lastCall[0].headers["X-Security-Token"]).toBeUndefined();
+        expect(lastCall[0].headers["X-Session-Token"]).toBeUndefined();
+    });
+
+    it("Should call mcPing API", async () => {
+        const client = await makeImsClient();
+        await client.NLWS.xtkSession.logon();
+
+        client._transport.mockReturnValueOnce(Mock.MC_PING);
+        const ping = await client.mcPing();
+        expect(ping.status).toBe("Ok");
+
+        const lastCall = client._transport.mock.calls[client._transport.mock.calls.length - 1];
+        expect(lastCall[0].headers).toMatchObject({
+            "ACC-SDK-Auth": "ImsBearerToken",
+            "Authorization": "Bearer ey..."
+        });
+        expect(lastCall[0].headers["X-Security-Token"]).toBeUndefined();
+        expect(lastCall[0].headers["X-Session-Token"]).toBeUndefined();
+    });
+
+    it("Should allow to use the application object", async () => {
+        const client = await makeImsClient();
+        await client.NLWS.xtkSession.logon();
+        const application = client.application;
+        expect(application).toBeDefined();
+
+        client._transport.mockReturnValueOnce(Mock.GET_NMS_EXTACCOUNT_SCHEMA_RESPONSE);
+        const schema = await application.getSchema("nms:extAccount");
+        expect(schema).toBeDefined();
+        expect(schema.name).toBe("extAccount");
+
+        // But the application object does not have any info about packages
+        // since we are using a bearer token. Packages are only available
+        // when using one of the Logon methods (Logno or BearertokenLogon)
+        expect(application.packages).toBeUndefined();
+    });
+});


### PR DESCRIPTION
## Description

Campaign V8.5 supports direct authentication with IMS Bearer tokens, which means there's no need any more to call the Logon or BearerTokenLogon: a IMS Bearer token passed in the Authorization header is enough to authenticate.

## How Has This Been Tested?

Unit tests

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
