### PR TITLE
Fix GetModifiedEntities API payload XML issue

### DIFF
--- a/src/cacheRefresher.js
+++ b/src/cacheRefresher.js
@@ -161,7 +161,10 @@ governing permissions and limitations under the License.
                 }
             }
 
-            // Use Json because xtk:schema does not work directly in DomUtil.parse(`<cache buildNumber="9469" time="2022-06-30T00:00:00.000"><xtk:schema></xtk:schema></cache>`);
+            // Extract namespace from the cacheSchemaId
+            const namespace = this._cacheSchemaId.split(":")[0];
+
+            // Use Json because xtk:schema does not work directly in DomUtil.parse(`<cache buildNumber="9469" time="2022-06-30T00:00:00.000"><xtk:schema xmlns:xtk="urn:xtk:schema"></xtk:schema></cache>`);
             // due to the colon character
             let jsonCache;
             if (this._lastTime === undefined || this._buildNumber === undefined) {
@@ -172,7 +175,9 @@ governing permissions and limitations under the License.
                 jsonCache = {
                     buildNumber: this._buildNumber,
                     lastModified: this._lastTime,
-                    [this._cacheSchemaId]: {}
+                    [this._cacheSchemaId]: {
+                        [`xmlns:${namespace}`]: `urn:${this._cacheSchemaId}`
+                    }
                 };
             }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix the GetModifiedEntities API payload XML issue:
```
Caused by: org.xml.sax.SAXParseException: The prefix "xtk" for element "xtk:schema" is not bound.
	at java.xml/com.sun.org.apache.xerces.internal.parsers.DOMParser.parse(DOMParser.java:262) 
```
The cache schema is added as an element in the format xtk:schema, and valid XML should declare the namespace for xtk prefix

Before the Fix
```
<cache buildNumber="9469" time="2022-06-30T00:00:00.000">
  <xtk:schema/>
</cache>
```

After the fix
```
<cache buildNumber="9469" time="2022-06-30T00:00:00.000">
  <xtk:schema xmlns:xtk="urn:xtk:schema"/>
</cache>
```

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
