### PR TITLE
Adding class name to uploader frame for unique identification

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -606,8 +606,10 @@ const fileUploader = (client) => {
                             throw okay;
                         }
                         const iframe = document.createElement('iframe');
+                        iframe.style.display = 'block';
                         iframe.style.height = 0;
                         iframe.style.width = 0;
+                        iframe.className = 'fileUploaderFrame';
                         document.controller = { // Written to  support https://git.corp.adobe.com/Campaign/ac/blob/v6-master/nl/datakit/nl/jsp/uploadFile.jsp
                             uploadFileCallBack: async (data) => {
                                 if (!data || data.length !== 1) {

--- a/src/client.js
+++ b/src/client.js
@@ -609,7 +609,9 @@ const fileUploader = (client) => {
                         iframe.style.display = 'block';
                         iframe.style.height = 0;
                         iframe.style.width = 0;
-                        iframe.className = 'fileUploaderFrame';
+                        if(options && options.className) {
+                            iframe.className = options.className;
+                        }
                         document.controller = { // Written to  support https://git.corp.adobe.com/Campaign/ac/blob/v6-master/nl/datakit/nl/jsp/uploadFile.jsp
                             uploadFileCallBack: async (data) => {
                                 if (!data || data.length !== 1) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

IFrame is an inline element. Giving just height and width without the display won't work. So, adding display property and also adding a unique className for identification.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Multiple iframes are rendered on UI for uploads and these iframes are taking up empty space provided by default by the browser.

## How Has This Been Tested?

Tested it on ACC UI to see if IFrame is no more taking up empty space. Also classname can be seen.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
