### PR TITLE
NEO-90890 Fix - Add enableRequestId option to connection parameters 

### DIFF
--- a/docs/connectionParameters.html
+++ b/docs/connectionParameters.html
@@ -114,6 +114,11 @@ const connectionParameters = sdk.ConnectionParameters.ofUserAndPassword(
             <td>string</td>
             <td>An optional value to override the instance key which is used for the caches of schemas, options, etc.</td>
         </tr>
+        <tr>
+            <td>enableRequestIdHeader</td>
+            <td>boolean</td>
+            <td>Enable the request ID header for SOAP API calls</td>
+        </tr>
     </tbody>
 </table>
 

--- a/src/client.js
+++ b/src/client.js
@@ -309,6 +309,7 @@ class Credentials {
     * @property {number} timeout - Can be set to change the HTTP call timeout. Value is passed in ms.
     * @property {string} cacheRootKey - "default" or "none" - determine the prefix to use for the keys in the caches of schemas, options, etc.
     * @property {string} instanceKey - an optional value to override the instance key which is used for the caches of schemas, options, etc.
+    * @property {boolean} enableRequestIdHeader - an optional value to enable the request ID header for SOAP API calls
     * @memberOf Campaign
  */
 
@@ -1185,10 +1186,12 @@ class Client {
         } catch (error) {
           console.error("Failed to generate request ID", error);
         }
-        const updatedExtraHttpHeaders = requestId ? Object.assign({}, extraHttpHeaders, {
-              "x-request-id": requestId,
-            })
-          : extraHttpHeaders;
+        const enableRequestIdHeader = this._connectionParameters._options?.enableRequestIdHeader;
+        const updatedExtraHttpHeaders = (enableRequestIdHeader && requestId) 
+        ? Object.assign({}, extraHttpHeaders, {
+            "x-request-id": requestId,
+          })
+        : extraHttpHeaders;
         const soapCall = new SoapMethodCall(this._transport, urn, method,
                                             this._sessionToken, this._securityToken,
                                             this._getUserAgentString(),

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -3447,8 +3447,8 @@ describe('ACC Client', function () {
             });
         });
 
-        it("Should add x-request-id header to every SOAP call", async () => {
-            const client = await Mock.makeClient();
+        it("Should add x-request-id header to SOAP call when enableRequestIdHeader is true", async () => {
+            const client = await Mock.makeClient({ enableRequestIdHeader: true });
             client._transport.mockReturnValueOnce(Mock.LOGON_RESPONSE);
             await client.NLWS.xtkSession.logon();
 
@@ -3480,7 +3480,37 @@ describe('ACC Client', function () {
         });
 
         it("Should call SOAP call on request ID generation failure", async () => {
-            const client = await Mock.makeClient();
+            const client = await Mock.makeClient({enableRequestIdHeader: true});
+            client._transport.mockReturnValueOnce(Mock.LOGON_RESPONSE);
+            await client.NLWS.xtkSession.logon();
+            
+            const mockGetUUID = jest.spyOn(Util, 'getUUID').mockImplementation(() => { throw new Error('UUID error'); });
+            
+            client._transport.mockReturnValueOnce(Mock.GET_XTK_QUERY_SCHEMA_RESPONSE);
+            client._transport.mockReturnValueOnce(Mock.GET_QUERY_EXECUTE_RESPONSE);
+            const queryDef = {
+                "schema": "nms:extAccount",
+                "operation": "select",
+                "select": {
+                    "node": [{ "expr": "@id" }]
+                }
+            };
+            
+            const query = client.NLWS.xtkQueryDef.create(queryDef);
+
+            const headers = await collectHeaders(client, async() => {
+                await query.executeQuery();
+            });
+
+            expect(headers["x-request-id"]).toBeUndefined();
+            
+            // Restore the mock
+            mockGetUUID.mockRestore();
+        });
+
+
+        it("Should not add x-request-id header to SOAP call when enableRequestIdHeader is false", async () => {
+            const client = await Mock.makeClient({ enableRequestIdHeader: false });
             client._transport.mockReturnValueOnce(Mock.LOGON_RESPONSE);
             await client.NLWS.xtkSession.logon();
             


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Addition of x-request-id to SOAP requests  based on enableRequestId option

Jira - [NEO-90890](https://jira.corp.adobe.com/browse/NEO-90890)


## Description

Addition of x-request-id to SOAP requests is now being done based on the flag - enableRequestId added to options object of connection Parameters. 

If the flag is not sent , or is passed as false during initialisation , then SOAP requests don't include x-request-id header. 
If the flag is set as true during acc-js-sdk client initialisation, SOAP requests will include  x-request-id header.


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
