### PR TITLE
NEO-62405: set description localization id when description is empty

### DIFF
--- a/src/application.js
+++ b/src/application.js
@@ -62,7 +62,10 @@ function propagateImplicitValues(xtkDesc, labelOnly) {
         // Force first letter as uppercase
         xtkDesc.label = xtkDesc.label.substring(0, 1).toUpperCase() + xtkDesc.label.substring(1);
     }
-    if (!labelOnly && !xtkDesc.description) xtkDesc.description = xtkDesc.label;
+    if (!labelOnly && !xtkDesc.description) {
+        xtkDesc.description = xtkDesc.label;
+        xtkDesc.descriptionLocalizationId = xtkDesc.labelLocalizationId;
+    };
 }
 
 // ========================================================================================

--- a/test/application.test.js
+++ b/test/application.test.js
@@ -2400,7 +2400,15 @@ describe('Application', () => {
             expect(root.labelLocalizationId).toBe('nms__recipient__e____recipient__@label');
             expect(root.descriptionLocalizationId).toBe('nms__recipient__e____recipient__@desc');
           });
-
+            
+          it("root node should have the label localization id when label exist but description does not exist", () => {
+            const xml = DomUtil.parse("<schema namespace='nms' name='recipient'><element name='recipient' label='Recipients' /></schema>");
+            const schema = newSchema(xml);
+            const root = schema.root;
+            expect(root.labelLocalizationId).toBe('nms__recipient__e____recipient__@label');
+            expect(root.descriptionLocalizationId).toBe('nms__recipient__e____recipient__@label');
+          });
+            
           it("child node should have a correct label localization id", () => {
             const xml = DomUtil.parse("<schema namespace='nms' name='recipient'><element name='lib' label='library' desc='library'/><element name='recipient' label='Recipients'/></schema>");
             const schema = newSchema(xml);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

set description localization id equals to label localization id when description is empty in source schema and is set to label 

## Related Issue
in web ui the description of attributes without description in the source schema is displayed in English even if the language is not English

## Motivation and Context

it fixes attributes description localization

## How Has This Been Tested?

unit test
test in web ui with a modified version of the SDK

## Screenshots (if appropriate):
Before:
![image](https://github.com/adobe/acc-js-sdk/assets/108726886/7203a8d6-16b5-411f-8fdc-5b8a3c0c9480)
After:
![image](https://github.com/adobe/acc-js-sdk/assets/108726886/ba1e0c57-fec6-4f36-bf59-3bf95b2c5cb1)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
