### PR TITLE
add without Cache parameter to getSchema

### DIFF
--- a/src/application.js
+++ b/src/application.js
@@ -1419,15 +1419,19 @@ class Application {
      * Using the `XtkSchema` API makes it easier to navigate schemas than using a plain XML or JSON object
      * 
      * @param {string} schemaId 
+     * @param {boolean} withoutCache if true, the schema will be fetched from the server without using the cache, defaults to false
      * @returns {Campaign.XtkSchema} the schema, or null if the schema was not found
      */
-     async getSchema(schemaId) {
+     async getSchema(schemaId, withoutCache = false) {
+        if (withoutCache) {
+            return this._getSchema(schemaId, withoutCache);
+        }
         return this._schemaCache.getSchema(schemaId);
     }
 
     // Private function: get a schema without using the SchemaCache
-    async _getSchema(schemaId) {
-        const xml = await this.client.getSchema(schemaId, "xml");
+    async _getSchema(schemaId, withoutCache = false) {
+        const xml = await this.client.getSchema(schemaId, "xml", undefined, withoutCache);
         if (!xml)
             return null;
         return newSchema(xml, this);

--- a/src/client.js
+++ b/src/client.js
@@ -1943,9 +1943,10 @@ class Client {
      * @param {string} schemaId the schema id, such as "xtk:session", or "nms:recipient"
      * @param {string} representation an optional representation of the schema: "BadgerFish", "SimpleJson" or "xml". If not set, we'll use the client default representation
      * @param {boolean} internal indicates an "internal" call, i.e. a call performed by the SDK itself rather than the user of the SDK. For instance, the SDK will dynamically load schemas to find method definitions
+     * @param {boolean} withoutCache if true, the schema will be fetched from the server without using the cache, defaults to false
      * @returns {XML.XtkObject}  the schema definition, as either a DOM document or a JSON object
      */
-    async getSchema(schemaId, representation, internal) {
+    async getSchema(schemaId, representation, internal, withoutCache = false) {
         // Support for Orchestrated Campaign XDM schemas (do not use cache)
         const pipeIndex = schemaId.indexOf("|");
         if( pipeIndex != -1 && schemaId.startsWith("xdm:") ) {
@@ -1955,7 +1956,7 @@ class Client {
             return entity;
         }
         var entity = await this._entityCache.get("xtk:schema", schemaId);
-        if (!entity) {
+        if (!entity || withoutCache) {
               // special case of "temp:group:*" schemas for nms:group
               // Schema "temp:group:*" is not cached because life cycle of this kind of schema is not the same as the others schemas
               if (schemaId.startsWith("temp:group:")) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add a new withoutCache parameter to Client.getSchema() and Application.getSchema() methods, allowing developers to bypass the cache and fetch schemas directly from the server.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://jira.corp.adobe.com/browse/NEO-85872

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
