### PR TITLE
Support for xtk:dataTransfer:decimalCount enumeration

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -194,14 +194,15 @@ class ArrayMap {
       });
   }
 
-  _push(key, value) {
+  _push(key, value, withoutIndexing) {
       let isNumKey = false;
       if (key) {
         // reserved keyworkds
         const isReserved = key === "_items" || key === "length" || key === "_push" || key === "forEach" || key === "map" || key === "_map" || key === "get" || key === "find" || key === "flatMap" || key === "filter";
 
         // already a child with the name => there's a problem with the schema
-        if (!isReserved && this[key]) throw new Error(`Failed to add element '${key}' to ArrayMap. There's already an item with the same name`);
+        if (!isReserved && this[key]) 
+          throw new Error(`Failed to add element '${key}' to ArrayMap. There's already an item with the same name`);
 
         // Set key as a enumerable property, so that elements can be accessed by key, 
         // but also iterated on with a for ... in loop
@@ -218,7 +219,7 @@ class ArrayMap {
         }
       }
 
-      if (!isNumKey) {
+      if (!withoutIndexing && !isNumKey) {
         // Set the index property so that items can be accessed by array index.
         // However, make it non-enumerable to make sure indexes do not show up in a for .. in loop
         Object.defineProperty(this, this._items.length, {

--- a/test/application.test.js
+++ b/test/application.test.js
@@ -700,6 +700,43 @@ describe('Application', () => {
                     expect(enumeration).toBeFalsy();
                 });
             });
+
+            it("Should support numeric enumeration with implicit value", async () => {
+                // Example in xtk:dataTransfer:decimalCount
+                const client = await Mock.makeClient();
+                client._transport.mockReturnValueOnce(Mock.LOGON_RESPONSE);
+                await client.NLWS.xtkSession.logon();
+                client._transport.mockReturnValueOnce(Promise.resolve(`<?xml version='1.0'?>
+                <SOAP-ENV:Envelope xmlns:xsd='http://www.w3.org/2001/XMLSchema' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xmlns:ns='urn:wpp:default' xmlns:SOAP-ENV='http://schemas.xmlsoap.org/soap/envelope/'>
+                <SOAP-ENV:Body>
+                    <GetEntityIfMoreRecentResponse xmlns='urn:wpp:default' SOAP-ENV:encodingStyle='http://schemas.xmlsoap.org/soap/encoding/'>
+                        <pdomDoc xsi:type='ns:Element' SOAP-ENV:encodingStyle='http://xml.apache.org/xml-soap/literalxml'>
+                            <schema name="dataTransfer" namespace="xtk" xtkschema="xtk:schema">
+                                <enumeration name="decimalCount" basetype="short">
+                                    <value value="-1" name="all" label="All"/>
+                                    <value name="0"/>
+                                    <value name="1"/>
+                                    <value name="2"/>
+                                    <value name="3"/>
+                                    <value name="4"/>
+                                    <value name="5"/>
+                                    <value name="6"/>
+                                    <value name="7"/>
+                                    <value name="8"/>
+                                    <value name="9"/>
+                                </enumeration>
+                            </schema>
+                        </pdomDoc>
+                    </GetEntityIfMoreRecentResponse>
+                </SOAP-ENV:Body>
+                </SOAP-ENV:Envelope>`));
+                const enumeration = await client.application.getSysEnum("decimalCount", "xtk:dataTransfer");
+                expect(enumeration.label).toBe("DecimalCount");
+                const values = enumeration.values;
+                expect(values["all"].value).toBe(-1)
+                expect(values["0"].value).toBe(0)
+                expect(values["1"].value).toBe(1)
+            });
         });
 
         describe("Keys", () => {


### PR DESCRIPTION
## Description

Some enumerations such as xtk:dataTransfer:decimalCount are a little bit special.
* They are of numeric type (baseType=short in this case)
* They have several enum values for which the "value" is not defined (only "name" is defined)
* The "name" property of enumeration values may be a stringified number (ex: "0")

This cause a problem loading schemas since enumeration values are indexed in an array map as both a map (indexed by enum name) and as an array (indexed by the order of apperance of value elements). 
In this example, the first value (with name "all") is indexed with index 0 (as it is the first one), and the second value is indexed with name "0" which collides with the previous and causes an error.

```
<enumeration name="decimalCount" basetype="short">
    <value value="-1" name="all" label="All"/>
    <value name="0"/>
    <value name="1"/>
    <value name="2"/>
    <value name="3"/>
    <value name="4"/>
    <value name="5"/>
    <value name="6"/>
    <value name="7"/>
    <value name="8"/>
    <value name="9"/>
  </enumeration>
```

The fix consists in detecting such enumerations and only index by name.

## How Has This Been Tested?

Unit tests

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
