### PR TITLE
[NEO-78835]: fix extraHttpHeaders issue

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -595,6 +595,8 @@ const fileUploader = (client) => {
                     const data = new FormData();
                     data.append('file_noMd5', file);
                     const headers = client._getAuthHeaders(false);
+                    for (let h in client._connectionParameters._options.extraHttpHeaders)
+                        headers[h] = client._connectionParameters._options.extraHttpHeaders[h];
                     client._makeHttpCall({
                         url: `${client._connectionParameters._endpoint}/nl/jsp/uploadFile.jsp`,
                         processData: false,
@@ -680,7 +682,8 @@ const fileUploader = (client) => {
                 const jsonData = JSON.stringify({
                     'assetDownloadUrl': assetDownloadUrl
                 });
-
+                for (let h in client._connectionParameters._options.extraHttpHeaders)
+                    headers[h] = client._connectionParameters._options.extraHttpHeaders[h];
                 var response = await client._makeHttpCall({
                     url: url,
                     method: 'POST',
@@ -746,6 +749,8 @@ const fileUploader = (client) => {
             }
 
             const headers = client._getAuthHeaders(false);
+            for (let h in client._connectionParameters._options.extraHttpHeaders)
+                headers[h] = client._connectionParameters._options.extraHttpHeaders[h];
             const rawFileResponse = await client._makeHttpCall({
               url: `${client._connectionParameters._endpoint}/nl/jsp/downloadFile.jsp?${queryString}`,
               headers: headers,

--- a/src/xtkJob.js
+++ b/src/xtkJob.js
@@ -112,7 +112,8 @@ class XtkJobInterface {
             client: this._client,
             object: this._soapCall.object,
             schemaId: 'xtk:jobInterface',
-            entitySchemaId: entitySchemaId
+            entitySchemaId: entitySchemaId,
+            headers: this._client._connectionParameters._options.extraHttpHeaders
         };
         var jobId = await callContext.client._callMethod("Execute", callContext, [ methodName ]);
         this.jobId = jobId;
@@ -135,7 +136,8 @@ class XtkJobInterface {
             client: this._client,
             object: this._soapCall.object,
             schemaId: 'xtk:jobInterface',
-            entitySchemaId: entitySchemaId
+            entitySchemaId: entitySchemaId,
+            headers: this._client._connectionParameters._options.extraHttpHeaders
         };
         var jobId = await callContext.client._callMethod("Submit", callContext, [ this._soapCall.method ]);
         this.jobId = jobId;
@@ -156,8 +158,8 @@ class XtkJobInterface {
             object: this._soapCall.object,
             schemaId: 'xtk:jobInterface',
             entitySchemaId: entitySchemaId,
+            headers: this._client._connectionParameters._options.extraHttpHeaders
         };
-
         const methodName = this._soapCall.method;
         var schema = await this._client.getSchema(entitySchemaId, "xml", true);
         if (!schema)

--- a/test/xtkJob.test.js
+++ b/test/xtkJob.test.js
@@ -176,7 +176,7 @@ describe('XRK Jobs', function () {
 
     describe("Execute", () => {
         it("Execute with success", async () => {
-            const client = { _callMethod: jest.fn() };
+            const client = { _callMethod: jest.fn(), _connectionParameters: { _options: {}} };
             const job = new XtkJobInterface(client, { xtkschema: "nms:delivery", object: "Hello World", method: "Prepare" });
             client._callMethod.mockReturnValueOnce(Promise.resolve("9876"));
             const jobId = await job.execute();
@@ -192,7 +192,7 @@ describe('XRK Jobs', function () {
         });
 
         it("Infer schema from objects", async () => {
-            const client = { _callMethod: jest.fn() };
+            const client = { _callMethod: jest.fn(), _connectionParameters: { _options: {}} };
             const job = new XtkJobInterface(client, { object: { xtkschema: "nms:delivery", name: "Hello World" }, method: "Prepare" });
             client._callMethod.mockReturnValueOnce(Promise.resolve("9876"));
             const jobId = await job.execute();
@@ -238,7 +238,7 @@ describe('XRK Jobs', function () {
 
     describe("Submit", () => {
         it("Submit with success", async () => {
-            const client = { _callMethod: jest.fn() };
+            const client = { _callMethod: jest.fn(), _connectionParameters: { _options: {}} };
             const job = new XtkJobInterface(client, { xtkschema: "nms:delivery", object: "Hello World", method: "Prepare" });
             client._callMethod.mockReturnValueOnce(Promise.resolve("9876"));
             const jobId = await job.submit();
@@ -254,7 +254,7 @@ describe('XRK Jobs', function () {
         });
 
         it("Infer schema from objects", async () => {
-            const client = { _callMethod: jest.fn() };
+            const client = { _callMethod: jest.fn(), _connectionParameters: { _options: {}} };
             const job = new XtkJobInterface(client, { object: { xtkschema: "nms:delivery", name: "Hello World" }, method: "Prepare" });
             client._callMethod.mockReturnValueOnce(Promise.resolve("9876"));
             const jobId = await job.submit();
@@ -301,7 +301,7 @@ describe('XRK Jobs', function () {
 
     describe("SubmitSoapCall", () => {
         it("SubmitSoapCall with success", async () => {
-            const client = { _callMethod: jest.fn(), getSchema: jest.fn(), _methodCache: { get: jest.fn()} };
+            const client = { _callMethod: jest.fn(), getSchema: jest.fn(), _methodCache: { get: jest.fn()}, _connectionParameters: { _options: {}} };
             const job = new XtkJobInterface(client, { xtkschema: "nms:delivery", object: "Hello World", method: "Prepare" });
             client._callMethod.mockReturnValueOnce(Promise.resolve("9876"));
             client.getSchema.mockReturnValueOnce(Promise.resolve(true));
@@ -326,7 +326,7 @@ describe('XRK Jobs', function () {
         });
 
         it("SubmitSoapCall a non-persistant and static job with success", async () => {
-            const client = { _callMethod: jest.fn(), getSchema: jest.fn(), _methodCache: { get: jest.fn()} };
+            const client = { _callMethod: jest.fn(), getSchema: jest.fn(), _methodCache: { get: jest.fn()}, _connectionParameters: { _options: {}} };
             const jobDescription = { 
                 doNotPersist: "true",
                 xtkschema: 'nms:webApp',
@@ -368,7 +368,7 @@ describe('XRK Jobs', function () {
         });
 
         it("Infer schema from objects", async () => {
-            const client = { _callMethod: jest.fn(), getSchema: jest.fn(), _methodCache: { get: jest.fn()} };
+            const client = { _callMethod: jest.fn(), getSchema: jest.fn(), _methodCache: { get: jest.fn()}, _connectionParameters: { _options: {}} };
             const job = new XtkJobInterface(client, { object: { xtkschema: "nms:delivery", name: "Hello World" }, method: "Prepare" });
             client._callMethod.mockReturnValueOnce(Promise.resolve("9876"));
             client.getSchema.mockReturnValueOnce(Promise.resolve(true));
@@ -383,7 +383,7 @@ describe('XRK Jobs', function () {
         });
 
         it("Should fail on missing schema", async () => {
-            const client = { _callMethod: jest.fn(), getSchema: jest.fn(), _methodCache: { get: jest.fn()} };
+            const client = { _callMethod: jest.fn(), getSchema: jest.fn(), _methodCache: { get: jest.fn()}, _connectionParameters: { _options: {}} };
             const job = new XtkJobInterface(client, { method: "Prepare" });
             client._callMethod.mockReturnValueOnce(Promise.resolve("9876"));
             client.getSchema.mockReturnValueOnce(Promise.resolve(false));
@@ -400,7 +400,7 @@ describe('XRK Jobs', function () {
         });
 
         it("Should fail on invalid schema", async () => {
-            const client = { _callMethod: jest.fn(), getSchema: jest.fn(), _methodCache: { get: jest.fn()} };
+            const client = { _callMethod: jest.fn(), getSchema: jest.fn(), _methodCache: { get: jest.fn()}, _connectionParameters: { _options: {}} };
             const job = new XtkJobInterface(client, { object: { xtkschema: "nms:notFound", name: "Hello World" }, method: "Prepare" });
             client._callMethod.mockReturnValueOnce(Promise.resolve("9876"));
             client.getSchema.mockReturnValueOnce(Promise.resolve(false));
@@ -417,7 +417,7 @@ describe('XRK Jobs', function () {
         });
 
         it("Should fail on method not found", async () => {
-            const client = { _callMethod: jest.fn(), getSchema: jest.fn(), _methodCache: { get: jest.fn()} };
+            const client = { _callMethod: jest.fn(), getSchema: jest.fn(), _methodCache: { get: jest.fn()}, _connectionParameters: { _options: {}} };
             const job = new XtkJobInterface(client, { object: { xtkschema: "nms:delivery", name: "Hello World" }, method: "NotFound" });
             client._callMethod.mockReturnValueOnce(Promise.resolve("9876"));
             client.getSchema.mockReturnValueOnce(Promise.resolve(true));

--- a/test/xtkJob.test.js
+++ b/test/xtkJob.test.js
@@ -191,6 +191,24 @@ describe('XRK Jobs', function () {
             expect(client._callMethod.mock.calls[0][2]).toEqual([ "Prepare" ]);
         });
 
+        it("Execute should pass extraHttpHeaders in headers", async () => {
+            const extraHttpHeaders = {'x-api-key': 'check'};
+            const client = { _callMethod: jest.fn(), _connectionParameters: { _options: { extraHttpHeaders }} };
+            const job = new XtkJobInterface(client, { xtkschema: "nms:delivery", object: "Hello World", method: "Prepare" });
+            client._callMethod.mockReturnValueOnce(Promise.resolve("9876"));
+            const jobId = await job.execute();
+            expect(jobId).toBe("9876");
+            expect(client._callMethod.mock.calls.length).toBe(1);
+            expect(client._callMethod.mock.calls[0][0]).toBe("Execute");
+            expect(client._callMethod.mock.calls[0][1]).toMatchObject({
+                entitySchemaId: "nms:delivery",
+                schemaId: "xtk:jobInterface",
+                object: "Hello World",
+                headers: extraHttpHeaders,
+            });
+            expect(client._callMethod.mock.calls[0][2]).toEqual([ "Prepare" ]);
+        });
+
         it("Infer schema from objects", async () => {
             const client = { _callMethod: jest.fn(), _connectionParameters: { _options: {}} };
             const job = new XtkJobInterface(client, { object: { xtkschema: "nms:delivery", name: "Hello World" }, method: "Prepare" });
@@ -249,6 +267,24 @@ describe('XRK Jobs', function () {
                 entitySchemaId: "nms:delivery",
                 schemaId: "xtk:jobInterface",
                 object: "Hello World"
+            });
+            expect(client._callMethod.mock.calls[0][2]).toEqual([ "Prepare" ]);
+        });
+
+        it("Submit should pass extraHttpHeaders in headers", async () => {
+            const extraHttpHeaders = {'x-api-key': 'check'};
+            const client = { _callMethod: jest.fn(), _connectionParameters: { _options: { extraHttpHeaders }} };
+            const job = new XtkJobInterface(client, { xtkschema: "nms:delivery", object: "Hello World", method: "Prepare" });
+            client._callMethod.mockReturnValueOnce(Promise.resolve("9876"));
+            const jobId = await job.submit();
+            expect(jobId).toBe("9876");
+            expect(client._callMethod.mock.calls.length).toBe(1);
+            expect(client._callMethod.mock.calls[0][0]).toBe("Submit");
+            expect(client._callMethod.mock.calls[0][1]).toMatchObject({
+                entitySchemaId: "nms:delivery",
+                schemaId: "xtk:jobInterface",
+                object: "Hello World",
+                headers: extraHttpHeaders,
             });
             expect(client._callMethod.mock.calls[0][2]).toEqual([ "Prepare" ]);
         });
@@ -323,6 +359,25 @@ describe('XRK Jobs', function () {
                     { name:"bStart", type:"boolean", value:"false" },
                 ]
             } ]);
+        });
+
+        it("SubmitSoapCall should pass extraHttpHeaders in headers", async () => {
+            const extraHttpHeaders = {'x-api-key': 'check'};
+            const client = { _callMethod: jest.fn(), getSchema: jest.fn(), _methodCache: { get: jest.fn()}, _connectionParameters: { _options: { extraHttpHeaders }} };
+            const job = new XtkJobInterface(client, { xtkschema: "nms:delivery", object: "Hello World", method: "Prepare" });
+            client._callMethod.mockReturnValueOnce(Promise.resolve("9876"));
+            client.getSchema.mockReturnValueOnce(Promise.resolve(true));
+            client._methodCache.get.mockReturnValueOnce(DomUtil.parse("<method></method>").documentElement);
+            const jobId = await job.submitSoapCall();
+            expect(jobId).toBe("9876");
+            expect(client._callMethod.mock.calls.length).toBe(1);
+            expect(client._callMethod.mock.calls[0][0]).toBe("SubmitSoapCall");
+            expect(client._callMethod.mock.calls[0][1]).toMatchObject({
+                entitySchemaId: "nms:delivery",
+                schemaId: "xtk:jobInterface",
+                object: "Hello World",
+                headers: extraHttpHeaders,
+            });
         });
 
         it("SubmitSoapCall a non-persistant and static job with success", async () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The extraHttpHeaders passed to the connection parameters which is used to initialise the client, is not present in the XtkJobInterface's function and FileUploader APIs

```
const connectionParameters = sdk.ConnectionParameters.ofBearerToken(targetDomain, imsToken, {extraHttpHeaders: {testHeader: 'headerValue'}});
const clientSdk = await sdk.init(connectionParameters).catch(() => false);
await clientSdk.logon();

const job = await clientSdk.jobInterface({
  xtkschema: "nms:dataModel",
  method: "write",
  jobId: name,
  args: dataModelJSON,
});

// This API call does not have the extraHttpHeaders in the headers.
await job.submitSoapCall();
```

Also, the submit and execute APIs does not have the extraHttpHeaders in the header.
Although, all the other methods like getStatus, getResult, cancel, pause, waitJobCancelled and hasWarning already support the extraHttpHeaders as they are being handled by the Proxy clientHandler.

Similarly, we have this issue in the fileUploader APIs.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
