### PR TITLE
Fix domUtil.fromJSON for attributes name starting by invalid at character

### DIFF
--- a/src/domUtil.js
+++ b/src/domUtil.js
@@ -314,7 +314,7 @@ class DomUtil {
             var attFirstIndex = 1;
 
             if (flavor == "SimpleJson") {
-                if ((t == "string" || t == "number" || t == "boolean") && att[0] != '$') {
+                if ((t == "string" || t == "number" || t == "boolean") && att[0] != '$' && att[0] != '@') {
                     isAtt = true;
                     attFirstIndex = 0;
                 }

--- a/test/domUtil.test.js
+++ b/test/domUtil.test.js
@@ -156,6 +156,8 @@ describe('DomUtil', function() {
             assert.strictEqual(fromJSON({ "a": [ ] }), '<root/>');
             assert.strictEqual(fromJSON({ "a": null }), '<root/>');
             assert.strictEqual(fromJSON({ "a": undefined }), '<root/>');
+            assert.strictEqual(fromJSON({ "@a":2, "@b":"zz", "@c": true }), '<root a="2" b="zz" c="true"/>');
+            assert.strictEqual(fromJSON({ "a":{ x:3 }, "@a": 2 }), '<root a="2"><a x="3"/></root>');
         });
 
         it("Should support attributes named 'length'", () => {
@@ -192,6 +194,8 @@ describe('DomUtil', function() {
             assert.strictEqual(fromJSON({ "a": [ ] }), '<root/>');
             assert.strictEqual(fromJSON({ "a": null }), '<root/>');
             assert.strictEqual(fromJSON({ "a": undefined }), '<root/>');
+            assert.strictEqual(fromJSON({ "@a":2, "@b":"zz", "@c": true }), '<root a="2" b="zz" c="true"/>');
+            assert.strictEqual(fromJSON({ "a":{ x:3 }, "@a": 2 }), '<root a="2"><a x="3"/></root>');
         });
     });
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
Before this fix, DOM setAttribute function could crash if name starts with '@' character, which is a forbidden starting character (https://www.w3.org/TR/REC-xml/#NT-NameStartChar) 


## Description

<!--- Describe your changes in detail -->

## Related Issue  

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
