### PR TITLE
fix bug in uploadAemAsset when used through browser

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -657,13 +657,22 @@ const fileUploader = (client) => {
                 if(headers['Authorization'] === undefined || headers['Authorization'] === '' || headers['Authorization'] === 'null') {
                     throw 'Bearer token is missing';
                 }
+                // Serialize json data (required for fetch)
+                const jsonData = JSON.stringify({
+                    'assetDownloadUrl': assetDownloadUrl
+                });
 
-                const response = await client._makeHttpCall({
+                var response = await client._makeHttpCall({
                     url: url,
                     method: 'POST',
-                    data: {assetDownloadUrl: assetDownloadUrl},
+                    data: jsonData,
                     headers: headers
                 });
+
+                // response is returned as string when using fetch(in browser)
+                // & returned as json using axios(nodejs).
+                if(typeof response === 'string')
+                  response = JSON.parse(response);
                 if(response.publishedURL)
                   return response;
                 else


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
The change done in https://github.com/adobe/acc-js-sdk/pull/91 didn't work correctly when sdk is used inside browser.
Noticed that we have two different implementations of transport layer - axios(node) & fetch(browser).
I didn't knew that earlier & had only tested with a nodejs app.
Two issues -

- Axios automatically serialized json body but fetch doesn't.
- Axios handled to return json response while fetch handled for string response.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
ttps://github.com/adobe/acc-js-sdk/pull/91
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
same as linked PR
## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
