### PR TITLE
Fix: Remove experimental upload feature console log

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -583,7 +583,6 @@ const fileUploader = (client) => {
          * @returns {Promise<{name: string, md5: string, type: string, size: string, url: string}>}
          */
         upload: (file, options) => {
-            console.log(`fileuploader.upload is an experimental feature and is not currently fully functional. It is work in progress and will change in the future.`);
             return new Promise((resolve, reject) => {
                 const action = (options && options.action) ? options.action : "publishIfNeeded";
                 if (action !== "publishIfNeeded" && action !== "none")


### PR DESCRIPTION
Remove experimental upload feature console log

## Description

This experimental upload feature console log was added long back when upload was in experimental phase. Removing it now as upload it available on GA now.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://jira.corp.adobe.com/browse/NEO-73607

## Motivation and Context

This fix removes the unnecessary console log from the browser's console.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
