### PR TITLE
ofImsBearerToken connection method now has the ability to return session info. As this method is not yet available on the server, some workaround is used involving mulitple API calls

### DIFF
--- a/src/application.js
+++ b/src/application.js
@@ -1365,9 +1365,11 @@ class Application {
              * The server version, formatted as major.minor.servicePack (ex: 8.2.10)
              * @type {string}
              */
-            this.version = EntityAccessor.getAttributeAsString(serverInfo, "majNumber") + "." +
-                           EntityAccessor.getAttributeAsString(serverInfo, "minNumber") + "." +
-                           EntityAccessor.getAttributeAsString(serverInfo, "servicePack");
+            const majNumber = EntityAccessor.getAttributeAsString(serverInfo, "majNumber");
+            const minNumber = EntityAccessor.getAttributeAsString(serverInfo, "minNumber");
+            const servicePack = EntityAccessor.getAttributeAsString(serverInfo, "servicePack");
+            if (majNumber && minNumber && servicePack)
+                this.version = majNumber + "." + minNumber + "." + servicePack;
             /**
              * The Campaign instance name
              * @type {string}

--- a/src/client.js
+++ b/src/client.js
@@ -1418,7 +1418,7 @@ class Client {
         const userInfo = DomUtil.findElement(sessionInfo, "userInfo");
         if (!userInfo)
             throw CampaignException.UNEXPECTED_SOAP_RESPONSE(soapCall, `userInfo structure missing`);
-        var pack = DomUtil.getFirstChildElement(userInfo, "installed-package");
+        let pack = DomUtil.getFirstChildElement(userInfo, "installed-package");
         while (pack) {
             const name = `${DomUtil.getAttributeAsString(pack, "namespace")}:${DomUtil.getAttributeAsString(pack, "name")}`;
             this._installedPackages[name] = name;
@@ -1427,8 +1427,8 @@ class Client {
     }
 
     async _fetchSessionInfo() {
-        const userInfoPromise = this.NLWS.xml.xtkSession.getUserInfo()
-        const testPromise = this.test()
+        const userInfoPromise = this.NLWS.xml.xtkSession.getUserInfo();
+        const testPromise = this.test();
         const all = Promise.all([userInfoPromise, testPromise]);
         const values = await all;
 
@@ -1455,7 +1455,6 @@ class Client {
         if (!buildNumber)
             throw CampaignException.UNEXPECTED_SOAP_RESPONSE(undefined, `buildNumber structure missing for both /r/test and NmsServer_LastPostUpgrade option`);
         serverInfo.setAttribute("buildNumber", buildNumber);
-        console.log(DomUtil.toXMLString(sessionInfo))
         return sessionInfoRoot;
     }
 

--- a/src/client.js
+++ b/src/client.js
@@ -1412,6 +1412,53 @@ class Client {
         delete this._observabilityContext.session;
     }
 
+    _updateSessionInfo(sessionInfo, soapCall) {
+        this._sessionInfo = sessionInfo;
+        this._installedPackages = {};
+        const userInfo = DomUtil.findElement(sessionInfo, "userInfo");
+        if (!userInfo)
+            throw CampaignException.UNEXPECTED_SOAP_RESPONSE(soapCall, `userInfo structure missing`);
+        var pack = DomUtil.getFirstChildElement(userInfo, "installed-package");
+        while (pack) {
+            const name = `${DomUtil.getAttributeAsString(pack, "namespace")}:${DomUtil.getAttributeAsString(pack, "name")}`;
+            this._installedPackages[name] = name;
+            pack = DomUtil.getNextSiblingElement(pack);
+        }
+    }
+
+    async _fetchSessionInfo() {
+        const userInfoPromise = this.NLWS.xml.xtkSession.getUserInfo()
+        const testPromise = this.test()
+        const all = Promise.all([userInfoPromise, testPromise]);
+        const values = await all;
+
+        const sessionInfo = DomUtil.newDocument("sessionInfo");
+        const sessionInfoRoot = sessionInfo.documentElement;
+        const userInfo = sessionInfo.importNode(values[0], true);
+        sessionInfoRoot.appendChild(userInfo);
+        const serverInfo = sessionInfo.createElement('serverInfo');
+        sessionInfoRoot.appendChild(serverInfo);
+        const test = values[1];
+        if (test["date"])
+            serverInfo.setAttribute("serverDate", new Date(Date.parse(test["date"])).toISOString());
+        serverInfo.setAttribute("instanceName", test["instance"]);
+        if (test["version"]) {
+            const versionParts = test["version"].split(".");
+            serverInfo.setAttribute("majNumber", versionParts[0]);
+            serverInfo.setAttribute("minNumber", versionParts[1]);
+            serverInfo.setAttribute("servicePack", versionParts[2]);
+        }
+        let buildNumber = test["build"];
+        // Alternative method to get the build number (not available unless server has been upgraded at least once)
+        if (!buildNumber)
+            buildNumber = await this.getOption("NmsServer_LastPostUpgrade", false);
+        if (!buildNumber)
+            throw CampaignException.UNEXPECTED_SOAP_RESPONSE(undefined, `buildNumber structure missing for both /r/test and NmsServer_LastPostUpgrade option`);
+        serverInfo.setAttribute("buildNumber", buildNumber);
+        console.log(DomUtil.toXMLString(sessionInfo))
+        return sessionInfoRoot;
+    }
+
     /**
      * Login to an instance
      */
@@ -1466,8 +1513,18 @@ class Client {
             that._sessionToken = "";
             that._securityToken = "";
             that._bearerToken = credentials._bearerToken;
-            that._onLogon();
-            return Promise.resolve();
+
+            // With IMS Bearer token, we do not call the Logon or BearerTokenLogon method any more. As a consequence,
+            // we do not have the user and server information returned by those methods, so we need to get the corresponding
+            // information by other means
+            if (!this._connectionParameters._options.sessionInfo) {
+                that._onLogon();
+                return Promise.resolve();
+            }
+            return that._fetchSessionInfo().then((sessionInfo) => {
+                that._updateSessionInfo(sessionInfo, undefined);
+                that._onLogon();
+            });
         }
         else if (credentials._type == "UserPassword" || credentials._type == "BearerToken") {
             const soapCall = that._prepareSoapCall("xtk:session", credentials._type === "UserPassword" ? "Logon" : "BearerTokenLogon", true, false, this._connectionParameters._options.extraHttpHeaders);
@@ -1493,19 +1550,8 @@ class Client {
             }
             return this._makeSoapCall(soapCall).then(function() {
                 const sessionToken = soapCall.getNextString();
-
-                that._sessionInfo = soapCall.getNextDocument();
-                that._installedPackages = {};
-                const userInfo = DomUtil.findElement(that._sessionInfo, "userInfo");
-                if (!userInfo)
-                    throw CampaignException.UNEXPECTED_SOAP_RESPONSE(soapCall, `userInfo structure missing`);
-                var pack = DomUtil.getFirstChildElement(userInfo, "installed-package");
-                while (pack) {
-                    const name = `${DomUtil.getAttributeAsString(pack, "namespace")}:${DomUtil.getAttributeAsString(pack, "name")}`;
-                    that._installedPackages[name] = name;
-                    pack = DomUtil.getNextSiblingElement(pack);
-                }
-
+                const sessionInfo = soapCall.getNextDocument();
+                that._updateSessionInfo(sessionInfo, soapCall);
                 const securityToken = soapCall.getNextString();
                 soapCall.checkNoMoreArgs();
                 // Sanity check: we should have both a session token and a security token.


### PR DESCRIPTION
## Description

When using the ofUserAndPassword or ofBearerToken logon methods, a session object is returned containing information about the server and the user. This is not available when using the new ofImsBearerToken because this type of authentication uses a Bearer token obtained outside of Campaign and does not actually perform any SOAP call.

## Related Issue

The issue is that some clients of the SDK expect to have this user and session information. While there's no API for this yet, this PR implements a workaround to get most of the information. This workaround involves multiple API calls.

it's not active by default, one must use the "sessionInfo" boolean option to activate

      const connectionParameters = sdk.ConnectionParameters.ofImsBearerToken(utils.url, 'ey...', { sessionInfo: true });

## Motivation and Context

Backwards compatibility with other connection methods

## How Has This Been Tested?

Unit tests
Test on a real instance

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
