### PR TITLE
NEO-63455: allow duplicated enum values

### DIFF
--- a/src/application.js
+++ b/src/application.js
@@ -1224,7 +1224,9 @@ class XtkSchema extends XtkSchemaNode {
          this.enumerations = new ArrayMap();
          for (var child of EntityAccessor.getChildElements(xml, "enumeration")) {
              const e = new XtkEnumeration(this.id, child);
-             this.enumerations._push(e.shortName, e);
+             if (this.enumerations.get(e.shortName) === undefined) {
+                 this.enumerations._push(e.shortName, e);
+             }
          }
      }
 

--- a/test/application.test.js
+++ b/test/application.test.js
@@ -345,6 +345,19 @@ describe('Application', () => {
                 expect(enumerations[1].label).toBe("Status code");
             });
 
+            it("Should support duplicate  enumerations", () => {
+                var xml = DomUtil.parse(`<schema namespace='nms' name='recipient'>
+                                            <enumeration name="duplicated" basetype="byte"/>
+                                            <enumeration name="duplicated" basetype="byte"/>
+                                            <element name='recipient' label='Recipients'></element>
+                                        </schema>`);
+                var schema = newSchema(xml);
+                var enumerations = schema.enumerations;
+                expect(enumerations.duplicated.dummy).toBeFalsy();
+                expect(enumerations[0].label).toBe("Duplicated");
+                expect(enumerations[1]).toBeUndefined();
+            });
+
             it("Should test images", () => {
                 var xml = DomUtil.parse(`<schema namespace='nms' name='recipient'>
                                             <enumeration name="gender" basetype="byte">


### PR DESCRIPTION
Allow duplicated enum values in schemas

## Description

Fix issue in temp schema generated in the workflow with an enrichement activity
An example of a schema taht contents a duplicated enum value e029d4880:
```xml
<extension xmlns="urn:xtk:queryDef" label="Enrichment : get last 2 products bought" mappingType="sql" name="enrich" namespace="temp">
	<enumeration basetype="string" name="e029d4880">
		<value desc="Computer" label="Computer" name="computer" value="computer"/>
		<value desc="Watch" label="Watch" name="watch" value="watch"/>
	</enumeration>
	<enumeration basetype="string" name="e029d4880">
		<value desc="Computer" label="Computer" name="computer" value="computer"/>
		<value desc="Watch" label="Watch" name="watch" value="watch"/>
	</enumeration>
	<element advanced="false" label="Enrichment : get last 2 products bought" name="enrich" pkSequence="" sqltable="grp5170" unbound="false">
		<compute-string expr=""/>
		<key internal="true" name="internal">
			<keyfield xpath="@id"/>
		</key>
		<attribute advanced="false" belongsTo="@id" label="Primary key" length="0" name="id" notNull="false" sql="true" sqlname="iId" type="long" xml="false"/>
		<element advanced="false" belongsTo="purchase1" label="Retail - Purchases" length="0" name="purchase1" notNull="false" type="" unbound="false">
			<attribute advanced="false" belongsTo="purchase1/product/brand/@name" label="Name (Product/Brand)" length="255" name="name" notNull="false" sql="true" sqlname="sPurchase1Name" type="string" xml="false"/>
			<attribute advanced="false" belongsTo="purchase1/product/@category" enum="temp:enrich:e029d4880" label="Category (Product)" length="255" name="category" notNull="false" sql="true" sqlname="sPurchase1Category" type="string" xml="false"/>
		</element>
		<element advanced="false" belongsTo="purchase2" label="Retail - Purchases" length="0" name="purchase2" notNull="false" type="" unbound="false">
			<attribute advanced="false" belongsTo="purchase2/product/brand/@name" label="Name (Product/Brand)" length="255" name="name" notNull="false" sql="true" sqlname="sPurchase2Name" type="string" xml="false"/>
			<attribute advanced="false" belongsTo="purchase2/product/@category" enum="temp:enrich:e029d4880" label="Category (Product)" length="255" name="category" notNull="false" sql="true" sqlname="sPurchase2Category" type="string" xml="false"/>
		</element>
		<element advanced="false" externalJoin="false" label="Targeting dimension" name="target" revLink="" target="nms:recipient" type="link" unbound="false">
			<join xpath-dst="@id" xpath-src="@id"/>
		</element>
	</element>
</extension>
```

## Related Issue

Issue found while testing web ui  https://jira.corp.adobe.com/browse/NEO-63455
The issue causes the display of audience properties to fail.
this fix is temporary and it will be reverted when the issue on backend side will be fixed.
The ticket opened to fix the duplicated values on acc backend side is https://jira.corp.adobe.com/browse/NEO-63689

## Motivation and Context

Able to create the schema object in the sdk  even with duplicated enumerations values to able to see schema in Acc web ui.
For information in the client console the duplication does not caused any issue.

## How Has This Been Tested?

a unit test
tested in acc web ui

## Screenshots (if appropriate):
error in console.log:
```
Error: Failed to add element 'e029d4880' to ArrayMap. There's already an item with the same name
    at ArrayMap._push (util.js:205:1)
    at new XtkSchema (application.js:1227:1)
    at newSchema (application.js:52:1)
    at Application._getSchema (application.js:1414:1)
    at async SchemaCache.getSchema (application.js:96:1)
    at async edit.tsx:418:1
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
