### PR TITLE
New instanceKey connection parameter can be used to configure the cache key

### DIFF
--- a/docs/changeLog.html
+++ b/docs/changeLog.html
@@ -10,6 +10,9 @@ title: Change Log
   <li>
     Update getSchema function to support XDM schemas (without caching)
   </li>
+  <li>
+    New "instanceKey" connection parameter can be used to configure the cache key
+  </li>
 </section>
 
 

--- a/docs/connectionParameters.html
+++ b/docs/connectionParameters.html
@@ -104,6 +104,16 @@ const connectionParameters = sdk.ConnectionParameters.ofUserAndPassword(
             <td>number</td>
             <td>Can be used to set the APIs call timeout (in ms)</td>
         </tr>
+        <tr>
+            <td>cacheRootKey</td>
+            <td>"default" or "none"</td>
+            <td>Determine the prefix to use for the keys in the caches of schemas, options, etc.<p>The value "default" means that cached keys are prefixed with "acc.js.sdk.${this.sdk.getSDKVersion().version}.${instanceKey}.cache."</p></td>
+        </tr>
+        <tr>
+            <td>instanceKey</td>
+            <td>string</td>
+            <td>An optional value to override the instance key which is used for the caches of schemas, options, etc.</td>
+        </tr>
     </tbody>
 </table>
 

--- a/src/client.js
+++ b/src/client.js
@@ -308,6 +308,7 @@ class Credentials {
     * @property {boolean} noMethodInURL - Can be set to true to remove the method name from the URL
     * @property {number} timeout - Can be set to change the HTTP call timeout. Value is passed in ms.
     * @property {string} cacheRootKey - "default" or "none" - determine the prefix to use for the keys in the caches of schemas, options, etc.
+    * @property {string} instanceKey - an optional value to override the instance key which is used for the caches of schemas, options, etc.
     * @memberOf Campaign
  */
 
@@ -829,8 +830,10 @@ class Client {
         this._secretKeyCipher = undefined;
 
         this._storage = connectionParameters._options._storage;
-        // TODO late cache initiallzation because need XtkDatabaseId / instance name
-        var instanceKey = connectionParameters._endpoint || "";
+
+        var instanceKey = connectionParameters._options.instanceKey;
+        if (!instanceKey)
+            instanceKey = connectionParameters._endpoint || "";
         if (instanceKey.startsWith("http://")) instanceKey = instanceKey.substr(7);
         if (instanceKey.startsWith("https://")) instanceKey = instanceKey.substr(8);
 
@@ -894,6 +897,7 @@ class Client {
                 endpoint: this._connectionParameters._endpoint,
                 createdAt: Date.now(),
                 clientApp: this._connectionParameters._options.clientApp,
+                instanceKey: instanceKey
             }
         };
         if  (this._connectionParameters._credentials) {

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -2755,6 +2755,15 @@ describe('ACC Client', function () {
             expect(client._optionCache._storage._rootKey).toBe(`OptionCache$`);
         });
 
+        it("Should support instanceKey", async () => {
+            // Default has version & instance name
+            const version = sdk.getSDKVersion().version; // "${version}" or similar
+            connectionParameters = sdk.ConnectionParameters.ofUserAndPassword("http://acc-sdk:8080", "admin", "admin");
+            connectionParameters = sdk.ConnectionParameters.ofUserAndPassword("http://acc-sdk:8080", "admin", "admin", { instanceKey: "hello" });
+            var client = await sdk.init(connectionParameters);
+            expect(client._optionCache._storage._rootKey).toBe(`acc.js.sdk.${version}.hello.cache.OptionCache$`);
+        });
+
         describe("Should simulate the Shell Cache API", () => {
             // See https://github.com/AdobeDocs/exc-app/blob/master/docs/modules/cache.md#sample-code
             it("Sould get cached option", async () => {


### PR DESCRIPTION
## Description

Optimization of the ACC JS SDK to handle multi-tenant access.
In multi-tenant deployments of ACC, the access URL is shared across multiple ACC instances. Each instance must have its own caches (schemas, options, etc.) but we use a string derived from the access URL as the cache key.
This does not work in a multi-tenant deployment

## Related Issue

UX slowness
Inability to use cache
Corrupted data

## Motivation and Context

Improve User experience (page load speed) in the context of Orchstrated Campaigns

## How Has This Been Tested?

New Unit tests

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [] All new and existing tests passed.
