### PR TITLE
NEO-62095: ensure to reload xtk:session

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -1871,6 +1871,11 @@ class Client {
             if (method) methodName = methodNameLC;
         }
         if (!method) {
+            const impls = DomUtil.getAttributeAsString(schema, "implements");
+            if (impls === "xtk:persist" && schemaId !== "xtk:session" && schemaId !== "xtk:persist") {
+                // Ensure xtk:persist is present by loading the xtk:session schema
+                await this.getSchema("xtk:session", "xml", true);
+            }
             await this._methodCache.put(schema);
             method = await that._methodCache.get(methodSchemaId, methodName);
         }

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -621,6 +621,7 @@ describe('ACC Client', function () {
             await client.NLWS.xtkSession.logon();
 
             client._transport.mockReturnValueOnce(Mock.GET_XTK_ALL_SCHEMA_RESPONSE);
+            client._transport.mockReturnValueOnce(Mock.GET_XTK_SESSION_SCHEMA_RESPONSE);
             var sysEnum = await client.getSysEnum("xtk:all:encryptionType");
             expect(sysEnum).toBeUndefined();
         });
@@ -632,6 +633,7 @@ describe('ACC Client', function () {
             await client.NLWS.xtkSession.logon();
 
             client._transport.mockReturnValueOnce(Mock.GET_XTK_ALL_SCHEMA_RESPONSE);
+            client._transport.mockReturnValueOnce(Mock.GET_XTK_SESSION_SCHEMA_RESPONSE);
             var sysEnum = await client.getSysEnum("xtk:all:encryptionType");
             expect(sysEnum).toBeUndefined();
         });
@@ -642,6 +644,7 @@ describe('ACC Client', function () {
             await client.NLWS.xtkSession.logon();
 
             client._transport.mockReturnValueOnce(Mock.GET_XTK_ALL_SCHEMA_RESPONSE);
+            client._transport.mockReturnValueOnce(Mock.GET_XTK_SESSION_SCHEMA_RESPONSE);
             var sysEnum = await client.getSysEnum("xtk:all:encryptionType");
             expect(sysEnum).toBeUndefined();
         });
@@ -660,6 +663,7 @@ describe('ACC Client', function () {
             client._transport.mockReturnValueOnce(Mock.LOGON_RESPONSE);
             await client.NLWS.xtkSession.logon();
             client._transport.mockReturnValueOnce(Mock.GET_XTK_ALL_SCHEMA_RESPONSE);
+            client._transport.mockReturnValueOnce(Mock.GET_XTK_SESSION_SCHEMA_RESPONSE);
             await client.getSysEnum("xtk:all:encryptionType"); // cache schema before setting invalid representation
             client._representation = "Dummy";
             await expect(client.getSysEnum("xtk:all:encryptionType")).rejects.toMatchObject({ errorCode: "SDK-000004" });
@@ -845,6 +849,7 @@ describe('ACC Client', function () {
             await client.NLWS.xtkSession.logon();
 
             client._transport.mockReturnValueOnce(Mock.GET_XTK_ALL_SCHEMA_RESPONSE);
+            client._transport.mockReturnValueOnce(Mock.GET_XTK_SESSION_SCHEMA_RESPONSE);
             client._transport.mockReturnValueOnce(Mock.GET_XTK_ALL_TYPES_RESPONSE);
 
             const element = { "@type": "element", "@xtkschema": "nms:recipient" };          // @xtkschema needed to determine root name
@@ -878,6 +883,7 @@ describe('ACC Client', function () {
             await client.NLWS.xtkSession.logon();
 
             client._transport.mockReturnValueOnce(Mock.GET_XTK_ALL_SCHEMA_RESPONSE);
+            client._transport.mockReturnValueOnce(Mock.GET_XTK_SESSION_SCHEMA_RESPONSE);
             client._transport.mockReturnValueOnce(Mock.GET_XTK_ALL_TYPES_RESPONSE);
 
             const element = { "@type": "element" };          // @xtkschema needed to determine root name, missing on purpose
@@ -896,6 +902,7 @@ describe('ACC Client', function () {
             await client.NLWS.xtkSession.logon();
 
             client._transport.mockReturnValueOnce(Mock.GET_XTK_ALL_SCHEMA_RESPONSE);
+            client._transport.mockReturnValueOnce(Mock.GET_XTK_SESSION_SCHEMA_RESPONSE);
 
             // unsupported input parameter
             await expect(client.NLWS.xtkAll.unsupportedInput()).rejects.toMatchObject({ errorCode: "SDK-000008" });
@@ -960,6 +967,19 @@ describe('ACC Client', function () {
 
             client._transport.mockReturnValueOnce(Mock.GET_XTK_SESSION_SCHEMA_RESPONSE);
             await expect(client.NLWS.xtkSession.unsupported()).rejects.toMatchObject({ errorCode: "SDK-000009" });
+
+            client._transport.mockReturnValueOnce(Mock.LOGOFF_RESPONSE);
+            await client.NLWS.xtkSession.logoff();
+        });
+
+        it("Should reload session schema when looking for a not existing method", async () => {
+            const client = await Mock.makeClient();
+            client._transport.mockReturnValueOnce(Mock.LOGON_RESPONSE);
+            await client.NLWS.xtkSession.logon();
+
+            client._transport.mockReturnValueOnce(Mock.GET_XTK_ALL_SCHEMA_RESPONSE);
+            client._transport.mockReturnValueOnce(Mock.GET_XTK_SESSION_SCHEMA_RESPONSE);
+            await expect(client.NLWS.xtkAll.Duplicate()).rejects.toMatchObject({ errorCode: "SDK-000009" });
 
             client._transport.mockReturnValueOnce(Mock.LOGOFF_RESPONSE);
             await client.NLWS.xtkSession.logoff();

--- a/test/mock.js
+++ b/test/mock.js
@@ -570,7 +570,7 @@ const GET_XTK_ALL_SCHEMA_RESPONSE = Promise.resolve(`<?xml version='1.0'?>
     <SOAP-ENV:Body>
         <GetEntityIfMoreRecentResponse xmlns='urn:wpp:default' SOAP-ENV:encodingStyle='http://schemas.xmlsoap.org/soap/encoding/'>
             <pdomDoc xsi:type='ns:Element' SOAP-ENV:encodingStyle='http://xml.apache.org/xml-soap/literalxml'>
-                <schema name="all" namespace="xtk" xtkschema="xtk:schema">
+                <schema name="all" namespace="xtk" xtkschema="xtk:schema" implements="xtk:persist">
                     <element name="all"></element>
                     <methods>
                         <method name="AllTypes" static="true">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Ensure that schema xtk:session is loaded when looking for method for a schema which implement xtk:persist.

## Related Issue

In same case the cache does not content anymore the methods of xtk:persist because cache values have expired.
So when calling a method it fails:
```
{
    "name": "CampaignException",
    "message": "400 - Error 16384: SDK-000009 Unknown method 'Duplicate' of schema 'xtk:workflow'. Method 'Duplicate' of schema 'xtk:workflow' not found",
    "statusCode": 400,
    "errorCode": "SDK-000009",
    "faultCode": 16384,
    "faultString": "Unknown method 'Duplicate' of schema 'xtk:workflow'",
    "detail": "Method 'Duplicate' of schema 'xtk:workflow' not found"
}
```

## Motivation and Context

Bug fix

## How Has This Been Tested?

Change expiration value of the cache

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
