### PR TITLE
NEO-90890 - Add request id to soap calls

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -1178,11 +1178,15 @@ class Client {
      * parameters should be set
      */
     _prepareSoapCall(urn, method, isStatic, internal, extraHttpHeaders, pushDownOptions) {
+        const requestId = Util.getUUID();
+        const extraHttpHeadersWithRequestId = Object.assign({}, extraHttpHeaders, {
+            'x-request-id': requestId
+        }); 
         const soapCall = new SoapMethodCall(this._transport, urn, method,
                                             this._sessionToken, this._securityToken,
                                             this._getUserAgentString(),
                                             Object.assign({}, this._connectionParameters._options, pushDownOptions),
-                                            extraHttpHeaders,
+                                            extraHttpHeadersWithRequestId,
                                             this._bearerToken);
         soapCall.internal = !!internal;
         soapCall.isStatic = isStatic;

--- a/src/client.js
+++ b/src/client.js
@@ -1178,15 +1178,23 @@ class Client {
      * parameters should be set
      */
     _prepareSoapCall(urn, method, isStatic, internal, extraHttpHeaders, pushDownOptions) {
-        const requestId = Util.getUUID();
-        const extraHttpHeadersWithRequestId = Object.assign({}, extraHttpHeaders, {
-            'x-request-id': requestId
-        }); 
+        // Generate unique request ID for every SOAP call
+        let requestId;
+        try {
+          requestId = Util.getUUID();
+        } catch (error) {
+          console.error("Failed to generate request ID", error);
+        }
+        const updatedExtraHttpHeaders = requestId
+          ? Object.assign({}, extraHttpHeaders, {
+              "x-request-id": requestId,
+            })
+          : extraHttpHeaders;
         const soapCall = new SoapMethodCall(this._transport, urn, method,
                                             this._sessionToken, this._securityToken,
                                             this._getUserAgentString(),
                                             Object.assign({}, this._connectionParameters._options, pushDownOptions),
-                                            extraHttpHeadersWithRequestId,
+                                            updatedExtraHttpHeaders,
                                             this._bearerToken);
         soapCall.internal = !!internal;
         soapCall.isStatic = isStatic;

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -4354,7 +4354,7 @@ describe('ACC Client', function () {
                     type: "text/html",
                     size: 12345,
                     }, undefined, 'PREFIX');
-                expect(Util.getUUID).toHaveBeenCalledTimes(1);
+                expect(Util.getUUID).toHaveBeenCalledTimes(8);
             });
             }); // "File uploader - on browser"
         }); // 'upload'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Addition of **x-request-id**  to SOAP requests

Jira - [NEO-90890](https://jira.corp.adobe.com/browse/NEO-90890)

## Description
The code change adds a new header x-request-id to every soap request , which allows us to better debug the requests that fail . We can refer the request id and check the corresponding metrics to debug the issue. 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
