### PR TITLE
Xdm schemas

### DIFF
--- a/docs/changeLog.html
+++ b/docs/changeLog.html
@@ -7,6 +7,9 @@ title: Change Log
   <li>
     Bumped dependencies version to fix vulnerabilities
   </li>
+  <li>
+    Update getSchema function to support XDM schemas (without caching)
+  </li>
 </section>
 
 

--- a/docs/changeLog.html
+++ b/docs/changeLog.html
@@ -2,6 +2,14 @@
 layout: page
 title: Change Log
 ---
+<section class="changelog"><h1>Version 1.1.56</h1>
+  <h2></h2>
+  <li>
+    Bumped dependencies version to fix vulnerabilities
+  </li>
+</section>
+
+
 <section class="changelog"><h1>Version 1.1.55</h1>
   <h2>2025/01/27</h2>
   <li>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1275,9 +1275,10 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -5403,7 +5404,9 @@
       "dev": true
     },
     "brace-expansion": {
-      "version": "1.1.11",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",

--- a/src/client.js
+++ b/src/client.js
@@ -1928,6 +1928,14 @@ class Client {
      * @returns {XML.XtkObject}  the schema definition, as either a DOM document or a JSON object
      */
     async getSchema(schemaId, representation, internal) {
+        // Support for Orchestrated Campaign XDM schemas (do not use cache)
+        const pipeIndex = schemaId.indexOf("|");
+        if( pipeIndex != -1 && schemaId.startsWith("xdm:") ) {
+            const entityType = schemaId.substring(0, pipeIndex);
+            schemaId = schemaId.substring(pipeIndex + 1);
+            const entity = await this.getEntityIfMoreRecent(entityType, schemaId, representation, internal);
+            return entity;
+        }
         var entity = await this._entityCache.get("xtk:schema", schemaId);
         if (!entity) {
               // special case of "temp:group:*" schemas for nms:group

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -435,6 +435,20 @@ describe('ACC Client', function () {
             await client.NLWS.xtkSession.logoff();
         });
 
+        it("Should return XDM schema definition", async () => {
+            const client = await Mock.makeClient();
+            client._transport.mockReturnValueOnce(Mock.LOGON_RESPONSE);
+            await client.NLWS.xtkSession.logon();
+
+            client._transport.mockReturnValueOnce(Mock.GET_UNION_PROFILE_SCHEMA_RESPONSE);
+            var schema = await client.getSchema("xdm:tenant:unions|_xdm.context.profile__union");
+            expect(schema["namespace"]).toBe("xdm");
+            expect(schema["name"]).toBe("profile__union");
+
+            client._transport.mockReturnValueOnce(Mock.LOGOFF_RESPONSE);
+            await client.NLWS.xtkSession.logoff();
+        });
+
         it("Should return temp group schema definition", async () => {
             const client = await Mock.makeClient();
             client._transport.mockReturnValueOnce(Mock.LOGON_RESPONSE);

--- a/test/mock.js
+++ b/test/mock.js
@@ -455,6 +455,28 @@ const GET_XTK_QUERY_SCHEMA_RESPONSE = Promise.resolve(`<?xml version='1.0'?>
     </SOAP-ENV:Body>
     </SOAP-ENV:Envelope>`);
 
+const GET_UNION_PROFILE_SCHEMA_RESPONSE = Promise.resolve(`<?xml version='1.0'?>
+    <SOAP-ENV:Envelope xmlns:xsd='http://www.w3.org/2001/XMLSchema' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xmlns:ns='urn:wpp:default' xmlns:SOAP-ENV='http://schemas.xmlsoap.org/soap/envelope/'>
+    <SOAP-ENV:Body>
+        <GetEntityIfMoreRecentResponse xmlns='urn:wpp:default' SOAP-ENV:encodingStyle='http://schemas.xmlsoap.org/soap/encoding/'>
+            <pdomDoc xsi:type='ns:Element' SOAP-ENV:encodingStyle='http://xml.apache.org/xml-soap/literalxml'>
+
+             <schema label="XDM Individual Profile" labelSingular="XDM Individual Profile" library="true" name="profile__union" namespace="xdm" xtkschema="xtk:schema">
+                <element autopk="false" label="XDM Individual Profile" name="profile__union" pkgStatus="never">
+                    <element name="_ajobatchjourneystage" type="">
+                    <attribute label="email" length="255" name="email" type="string"/>
+                    <attribute label="Loyalty Member" name="loyaltyMember" type="boolean"/>
+                    <attribute label="Use Case ID" length="255" name="useCaseInstanceId" type="string"/>
+                    </element>
+                    <attribute label="Identifier" length="255" name="_id" type="string"/>
+                </element>
+                </schema>
+
+            </pdomDoc>
+        </GetEntityIfMoreRecentResponse>
+    </SOAP-ENV:Body>
+    </SOAP-ENV:Envelope>`);
+
 const GET_NMS_DELIVERY_SCHEMA_RESPONSE = Promise.resolve(`<?xml version='1.0'?>
 <SOAP-ENV:Envelope xmlns:xsd='http://www.w3.org/2001/XMLSchema' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xmlns:ns='urn:wpp:default' xmlns:SOAP-ENV='http://schemas.xmlsoap.org/soap/envelope/'>
 <SOAP-ENV:Body>
@@ -1127,6 +1149,7 @@ exports.Mock = {
   GET_OPTION_NOTFOUND_RESPONSE: GET_OPTION_NOTFOUND_RESPONSE,
   GET_OPTION_MISSING_DATA_RESPONSE: GET_OPTION_MISSING_DATA_RESPONSE,
   GET_XTK_QUERY_SCHEMA_RESPONSE: GET_XTK_QUERY_SCHEMA_RESPONSE,
+  GET_UNION_PROFILE_SCHEMA_RESPONSE: GET_UNION_PROFILE_SCHEMA_RESPONSE,
   GET_NMS_DELIVERY_SCHEMA_RESPONSE: GET_NMS_DELIVERY_SCHEMA_RESPONSE,
   GET_DELIVERY_TEST_RESPONSE: GET_DELIVERY_TEST_RESPONSE,
   GET_MID_EXT_ACCOUNT_RESPONSE: GET_MID_EXT_ACCOUNT_RESPONSE,


### PR DESCRIPTION
## Description

GetEntityIfMoreRecent supports schema ids starting with "xdm:"
Modify the SDK so that the getSchema API call supports them

Example

getSchema("xdm:tenant:unions|xdm.context.profile_union")
getSchema("xdm:audience|ejfwtu349tu0");

This is only supported in "Campaign Orchestration" product and not in ACC.
 