### PR TITLE
NEO-54340: Handle translatedDefault element of XTK schemas

### DIFF
--- a/src/application.js
+++ b/src/application.js
@@ -652,14 +652,22 @@ class XtkSchemaNode {
                 this.expr = EntityAccessor.getAttributeAsString(child, "expr");
                 this.isCalculated = false;
             }
-            if (child.tagName === "default") {
+            if (child.tagName === "default" || child.tagName === "translatedDefault") {
                 if(this.unbound) {
                     // Default value for a collection of elements
                     const xml = DomUtil.parse(`<xml>${child.textContent}</xml>`);
                     const json = DomUtil.toJSON(xml);
-                    this.default = XtkCaster.asArray(json[this.name]);
+                    if(child.tagName === "translatedDefault") {
+                        this.translatedDefault = XtkCaster.asArray(json[this.name]);
+                    } else {
+                        this.default = XtkCaster.asArray(json[this.name]);
+                    }
                 } else {
-                    this.default = child.textContent;
+                    if(child.tagName === "translatedDefault") {
+                        this.translatedDefault = child.textContent;
+                    } else {
+                        this.default = child.textContent;
+                    }
                 }
             }
         }

--- a/test/application.test.js
+++ b/test/application.test.js
@@ -2096,7 +2096,7 @@ describe('Application', () => {
                 expect(node).toMatchObject({ name:"period", childrenCount:0, default: "\"m_abDay='7' m_abDay[0]='0' m_abDay[1]='0'\"" });
             });
 
-            it("Should extract translatedDefault", async () => {
+            it("Should extract translatedDefault attribute", async () => {
                 var xml = DomUtil.parse(`<schema namespace='xtk' name='workflow'>
                     <element name='workflow' label='Workflow'>
                         <element name="delivery" label="Delivery">
@@ -2112,6 +2112,37 @@ describe('Application', () => {
 
                 var node = await schema.root.findNode("delivery/transitions/done/@label");
                 expect(node).toMatchObject({ name:"@label", childrenCount:0, translatedDefault: "'Ok'" });
+            });
+
+            it("Should extract translatedDefault element", async () => {
+                var xml = DomUtil.parse(`<schema namespace='xtk' name='workflow'>
+                    <element name='workflow' label='Workflow'>
+                        <element name="extract" label="Split">
+                            <element label="Transitions" name="transitions" xml="true">
+                                <element name="extractOutput" ordered="true" template="nms:workflow:extractOutput" unbound="true">
+                                     <translatedDefault>&lt;extractOutput enabled="true" label="Segment" name="subSet" &gt;
+                                     &lt;limiter type="percent" percent="10" random="true"/&gt;
+                                     &lt;filter enabled="true"/&gt;
+                                     &lt;/extractOutput&gt;</translatedDefault>
+                                </element>
+                            </element>
+                        </element>
+                    </element>
+                </schema>`);
+                var schema = newSchema(xml);
+
+                var node = await schema.root.findNode("extract/transitions/extractOutput");
+                expect(node).toMatchObject(
+                    { translatedDefault: [
+                        {
+                            enabled: "true", name:"subSet", 
+                            limiter: { 
+                                type: 'percent',
+                                percent: '10',
+                                random: 'true'
+                            }
+                        }] 
+                    });
             });
 
         });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Handle a new schema item translatedDefault. Required to implement workflow split activity

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Handle an element schema not taken in account.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Required to implement split activity.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit test included in the PR.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
