### PR TITLE
Fix GetModifiedEntities API payload XML issue when lasttime or buildN…

### DIFF
--- a/src/cacheRefresher.js
+++ b/src/cacheRefresher.js
@@ -169,7 +169,9 @@ governing permissions and limitations under the License.
             let jsonCache;
             if (this._lastTime === undefined || this._buildNumber === undefined) {
                 jsonCache = {
-                    [this._cacheSchemaId]: {}
+                    [this._cacheSchemaId]: {
+                        [`xmlns:${namespace}`]: `urn:${this._cacheSchemaId}`
+                    }
                 };
             } else {
                 jsonCache = {


### PR DESCRIPTION
…umber is empty

<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix GetModifiedEntities API payload XML issue when lasttime or buildNumber is empty
```
Caused by: org.xml.sax.SAXParseException: The prefix "xtk" for element "xtk:schema" is not bound.
	at java.xml/com.sun.org.apache.xerces.internal.parsers.DOMParser.parse(DOMParser.java:262) 
```
The cache schema is added as an element in the format xtk:schema/, and valid XML should declare the namespace for xtk prefix

GetModifiedEntities payload before the Fix

```
<cache buildNumber="9469" time="2022-06-30T00:00:00.000">
  <xtk:schema/>
</cache>
```
GetModifiedEntities payload after the fix

```
<cache buildNumber="9469" time="2022-06-30T00:00:00.000">
  <xtk:schema xmlns:xtk="urn:xtk:schema"/>
</cache>
```
Related Issue
https://jira.corp.adobe.com/browse/NEO-87784

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
