### PR TITLE
NEO-88828: fix Acrites upload.

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -143,6 +143,16 @@ class Util {
     return schemaId;
   }
 
+  static validateFileResPrefix(prefix, defaultPrefix = "RES") {
+    const regex = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+    if (typeof prefix !== "string" || !regex.test(prefix)) {
+      return defaultPrefix;
+    }
+
+    return prefix;
+  }
+
   /**
    * Test if an object is a promise
    * @param {*} object the object to test

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -446,5 +446,17 @@ describe('Util', function() {
             await expect(Util.asPromise(Promise.resolve(3))).resolves.toBe(3);
         });
     });
+
+    describe("Validate file res prefix", () => {
+        it("Should return the correct prefix", () => {
+            expect(Util.validateFileResPrefix("customPrefix")).toBe("customPrefix");
+            expect(Util.validateFileResPrefix("1invalidPrefix")).toBe("RES");
+            expect(Util.validateFileResPrefix("anotherInvalidPrefix!")).toBe("RES");
+            expect(Util.validateFileResPrefix("valid_prefix_2")).toBe("valid_prefix_2");
+
+            expect(Util.validateFileResPrefix("valid_prefix_3", "customDefault")).toBe("valid_prefix_3");
+            expect(Util.validateFileResPrefix("132Invalid", "customDefault")).toBe("customDefault");
+        });
+    });
 });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

For some reason the "const counter = await client.NLWS.xtkCounter.increaseValue( { name: 'xtkResource' } );" does not increase the value of the counter which results in the creation and the update of the 'RES1' fileResource.
The problem is that if the RES1 already exists in a folder the user does not have writing rights it results in an error.

The solution that has been decided was have a filename of 'WUI-[uuid]' to ensures unicity.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://jira.corp.adobe.com/browse/NEO-88828

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
With this fix, the fileResource created will be in the default folder where the user has writing right.
Only if there is no such folder then the upload will fail (as intended)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
New autotest has been added and existing autotest has been modified.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
