### PR TITLE
Fixed a bug causing incorrect JSON to XML transformation when the JSON object has a property named 'length'

### DIFF
--- a/src/domUtil.js
+++ b/src/domUtil.js
@@ -341,19 +341,17 @@ class DomUtil {
                     xmlElement.textContent = value;
                     xmlRoot.appendChild(xmlElement);
                 }
-                else if (t == "object") {
-                    if (value.length !== undefined && value.length !== null) {
-                        for (var i=0; i<value.length; i++) {
-                            const xmlElement = doc.createElement(att);
-                            this._fromJSON(doc, xmlElement, value[i], flavor);
-                            xmlRoot.appendChild(xmlElement);
-                        }
-                    }
-                    else {
+                else if (Util.isArray(value)) {
+                    for (var i=0; i<value.length; i++) {
                         const xmlElement = doc.createElement(att);
-                        this._fromJSON(doc, xmlElement, value, flavor);
+                        this._fromJSON(doc, xmlElement, value[i], flavor);
                         xmlRoot.appendChild(xmlElement);
                     }
+                }
+                else if (t == "object") {
+                    const xmlElement = doc.createElement(att);
+                    this._fromJSON(doc, xmlElement, value, flavor);
+                    xmlRoot.appendChild(xmlElement);
                 }
                 else
                     throw new DomException(`Cannot cast JSON to XML: element '${att}' type '${t}' is unknown or not supported yet`);

--- a/src/util.js
+++ b/src/util.js
@@ -51,18 +51,7 @@ class Util {
    * @returns {boolean} true if the object is an array
    */
   static isArray(obj) {
-    if (obj === null || obj === undefined) return false;
-    // JavaScript arrays are objects
-    if (typeof obj != "object") return false;
-    // They also have a length property. But checking the length is not enough
-    // since, it can also be an object literal with a "length" property. Campaign
-    // schema attributes typically have a "length" attribute and are not arrays
-    if (obj.length === undefined || obj.length === null) return false;
-    // So check for a "push" function
-    if (obj.push === undefined || obj.push === null) return false;
-    if (typeof obj.push != "function") 
-        return false;
-    return true;
+    return Array.isArray(obj);
   }
 
   // Helper function for trim() to replace text between 2 indices

--- a/test/domUtil.test.js
+++ b/test/domUtil.test.js
@@ -157,6 +157,20 @@ describe('DomUtil', function() {
             assert.strictEqual(fromJSON({ "a": null }), '<root/>');
             assert.strictEqual(fromJSON({ "a": undefined }), '<root/>');
         });
+
+        it("Should support attributes named 'length'", () => {
+            const json = {
+                element: {
+                  attribute: {
+                    length: "256",
+                    name: "id",
+                  },
+              }
+            };
+            const doc = DomUtil.fromJSON("extension", json);
+            const xml = DomUtil.toXMLString(doc);
+            expect(xml).toEqual('<extension><element><attribute length="256" name="id"/></element></extension>');
+        });
     });
 
     describe('fromJSON (default)', function() {


### PR DESCRIPTION
## Description

Fixed a bug causing incorrect JSON to XML transformation when the JON object has a property named 'length'

## Related Issue

In the following JSON object, there's an "attribute" object with a property named "length"
```
            const json = {
                element: {
                  attribute: {
                    length: "256",
                    name: "id",
                  },
              }
            };
```

Converting such an object to XML fails or does not return the expected result because an internal conversion function uses the existence of the "length" property to test if a JS object is an array In this example, "attribute" is considered an array since it has a "length" attribute. However, in this case "length" is just an XTK attribute which happens to be named 'length'. This attribute exists on schemas for example.

Now using Array.isArray javaScript function to safely test the type of an object to be an array.

## Motivation and Context

Bug fix discovered during implementation of https://github.com/adobe/acc-js-sdk/pull/80

## How Has This Been Tested?

New unit test which was failing before and is now successful

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
