### PR TITLE
[NEO-79113]: Show error toast when file upload API fails

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -629,22 +629,37 @@ const fileUploader = (client) => {
                                     size: file.size,
                                 };
                                 if (action === "publishIfNeeded") {
-                                    const counter = await client.NLWS.xtkCounter.increaseValue({name: 'xtkResource'});
-                                    const fileRes= {
-                                        internalName: 'RES' + counter,
-                                        md5: data[0].md5,
-                                        label: data[0].fileName,
-                                        fileName: data[0].fileName,
-                                        originalName: data[0].fileName,
-                                        useMd5AsFilename: '1',
-                                        storageType: 5,
-                                        xtkschema: 'xtk:fileRes'
-
+                                  try {
+                                    const counter =
+                                      await client.NLWS.xtkCounter.increaseValue(
+                                        { name: 'xtkResource' }
+                                      );
+                                    const fileRes = {
+                                      internalName: 'RES' + counter,
+                                      md5: data[0].md5,
+                                      label: data[0].fileName,
+                                      fileName: data[0].fileName,
+                                      originalName: data[0].fileName,
+                                      useMd5AsFilename: '1',
+                                      storageType: 5,
+                                      xtkschema: 'xtk:fileRes',
                                     };
                                     await client.NLWS.xtkSession.write(fileRes);
-                                    await client.NLWS.xtkFileRes.create(fileRes).publishIfNeeded();
-                                    const url = await client.NLWS.xtkFileRes.create(fileRes).getURL();
+                                    await client.NLWS.xtkFileRes
+                                      .create(fileRes)
+                                      .publishIfNeeded();
+                                    const url = await client.NLWS.xtkFileRes
+                                      .create(fileRes)
+                                      .getURL();
                                     result.url = url;
+                                  } catch (ex) {
+                                    reject(
+                                      CampaignException.FILE_UPLOAD_FAILED(
+                                        file.name,
+                                        ex
+                                      )
+                                    );
+                                  }
                                 }
                                 resolve(result);
                             }

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -4061,6 +4061,67 @@ describe('ACC Client', function () {
                 expect(found).toBe(true);
             });
 
+            it("Should throw error when 'publishIfNeeded' action rejected", async () => {
+              // Create a mock client and logon
+              const client = await Mock.makeClient();
+              client._transport.mockReturnValueOnce(Mock.LOGON_RESPONSE);
+              await client.NLWS.xtkSession.logon();
+
+              // Mock the upload protocol
+              // - the upload.jsp (which returns the content of an iframe and JS to eval)
+              // - call to xtk:counter#IncreaseValue (first, retrieve the schema xtk:counter then call the function)
+              // - call to xtk:session#Write
+              // - call to xtk:fileRes#PublishIfNeeded
+              // - call to xtk:fileRes#GetURL
+
+              client._transport.mockReturnValueOnce(
+                Promise.resolve(`Ok 
+                <html xmlns="http://www.w3.org/1999/xhtml">
+                    <head>
+                    <script type="text/javascript">if(window.parent&&window.parent.document.controller&&"function"==typeof window.parent.document.controller.uploadFileCallBack){var aFilesInfo=new Array;aFilesInfo.push({paramName:"file",fileName:"test.txt",newFileName:"d8e8fca2dc0f896fd7cb4cb0031ba249.txt",md5:"d8e8fca2dc0f896fd7cb4cb0031ba249"}),window.parent.document.controller.uploadFileCallBack(aFilesInfo)}</script>
+                    </head>
+                <body></body>
+                </html>`)
+              ); // upload.jsp
+
+              client._transport.mockReturnValueOnce(
+                Promise.resolve(Mock.GET_XTK_COUNTER_RESPONSE)
+              ); // GetEntityIfMoreRecentResponse - counter
+              client._transport.mockReturnValueOnce(
+                Mock.INCREASE_VALUE_RESPONSE
+              ); // xtk:counter#IncreaseValue
+
+              client._transport.mockReturnValueOnce(
+                Mock.GET_XTK_SESSION_SCHEMA_RESPONSE
+              ); // GetEntityIfMoreRecentResponse - session
+              client._transport.mockReturnValueOnce(
+                Mock.FILE_RES_WRITE_RESPONSE
+              ); // xtk:session#Write
+
+              client._transport.mockReturnValueOnce(
+                Promise.resolve(Mock.GET_FILERES_QUERY_SCHEMA_RESPONSE)
+              ); // GetEntityIfMoreRecentResponse - fileRes
+              client._transport.mockReturnValueOnce(
+                Promise.reject(`Some error occured`)
+              ); // xtk:fileRes#PublishIfNeeded
+
+              client._transport.mockReturnValueOnce(
+                Promise.resolve(Mock.GET_URL_RESPONSE)
+              ); // xtk:fileRes#GetURL
+
+              await client.fileUploader
+                .upload({
+                  type: "text/html",
+                  size: 12345,
+                  name: "abcd.txt",
+                })
+                .catch((ex) => {
+                  expect(ex.message).toMatch(
+                    "500 - Error 16384: SDK-000013 \"Failed to upload file abcd.txt. 500 - Error calling method 'xtk:fileRes#PublishIfNeeded': Some error occured"
+                  );
+                });
+            });
+
             it("Should support 'none' action", async () => {
                 // Create a mock client and logon
                 const client = await Mock.makeClient();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description


Currently the API will not throw back an error if the publishIfNeeded function fails or its URL gets blocked, which causes an infinite loop on uploading a file in Federated Databases. We needed to add a try and catch block in order to handle these uhnadled exceptions, which I added in this PR.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

The issue has ben tested on FAC, where we now get an error toast shown instead of falling into an infinite loop

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
