### PR TITLE
add tests for string response in uploadAemAsset

### DIFF
--- a/test/client.test.js
+++ b/test/client.test.js
@@ -1756,11 +1756,11 @@ describe('ACC Client', function () {
             await client.NLWS.xtkSession.logon();
 
             const mockResponse = {
-                "publishedURL" : "http://trk-inst-xyz.campaign.adobe.com/res/trk-inst/409afb8798180a36591456e152b6c406.jpeg"
+                "publishedURL" : "http://trk-inst-xyz.camp.adobe.com/res/trk-inst/409afb8798180a36591456e152b6c406.jpeg"
             };
             client._bearerToken = 'Bearer 1234567890';
             client._transport.mockReturnValueOnce(mockResponse);
-            const response = await client.fileUploader.uploadAemAsset("https://author-p74953-e183988-cmstg.adobeaemcloud.com/adobe/repository/content/dam/projects/children-kids-group-eating-ice-cream-funny-party-72701973%20%281%29%20%2812%29%20%282%29%20%283%29.jpg;api=block_download");
+            const response = await client.fileUploader.uploadAemAsset("https://author-stg.aem.adobe.com/adobe/repository/content/dam/projects/children-kids-group-eating-ice-cream-funny-party-72701973%20%281%29%20%2812%29%20%282%29%20%283%29.jpg;api=block_download");
             expect(response).toBe(mockResponse);
 
             client._transport.mockReturnValueOnce(Mock.LOGOFF_RESPONSE);
@@ -1773,7 +1773,7 @@ describe('ACC Client', function () {
             client._transport.mockReturnValueOnce(Mock.LOGON_RESPONSE);
             await client.NLWS.xtkSession.logon();
 
-            await (client.fileUploader.uploadAemAsset("https://author-p74953-e183988-cmstg.adobeaemcloud.com/adobe/repository/content/dam/projects/children-kids-group-eating-ice-cream-funny-party-72701973%20%281%29%20%2812%29%20%282%29%20%283%29.jpg;api=block_download"))
+            await (client.fileUploader.uploadAemAsset("https://author-stg.aem.adobe.com/adobe/repository/content/dam/projects/children-kids-group-eating-ice-cream-funny-party-72701973%20%281%29%20%2812%29%20%282%29%20%283%29.jpg;api=block_download"))
                   .catch( e => { expect(e).toMatchObject(CampaignException.AEM_ASSET_UPLOAD_FAILED('Bearer token is missing'))});
 
             client._transport.mockReturnValueOnce(Mock.LOGOFF_RESPONSE);
@@ -1791,7 +1791,7 @@ describe('ACC Client', function () {
             client._transport.mockReturnValueOnce(mockResponse);
             client._bearerToken = 'Bearer 1234567890';
 
-            await (client.fileUploader.uploadAemAsset("https://author-p74953-e183988-cmstg.adobeaemcloud.com/adobe/repository/content/dam/projects/children-kids-group-eating-ice-cream-funny-party-72701973%20%281%29%20%2812%29%20%282%29%20%283%29.jpg;api=block_download"))
+            await (client.fileUploader.uploadAemAsset("https://author-stg.aem.adobe.com/adobe/repository/content/dam/projects/children-kids-group-eating-ice-cream-funny-party-72701973%20%281%29%20%2812%29%20%282%29%20%283%29.jpg;api=block_download"))
                   .catch( e => { console.log(e); expect(e).toMatchObject(CampaignException.AEM_ASSET_UPLOAD_FAILED('Publishing failed'))});
 
             client._transport.mockReturnValueOnce(Mock.LOGOFF_RESPONSE);
@@ -1814,13 +1814,32 @@ describe('ACC Client', function () {
               client._bearerToken = 'Bearer 1234567890';
 
             var ex = CampaignException.AEM_ASSET_UPLOAD_FAILED('The requested content does not exist', 400);
-            await (client.fileUploader.uploadAemAsset("https://author-p74953-e183988-cmstg.adobeaemcloud.com/adobe/repository/content/dam/projects/children-kids-group-eating-ice-cream-funny-party-72701973%20%281%29%20%2812%29%20%282%29%20%283%29.jpg;api=block_download"))
+            await (client.fileUploader.uploadAemAsset("https://author-stg.aem.adobe.com/adobe/repository/content/dam/projects/children-kids-group-eating-ice-cream-funny-party-72701973%20%281%29%20%2812%29%20%282%29%20%283%29.jpg;api=block_download"))
                     .catch( e => { console.log(e); expect(e).toMatchObject(ex)});
 
             client._transport.mockReturnValueOnce(Mock.LOGOFF_RESPONSE);
             await client.NLWS.xtkSession.logoff();
         });
 
+        // Case 5: transport layer returns response as string instead of json when sdk
+        // used as package inside browser(Fetch API is used in browser while axios in node).
+        it("Should return correct response", async () => {
+            const client = await Mock.makeClient();
+            client._transport.mockReturnValueOnce(Mock.LOGON_RESPONSE);
+            await client.NLWS.xtkSession.logon();
+
+            const mockResponse = {
+                "publishedURL" : "http://trk-inst-xyz.camp.adobe.com/res/trk-inst/409afb8798180a36591456e152b6c406.jpeg"
+            };
+            const mockResponseString = JSON.stringify(mockResponse);
+            client._bearerToken = 'Bearer 1234567890';
+            client._transport.mockReturnValueOnce(mockResponseString);
+            const response = await client.fileUploader.uploadAemAsset("https://author-stg.aem.adobe.com/adobe/repository/content/dam/projects/children-kids-group-eating-ice-cream-funny-party-72701973%20%281%29%20%2812%29%20%282%29%20%283%29.jpg;api=block_download");
+            expect(response).toMatchObject(mockResponse);
+
+            client._transport.mockReturnValueOnce(Mock.LOGOFF_RESPONSE);
+            await client.NLWS.xtkSession.logoff();
+        });
     });
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
add test for code added in https://github.com/adobe/acc-js-sdk/pull/93
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/adobe/acc-js-sdk/pull/93
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
It makes client.js test coverage back to 100%
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
npm i
npm run unit-tests
## Screenshots (if appropriate):

![image](https://github.com/adobe/acc-js-sdk/assets/34598795/5c46651a-fa5c-4631-b29c-b0f0e8e3f7f3)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
