### PR TITLE
NEO-67140: fixing schemaName when the queryDef result is empty

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -1345,7 +1345,7 @@ class Client {
             else if (operation == "select" && emptyResult) {
                 const querySchemaId = EntityAccessor.getAttributeAsString(object, "schema");
                 const index = querySchemaId.indexOf(':');
-                const querySchemaName = querySchemaId.substr(index + 1);
+                const querySchemaName = querySchemaId.substr(index + 1).replace(':', '_');
                 outputParams[1].value[querySchemaName] = [];
             }
         }

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -1334,6 +1334,80 @@ describe('ACC Client', function () {
             expect(extAccount).toEqual({ extAccount: [] });
         });
 
+        it("select with empty result - temporary schema", async () => {
+          const client = await Mock.makeClient();
+          client._transport.mockReturnValueOnce(Mock.LOGON_RESPONSE);
+          await client.NLWS.xtkSession.logon();
+
+          client._transport.mockReturnValueOnce(Mock.GET_XTK_QUERY_SCHEMA_RESPONSE);
+
+          client._transport.mockReturnValueOnce(Promise.resolve(`<?xml version='1.0'?>
+          <SOAP-ENV:Envelope xmlns:xsd='http://www.w3.org/2001/XMLSchema' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xmlns:ns='urn:xtk:queryDef' xmlns:SOAP-ENV='http://schemas.xmlsoap.org/soap/envelope/'>
+            <SOAP-ENV:Body>
+              <ExecuteQueryResponse xmlns='urn:xtk:queryDef' SOAP-ENV:encodingStyle='http://schemas.xmlsoap.org/soap/encoding/'>
+                <pdomOutput xsi:type='ns:Element' SOAP-ENV:encodingStyle='http://xml.apache.org/xml-soap/literalxml'>
+                  <workflow_1047471_query2_result-collection/>
+                </pdomOutput>
+              </ExecuteQueryResponse>
+          </SOAP-ENV:Body></SOAP-ENV:Envelope>`));
+
+          var queryDef = {
+              "schema": "temp:workflow:1047471_query2_result",
+              "operation": "select",
+              "select": {
+                  "node": [
+                      { "expr": "@id" },
+                      { "expr": "@name" }
+                  ]
+              }
+          };
+
+          // Select should return empty array
+          var query = client.NLWS.xtkQueryDef.create(queryDef);
+          var temp = await query.executeQuery();
+          expect(temp).toEqual({ 'workflow_1047471_query2_result': [] });
+        });
+
+        it("select with results - temporary schema", async () => {
+          const client = await Mock.makeClient();
+          client._transport.mockReturnValueOnce(Mock.LOGON_RESPONSE);
+          await client.NLWS.xtkSession.logon();
+
+          client._transport.mockReturnValueOnce(Mock.GET_XTK_QUERY_SCHEMA_RESPONSE);
+
+          client._transport.mockReturnValueOnce(Promise.resolve(`<?xml version='1.0'?>
+          <SOAP-ENV:Envelope xmlns:xsd='http://www.w3.org/2001/XMLSchema' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xmlns:ns='urn:xtk:queryDef' xmlns:SOAP-ENV='http://schemas.xmlsoap.org/soap/envelope/'>
+            <SOAP-ENV:Body>
+              <ExecuteQueryResponse xmlns='urn:xtk:queryDef' SOAP-ENV:encodingStyle='http://schemas.xmlsoap.org/soap/encoding/'>
+                <pdomOutput xsi:type='ns:Element' SOAP-ENV:encodingStyle='http://xml.apache.org/xml-soap/literalxml'>
+                  <workflow_1047471_query2_result-collection>
+                    <workflow_1047471_query3_result _keyfield0="1195" id="1195">
+                      <target _cs="rner20 joewar (joewarner20@fake_domain.com)"></target>
+                    </workflow_1047471_query3_result>
+                    <workflow_1047471_query3_result _keyfield0="1198" id="1198">
+                      <target _cs="aliberte23 troyla (troylaliberte23@fake_domain.com)"></target>
+                    </workflow_1047471_query3_result>
+                  </workflow_1047471_query2_result-collection>
+                </pdomOutput>
+              </ExecuteQueryResponse>
+          </SOAP-ENV:Body></SOAP-ENV:Envelope>`));
+
+          var queryDef = {
+              "schema": "temp:workflow:1047471_query2_result",
+              "operation": "select",
+              "select": {
+                  "node": [
+                      { "expr": "@id" },
+                      { "expr": "target"}
+                  ]
+              }
+          };
+
+          var query = client.NLWS.xtkQueryDef.create(queryDef);
+          var temp = await query.executeQuery();
+          expect(temp.workflow_1047471_query3_result.length).toBe(2);
+        });
+
         it("getIfExists with a result of exactly one element", async () => {
             const client = await Mock.makeClient();
             client._transport.mockReturnValueOnce(Mock.LOGON_RESPONSE);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The QueryDef result for temporary schema is incorrect for empty results:
In case of a workflow we have the output : { 'workflow:1047471_query2_result': [] } 

instead of { 'workflow_1047471_query2_result': [] }

## Related Issue
[NEO-67140](https://jira.corp.adobe.com/browse/NEO-67140)

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

The change is fixing an issue when doing a preview of a workflow transition 

## How Has This Been Tested?
- This has been test manually
- Unit test is added to the PR

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
