### PR TITLE
Consider elements with multiple text children as if they had one single text child

### DIFF
--- a/src/domUtil.js
+++ b/src/domUtil.js
@@ -380,13 +380,22 @@ class DomUtil {
         return doc;
     }
 
+    // Get the text of a node. Will return the text if the xml node contains
+    // only text and cdata nodes. Otherwise will return null
     static _getTextIfTextNode(xml) {
-        const child = xml.firstChild;
+        let child = xml.firstChild;
         if (!child) return null;                   // no children
         if (xml.hasAttributes()) return null;      // no attributes
-        if (child.nextSibling) return null;        // more than 1 child
-        if (child.nodeType !== 3 && child.nodeType !== 4) return null;
-        const text = child.nodeValue;
+        let text = "";
+        while (child) {
+            // if child node is not text or cdata, it means we have a mix
+            // of text children and non-text children => we do not consider
+            // the xml node to be a text-only node
+            if (child.nodeType !== 3 && child.nodeType !== 4) 
+                return null;
+            text = text + child.nodeValue;
+            child = child.nextSibling;
+        }
         return text;
     }
 

--- a/test/domUtil.test.js
+++ b/test/domUtil.test.js
@@ -958,4 +958,21 @@ describe('DomUtil', function() {
             expect(new XPathElement(".").isParent()).toBe(false);
         })
     });
+
+    it("Should handle content made of CDATA text", () => {
+        const xml = DomUtil.parse(`<delivery>
+        <source><![CDATA[<head></head>]]></source>
+        </delivery>`);
+        const json = DomUtil.toJSON(xml, "SimpleJson");
+        expect(json.$source).toBe("<head></head>")
+    });
+    it("Should handle content made of multiple CDATA text", () => {
+        const xml = DomUtil.parse(`<delivery>
+        <source><![CDATA[<head>]]><![CDATA[</head>]]></source>
+        </delivery>`);
+        const json = DomUtil.toJSON(xml, "SimpleJson");
+        expect(json.$source).toBe("<head></head>")
+    });
 });
+
+


### PR DESCRIPTION
## Description

The content of HTML deliveries is returned as an XML CDATA node. Sometimes this content itself may contain CDATA elements. Campaign will "escape" such content as follow:

      /*<![CDATA[*/ @import url("https://fonts.googleapis.com/css?family=Lato|Open+Sans");[style*="Lato"]{font-family:Lato,Arial,sans-serif!important}[style*="Open Sans"]{font-family:Open Sans,Arial,sans-serif!important}/*]]]><![CDATA[]>*/

When the SDK tried to convert XML to JSON, it has the following logic:
* (1) If a XML element has a unique text child (text or cdata type), it will generate a JSON property starting with the element name prefix with "$". For instance <title><![CDATA[Hello]]></title> will be converted to $title: "Hello".
* (2) However, if there are multiple children, it will generate a JSON object with a "$" property. For instance: <title><![CDATA[Hello]]><![CDATA[World]]></title> will return "title": { "$": "HelloWorld" } and not "$title": "HelloWorld".

In our delivery content example, the /*<![CDATA[*/ and /*]]]><![CDATA[]>*/ escaping is a hack which actually splits the content into 2 CDATA elements. So when it's used, the delivery content will be returned as "source": { "$": content } instead of "$source": content.

This PR changes the behavior by changing the rule (2) above as follow: if a XML element has multiple children which are all text or cdata nodes, it will use the "$property" syntax instead of "$" property syntax. For the delivery content example, it means that it will always return "$source": content.

## Related Issue

Acrite email editor could not process content containing escape CDATA elements (usually coming from ACS) because the it expects the content to be available in "content.html.$source" property and not "content.html.source.$"

## Motivation and Context

All types of content should be returned consistently (i.e. with same syntax) by the SDK

## How Has This Been Tested?

New unit tests

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

Limited risk of breaking things as we are changing the structure of the returned JSON in some edge cases.

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
