### PR TITLE
Add support to execute job operations based on provided jobId

### DIFF
--- a/src/xtkJob.js
+++ b/src/xtkJob.js
@@ -32,6 +32,7 @@ const { XtkCaster } = require("./xtkCaster.js");
  * @property {string} xtkschema - the method schema id. It can be ommited if the object has a xtkschema property
  * @property {any} object - the object ("this") to call the method with, possibly null for static methods. Should implement the xtk:job interface
  * @property {Array} args - the list of arguments to the SOAP call
+ * @property {(string|number)} [jobId] - the optional job id, which can be used for subsequent calls
  * @memberOf Campaign
  */
 
@@ -77,10 +78,11 @@ class XtkJobInterface {
      * @param {Campaign.XtkSoapCallSpec} soapCallSpec the definition of the SOAP call
      */
     constructor(client, soapCallSpec) {
+        this._reset();
         this._client = client;
         this._soapCall = soapCallSpec;
         this._maxLogCount = 100; // default fetch size
-        this._reset();
+        this.jobId = soapCallSpec ? soapCallSpec.jobId : undefined;
     }
 
     // Reset state before executing or submitting a job

--- a/test/xtkJob.test.js
+++ b/test/xtkJob.test.js
@@ -487,6 +487,16 @@ describe('XRK Jobs', function () {
             expect(client.NLWS.xtkJob.getStatus.mock.calls.length).toBe(1);
             expect(client.NLWS.xtkJob.getStatus.mock.calls[0]).toEqual(["ABC", 12, 500]);
         });
+
+        it("Should get status from provided jobId", async () => {
+            const jobId = 'ABC';
+            const client = { NLWS: { xtkJob: { getStatus: jest.fn() } }  };
+            const job = new XtkJobInterface(client, { jobId });
+            client.NLWS.xtkJob.getStatus.mockReturnValueOnce(Promise.resolve({ }));
+            await job.getStatus(12, 500);
+            expect(client.NLWS.xtkJob.getStatus.mock.calls.length).toBe(1);
+            expect(client.NLWS.xtkJob.getStatus.mock.calls[0]).toEqual([jobId, 12, 500]);
+        });
     });
 
     describe("Get Result", () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Covered the scenarios where the various operations on the XtkJobInterface can be performed with provided jobId.

**UseCase**
User submits a job to perform some async operation and refreshes the browser. Now in order to show the status of the job to the user, we need a way to get the status based on the jobId.

User submits an async Job with a jobId.
```
 const job = await client.jobInterface({
    xtkschema: <Schema>,
    method: <Method>,
    jobId:<JobID>,
    args: <Arguements>,
  });
  await job.submitSoapCall();
```

With the implementation in PR, the status of the job with <JobId> can be fetched as mentioned below.
``` 
const job = new XtkJobInterface(client, { jobId: <JobID> }) 
await job.getStatus();
```

## How Has This Been Tested?

Added unit tests

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
