### PR TITLE
NEO-68882: support static method in SubmitSoapCall

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -2013,7 +2013,10 @@ class Client {
         const inputParams = [];
         const outputParams = [];
 
-        // For non static methods, the first input and the first output parameters represent the entity itself. The name of the corresponding
+        // For non static methods 
+        //   in case of persistent job: object represents the entity instance
+        //   in case of non-persistent job: object represents job description 
+        // the first output parameters represent the entity itself. The name of the corresponding
         // parameter is set the the entity schema name.
         if (!isStatic) {
             var schemaName = entitySchemaId.substring(entitySchemaId.indexOf(':') + 1);

--- a/src/xtkJob.js
+++ b/src/xtkJob.js
@@ -160,23 +160,32 @@ class XtkJobInterface {
         var schema = await this._client.getSchema(entitySchemaId, "xml", true);
         if (!schema)
             throw CampaignException.SOAP_UNKNOWN_METHOD(entitySchemaId, methodName, `Schema '${entitySchemaId}' not found`);
-        var method = this._client._methodCache.get(entitySchemaId, methodName);
+        var method = await this._client._methodCache.get(entitySchemaId, methodName);
         if (!method)
             throw CampaignException.SOAP_UNKNOWN_METHOD(entitySchemaId, methodName, `Method '${methodName}' of schema '${entitySchemaId}' not found`);
-        // SubmitSoapCall does not support 
+
         const isStatic = DomUtil.getAttributeAsBoolean(method, "static");
-        if (isStatic) 
-            throw CampaignException.SOAP_UNKNOWN_METHOD(entitySchemaId, methodName, `Method '${methodName}' of schema '${entitySchemaId}' is static`);
 
-
-        var jobId = await callContext.client._callMethod("SubmitSoapCall", callContext, [ {
-            name: this._soapCall.method,
-            service: this._soapCall.xtkschema,
-            param: [
-                { name:"this", type:"DOMDocument", value: this._soapCall.object },
-                { name:"bStart", type:"boolean", value:"false" },
-            ]
-        } ]);
+        var jobId = null;
+        if ( !isStatic)
+            jobId = await callContext.client._callMethod("SubmitSoapCall", callContext, [ {
+                name: this._soapCall.method,
+                service: this._soapCall.xtkschema,
+                param: [
+                    { name:"this", type:"DOMDocument", value: this._soapCall.object },
+                    { name:"bStart", type:"boolean", value:"false" },
+                ]
+            } ]);
+        else
+            // SubmitSoapCall now supports static method
+            // no need parameter type as it's already present in API definition
+            jobId = await callContext.client._callMethod("SubmitSoapCall", callContext,
+                    {                
+                        name: this._soapCall.method,
+                        service: this._soapCall.xtkschema,
+                        param : this._soapCall.args
+                    },
+             );
         this.jobId = jobId;
         return jobId;
     }

--- a/src/xtkJob.js
+++ b/src/xtkJob.js
@@ -176,7 +176,16 @@ class XtkJobInterface {
                     { name:"bStart", type:"boolean", value:"false" },
                 ]
             } ]);
-        else
+        else {
+            // for non-persistant job, override object to intialize job properties
+            callContext.object = {
+                doNotPersist: "true",
+                xtkschema: this._soapCall.xtkschema,
+                id: this._soapCall.jobId,
+                properties: {
+                    warning: false,
+                }
+            };
             // SubmitSoapCall now supports static method
             // no need parameter type as it's already present in API definition
             jobId = await callContext.client._callMethod("SubmitSoapCall", callContext,
@@ -186,6 +195,7 @@ class XtkJobInterface {
                         param : this._soapCall.args
                     },
              );
+        }
         this.jobId = jobId;
         return jobId;
     }

--- a/test/xtkJob.test.js
+++ b/test/xtkJob.test.js
@@ -347,7 +347,7 @@ describe('XRK Jobs', function () {
                   value: "10"
                 }
               ]
-            const job = new XtkJobInterface(client, { xtkschema: "nms:webApp", object: jobDescription, method: "Publish", args: soapCallArgs });
+            const job = new XtkJobInterface(client, { xtkschema: "nms:webApp", jobId: "9876", method: "Publish", args: soapCallArgs });
             client._callMethod.mockReturnValueOnce(Promise.resolve("9876"));
             client.getSchema.mockReturnValueOnce(Promise.resolve(true));
             client._methodCache.get.mockReturnValueOnce(DomUtil.parse('<method static="true"></method>').documentElement);

--- a/test/xtkJob.test.js
+++ b/test/xtkJob.test.js
@@ -325,6 +325,48 @@ describe('XRK Jobs', function () {
             } ]);
         });
 
+        it("SubmitSoapCall a non-persistant and static job with success", async () => {
+            const client = { _callMethod: jest.fn(), getSchema: jest.fn(), _methodCache: { get: jest.fn()} };
+            const jobDescription = { 
+                doNotPersist: "true",
+                xtkschema: 'nms:webApp',
+                id: "9876",
+                properties: {
+                    warning: false,
+                }};
+            const soapCallArgs =  [
+                {
+                  where: {
+                    condition: {
+                      expr: "@id=9876"
+                    }
+                  }
+                },
+                {
+                  type: "byte",
+                  value: "10"
+                }
+              ]
+            const job = new XtkJobInterface(client, { xtkschema: "nms:webApp", object: jobDescription, method: "Publish", args: soapCallArgs });
+            client._callMethod.mockReturnValueOnce(Promise.resolve("9876"));
+            client.getSchema.mockReturnValueOnce(Promise.resolve(true));
+            client._methodCache.get.mockReturnValueOnce(DomUtil.parse('<method static="true"></method>').documentElement);
+            const jobId = await job.submitSoapCall();
+            expect(jobId).toBe("9876");
+            expect(client._callMethod.mock.calls.length).toBe(1);
+            expect(client._callMethod.mock.calls[0][0]).toBe("SubmitSoapCall");
+            expect(client._callMethod.mock.calls[0][1]).toMatchObject({
+                entitySchemaId: "nms:webApp",
+                schemaId: "xtk:jobInterface",
+                object: jobDescription,
+            });
+            expect(client._callMethod.mock.calls[0][2]).toEqual({                
+                name: "Publish",
+                service: "nms:webApp",
+                param : soapCallArgs
+            });
+        });
+
         it("Infer schema from objects", async () => {
             const client = { _callMethod: jest.fn(), getSchema: jest.fn(), _methodCache: { get: jest.fn()} };
             const job = new XtkJobInterface(client, { object: { xtkschema: "nms:delivery", name: "Hello World" }, method: "Prepare" });
@@ -386,23 +428,6 @@ describe('XRK Jobs', function () {
                 "faultCode": 16384,
                 "faultString": "Unknown method 'NotFound' of schema 'nms:delivery'",
                 "message": "400 - Error 16384: SDK-000009 Unknown method 'NotFound' of schema 'nms:delivery'. Method 'NotFound' of schema 'nms:delivery' not found",
-                "name": "CampaignException",
-                "statusCode": 400,
-            });
-        });
-
-        it("Should fail on static methods", async () => {
-            const client = { _callMethod: jest.fn(), getSchema: jest.fn(), _methodCache: { get: jest.fn()} };
-            const job = new XtkJobInterface(client, { object: { xtkschema: "nms:delivery", name: "Hello World" }, method: "StaticMethod" });
-            client._callMethod.mockReturnValueOnce(Promise.resolve("9876"));
-            client.getSchema.mockReturnValueOnce(Promise.resolve(true));
-            client._methodCache.get.mockReturnValueOnce(DomUtil.parse('<method static="true"></method>').documentElement);
-            await expect(job.submitSoapCall()).rejects.toMatchObject({
-                "detail": "Method 'StaticMethod' of schema 'nms:delivery' is static",
-                "errorCode": "SDK-000009",
-                "faultCode": 16384,
-                "faultString": "Unknown method 'StaticMethod' of schema 'nms:delivery'",
-                "message": "400 - Error 16384: SDK-000009 Unknown method 'StaticMethod' of schema 'nms:delivery'. Method 'StaticMethod' of schema 'nms:delivery' is static",
                 "name": "CampaignException",
                 "statusCode": 400,
             });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- fix a bug when calling async getMethod in cache
- support static method in SubmitSoapCall


<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
